### PR TITLE
Quotes: Fix html appearing in quotes.

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -306,9 +306,9 @@ BLOCKQUOTE;
             if (in_array($NewFormat, array('Html', 'Wysiwyg')))
                $NewBody = Gdn_Format::To($NewBody, $QuoteFormat);
             elseif ($QuoteFormat == 'Html' && $NewFormat == 'BBCode')
-               $NewBody = Gdn_Format::Text($NewBody);
+               $NewBody = Gdn_Format::Text($NewBody, false);
             elseif ($QuoteFormat == 'Text' && $NewFormat == 'BBCode')
-               $NewBody = Gdn_Format::Text($NewBody);
+               $NewBody = Gdn_Format::Text($NewBody, false);
             else
                $NewBody = Gdn_Format::PlainText($NewBody, $QuoteFormat);
 


### PR DESCRIPTION
To test enable advanced editor and makes some posts as html.
Then change the input format to bbcode and/or text and quote html posts.

Problem appeared on polk audio
http://forum.polkaudio.com/discussion/163655/sooooo/p2
