### PR TITLE
Add usernameless SSO support to jsconnect.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -9,7 +9,7 @@
 $PluginInfo['jsconnect'] = array(
    'Name' => 'Vanilla jsConnect',
    'Description' => 'Enables custom single sign-on solutions. They can be same-domain or cross-domain. See the <a href="http://vanillaforums.org/docs/jsconnect">documentation</a> for details.',
-   'Version' => '1.4.3',
+   'Version' => '1.4.4',
    'RequiredApplications' => array('Vanilla' => '2.0.18'),
    'MobileFriendly' => TRUE,
    'Author' => 'Todd Burry',

--- a/plugins/jsconnect/js/jsconnect.js
+++ b/plugins/jsconnect/js/jsconnect.js
@@ -4,23 +4,23 @@ var jsUrl = gdn.definition('JsAuthenticateUrl', false);
 if (jsUrl) {
    // Reveal the please wait text after a small wait so that if the request is faster we never have to see it.
    setTimeout(function() { $('.Connect-Wait').show(); }, 2000);
-    
+
    $.ajax({
       url: jsUrl,
       dataType: 'json',
       timeout : 10000,
       success: function(data) {
          var connectData = $.param(data);
-         
+
          if ($('#Form_JsConnect-Connect').length > 0) {
             if (data['error']) {
                $('#Form_JsConnect-Connect').attr('action', gdn.url('/entry/jsconnect/error'));
-            } else if (!data['name']) {
+            } else if (!data['uniqueid']) {
                 // Just redirect to the target.
                 var target = $('#Form_Target').val();
                 if (!target)
                     target = '/';
-                
+
                 window.location.replace(gdn.url(target));
                 return;
    //            data = {'error': 'unauthorized', 'message': 'You are not signed in.' };
@@ -36,7 +36,7 @@ if (jsUrl) {
          } else {
             if (!data['error'] && data['name']) {
                var parts = $.jsconnectStrip(jsUrl);
-               
+
                $.ajax({
                   url: gdn.url('/entry/connect/jsconnect'),
                   type: 'POST',
@@ -58,33 +58,33 @@ $.jsconnectStrip = function(url) {
    var re = new RegExp("client_?id=([^&]+)(&Target=([^&]+))?", "g");
    var matches = re.exec(url);
    var client_id = false, target = '/';
-   
+
    if (matches) {
       if (matches[1])
          client_id = matches[1];
       if (matches[3])
          target = matches[3];
    }
-   
+
    return { client_id: client_id, target: target };
 };
-   
+
 $.fn.jsconnect = function(options) {
    if (this.length == 0)
       return;
-   
+
    var $elems = this;
-   
+
    // Collect the urls.
    var urls = {};
    $elems.each(function(i, elem) {
       var rel = $(elem).attr('rel');
-      
+
       if (urls[rel] == undefined)
          urls[rel] = [];
       urls[rel].push(elem);
    });
-   
+
    for (var url in urls) {
       var elems = urls[url];
 
@@ -98,7 +98,7 @@ $.fn.jsconnect = function(options) {
          if (matches[3])
             target = matches[3];
       }
-      
+
       // Make a request to the host page.
       $.ajax({
          url: url,
@@ -106,12 +106,12 @@ $.fn.jsconnect = function(options) {
          success: function(data, textStatus) {
             var connectUrl = gdn.url('/entry/jsconnect?client_id='+client_id+'&Target='+target);
 
-            var signedIn = data['name'] ? true : false;
+            var signedIn = data['name'] || data['signedin'] ? true : false;
 
             if (signedIn) {
                $(elems).find('.ConnectLink').attr('href', connectUrl);
                $(elems).find('.Username').text(data['name']);
-         
+
                if (data['photourl'])
                   $(elems).find('.UserPhoto').attr('src', data['photourl']);
 


### PR DESCRIPTION
Client libraries can now pass a user without a username into jsconnect. This requires adding a “signedin” flag to the non-secure js response.
