### PR TITLE
added support for inline attachment direct urls

### DIFF
--- a/plugins/FileUpload/views/fuploadsettings.php
+++ b/plugins/FileUpload/views/fuploadsettings.php
@@ -1,0 +1,3 @@
+<?php if (!defined('APPLICATION')) die(); ?>
+
+<?php $this->ConfigurationModule->Render(); ?>


### PR DESCRIPTION
Usable by others plugin like mediator or by theme makers.

Urls are appended at the end of comment body.
