### PR TITLE
Signatures plugin: Explicitly set form format.

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -166,7 +166,6 @@ class SignaturesPlugin extends Gdn_Plugin {
 
       $Data = $ConfigurationModel->Data;
       $Sender->SetData('Signature', $Data);
-      $Sender->SetData('Format', GetValue('Plugin.Signatures.Format', $Data, Gdn_Format::DefaultFormat()));
 
       $this->SetSignatureRules($Sender);
 
@@ -213,6 +212,7 @@ class SignaturesPlugin extends Gdn_Plugin {
       else {
          // Load form data.
          $Data['Body'] = GetValue('Plugin.Signatures.Sig', $Data);
+         $Data['Format'] = GetValue('Plugin.Signatures.Format', $Data) ?: Gdn_Format::DefaultFormat();
 
          // Apply the config settings to the form.
          $Sender->Form->SetData($Data);

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -166,6 +166,7 @@ class SignaturesPlugin extends Gdn_Plugin {
 
       $Data = $ConfigurationModel->Data;
       $Sender->SetData('Signature', $Data);
+      $Sender->SetData('Format', GetValue('Plugin.Signatures.Format', $Data, Gdn_Format::DefaultFormat()));
 
       $this->SetSignatureRules($Sender);
 
@@ -212,7 +213,6 @@ class SignaturesPlugin extends Gdn_Plugin {
       else {
          // Load form data.
          $Data['Body'] = GetValue('Plugin.Signatures.Sig', $Data);
-         $Data['Format'] = GetValue('Plugin.Signatures.Format', $Data);
 
          // Apply the config settings to the form.
          $Sender->Form->SetData($Data);


### PR DESCRIPTION
Fixes bug where advanced editor dropdowns were not working in signature form. 

The advanced editor js script adds supplementary js scripts based on the form's format attribute. This ensures that the signatures form has a non-empty, not null format attribute.