### PR TITLE
Error Related to Delivery Type.

### DIFF
--- a/plugins/FileUpload/js/fileupload.js
+++ b/plugins/FileUpload/js/fileupload.js
@@ -156,7 +156,7 @@ var GdnUploaders = null;
             jQuery('div.Attachments a.DeleteFile').popup({
                confirm: true,
                followConfirm: false,
-               deliveryType: 'JSON',
+               deliveryType: 'VIEW',
                afterConfirm: function(json, sender) {
                   var MediaData = json.Delete;
                   var FileRow = jQuery(sender).closest('.Attachment');


### PR DESCRIPTION
Open source community noticed a change in delivery type is causing "whoops error" when trying to delete files. 
Discussion: http://vanillaforums.org/discussion/comment/216330/#Comment_216330
Related to delivery type change here: https://github.com/vanilla/vanilla/commit/a69fa4048bd299d3248f0ff2897cde5e0ea93065
