### PR TITLE
jsconnect: Add user roles to profile/jsconnect endpoint.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -408,9 +408,9 @@ class JsConnectPlugin extends Gdn_Plugin {
          // Grab the user's roles.
          $Roles = Gdn::UserModel()->GetRoles(Gdn::Session()->UserID);
          $Roles = ConsolidateArrayValuesByKey($Roles, 'Name');
-         if (is_array($Roles) && sizeof($Roles)) {
+         $User['Roles'] = '';
+         if (is_array($Roles) && sizeof($Roles))
             $User['Roles'] = implode(',', $Roles);
-         }
 
 //         $Sfx = 'F';
 //         $User['UniqueID'] .= $Sfx;


### PR DESCRIPTION
Added user's current roles to the output of profile/jsconnect in support of vanilla<->vanilla jsconnect implementations that require role sync.
