### PR TITLE
Add SMF-style quote compatibility

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -117,10 +117,9 @@ QUOTE;
             break;
             
          case 'BBCode':
-			case 'Markdown':
+         case 'Markdown':
             // BBCode quotes with authors
-            //$Sender->EventArguments['Object']->Body = preg_replace_callback("/(\[quote=\"?([^\"]+)\"?\])/ui", array($this, 'QuoteAuthorCallback'), $Sender->EventArguments['Object']->Body);
-            $Sender->EventArguments['Object']->Body = preg_replace_callback("#(\[quote=[\"']?(.*?)(;[\d]+)?[\"']?\])#usi", array($this, 'QuoteAuthorCallback'), $Sender->EventArguments['Object']->Body);
+            $Sender->EventArguments['Object']->Body = preg_replace_callback("#(\[quote(\s+author)?=[\"']?(.*?)(\s+link.*?)?(;[\d]+)?[\"']?\])#usi", array($this, 'QuoteAuthorCallback'), $Sender->EventArguments['Object']->Body);
 
             // BBCode quotes without authors
             $Sender->EventArguments['Object']->Body = str_ireplace('[quote]','<blockquote class="UserQuote"><div class="QuoteText"><p>',$Sender->EventArguments['Object']->Body);


### PR DESCRIPTION
SMF uses a "[quote author=foo link=bar date=biz]" syntax in its BBCode.
 This change simply makes the Quotes plugin treat it as a more common
"[quote=foo]" instead.
