### PR TITLE
QnA: Option to disable filtering out accepted answers

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -8,7 +8,7 @@
 $PluginInfo['QnA'] = array(
    'Name' => 'Q&A',
    'Description' => "Users may designate a discussion as a Question and then officially accept one or more of the comments as the answer.",
-   'Version' => '1.2.1',
+   'Version' => '1.2.2',
    'RequiredApplications' => array('Vanilla' => '2.0.18'),
    'MobileFriendly' => TRUE,
    'Author' => 'Todd Burry',
@@ -390,6 +390,12 @@ class QnAPlugin extends Gdn_Plugin {
       }
    }
 
+   /**
+    * Modify flow of discussion by pinning accepted answers.
+    *
+    * @param $Sender
+    * @param $Args
+    */
    public function DiscussionController_BeforeDiscussionRender_Handler($Sender, $Args) {
       if ($Sender->Data('Discussion.QnA'))
          $Sender->CssClass .= ' Question';
@@ -410,12 +416,15 @@ class QnAPlugin extends Gdn_Plugin {
       $Sender->SetData('Answers', $Answers);
 
       // Remove the accepted answers from the comments.
-      if (isset($Sender->Data['Comments'])) {
-         $Comments = $Sender->Data['Comments']->Result();
-         $Comments = array_filter($Comments, function($Row) {
-            return strcasecmp(GetValue('QnA', $Row), 'accepted');
-         });
-         $Sender->Data['Comments'] = new Gdn_DataSet(array_values($Comments));
+      // Allow this to be skipped via config.
+      if (C('QnA.AcceptedAnswers.Filter', TRUE)) {
+         if (isset($Sender->Data['Comments'])) {
+            $Comments = $Sender->Data['Comments']->Result();
+            $Comments = array_filter($Comments, function($Row) {
+               return strcasecmp(GetValue('QnA', $Row), 'accepted');
+            });
+            $Sender->Data['Comments'] = new Gdn_DataSet(array_values($Comments));
+         }
       }
    }
 


### PR DESCRIPTION
QnA removing comments from the chronological flow is extremely problematic in some scenarios. This adds the option to stop it from doing that while preserving the current default. When invoked, will simply duplicate the accepted answers as pinned while leaving them in the flow for discussion coherence. A client requested this and I very much wish .org behaved this way too.
