### PR TITLE
Use ?zeroDateTimeBehavior=convertToNull in the JDBC connection

### DIFF
--- a/plugins/Solr/solr/data-config.xml
+++ b/plugins/Solr/solr/data-config.xml
@@ -1,5 +1,5 @@
 <dataConfig>
-<dataSource driver="com.mysql.jdbc.Driver" url="jdbc:mysql://localhost/#DATABASE#" user="#USERNAME#" password="#PASSWORD#"/>
+<dataSource driver="com.mysql.jdbc.Driver" url="jdbc:mysql://localhost/#DATABASE#?zeroDateTimeBehavior=convertToNull" user="#USERNAME#" password="#PASSWORD#"/>
 <document name="Discussions">
 	<entity 
       name="Discussion"


### PR DESCRIPTION
Vanilla does have some 0000-00-00 00:00:00 dates that will cause errors if this argument does not exist.
