### PR TITLE
Redirector: Add legacy redirects, fix for multiple URL parameters named p

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -787,14 +787,16 @@ class QnAPlugin extends Gdn_Plugin {
    }
 
    public function DiscussionModel_BeforeGet_Handler($Sender, $Args) {
-      $Unanswered = Gdn::Controller()->ClassName == 'DiscussionsController' && Gdn::Controller()->RequestMethod == 'unanswered';
+      if (Gdn::Controller()) {
+         $Unanswered = Gdn::Controller()->ClassName == 'DiscussionsController' && Gdn::Controller()->RequestMethod == 'unanswered';
 
-      if ($Unanswered) {
-         $Args['Wheres']['Type'] = 'Question';
-         $Sender->SQL->WhereIn('d.QnA', array('Unanswered', 'Rejected'));
-         Gdn::Controller()->Title('Unanswered Questions');
-      } elseif ($QnA = Gdn::Request()->Get('qna')) {
-         $Args['Wheres']['QnA'] = $QnA;
+         if ($Unanswered) {
+            $Args['Wheres']['Type'] = 'Question';
+            $Sender->SQL->WhereIn('d.QnA', array('Unanswered', 'Rejected'));
+            Gdn::Controller()->Title('Unanswered Questions');
+         } elseif ($QnA = Gdn::Request()->Get('qna')) {
+            $Args['Wheres']['QnA'] = $QnA;
+         }
       }
    }
 

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -228,7 +228,7 @@ class RedirectorPlugin extends Gdn_Plugin {
          $CommentModel = new CommentModel();
          // If a legacy slug is provided (assigned during a merge), attempt to lookup the comment using it
          if (isset($Get['legacy']) && Gdn::Structure()->Table('Comment')->ColumnExists('ForeignID')) {
-            $Comment = $CommentModel->GetWhere(array('ForeignID' => $Get['legacy'] . $Vars['CommentID']))->FirstRow();
+            $Comment = $CommentModel->GetWhere(array('ForeignID' => $Get['legacy'] . '-' . $Vars['CommentID']))->FirstRow();
          } else {
             $Comment = $CommentModel->GetID($Vars['CommentID']);
          }
@@ -245,7 +245,7 @@ class RedirectorPlugin extends Gdn_Plugin {
          if (is_numeric($DiscussionID)) {
             // If a legacy slug is provided (assigned during a merge), attempt to lookup the discussion using it
             if (isset($Get['legacy']) && Gdn::Structure()->Table('Discussion')->ColumnExists('ForeignID')) {
-               $Discussion = $DiscussionModel->GetWhere(array('ForeignID' => $Get['legacy'] . $DiscussionID))->FirstRow();
+               $Discussion = $DiscussionModel->GetWhere(array('ForeignID' => $Get['legacy'] . '-' . $DiscussionID))->FirstRow();
             } else {
                $Discussion = $DiscussionModel->GetID($Vars['DiscussionID']);
             }
@@ -276,7 +276,7 @@ class RedirectorPlugin extends Gdn_Plugin {
          // If a legacy slug is provided (assigned during a merge), attempt to lookup the category ID based on it
          if (isset($Get['legacy']) && Gdn::Structure()->Table('Category')->ColumnExists('ForeignID')) {
             $CategoryModel = new CategoryModel();
-            $Category = $CategoryModel->GetWhere(array('ForeignID' => $Get['legacy'] . $Vars['CategoryID']))->FirstRow();
+            $Category = $CategoryModel->GetWhere(array('ForeignID' => $Get['legacy'] . '-' . $Vars['CategoryID']))->FirstRow();
          } else {
             $Category = CategoryModel::Categories($Vars['CategoryID']);
          }

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -106,6 +106,21 @@ class RedirectorPlugin extends Gdn_Plugin {
       $Path = Gdn::Request()->Path();
       $Get = Gdn::Request()->Get();
 
+      // Grab the URI from the original request, see if it matches our special cases for the p parameter
+      $RequestUri = Gdn::Request()->GetValueFrom('server', 'REQUEST_URI', FALSE);
+      if ($RequestUri && preg_match('/(showpost.php|showthread.php|viewtopic.php)/i', $RequestUri)) {
+         // Grab the query_string value from the server, if available
+         $QueryString = Gdn::Request()->GetValueFrom('server', 'QUERY_STRING', FALSE);
+         Trace(array('RequestUri' => $RequestUri, 'QueryString' => $QueryString), 'Input');
+         // Check for multiple values of p in our URL parameters
+         if ($QueryString && preg_match_all('/(^|\?|\&)p\=(?P<val>[^&]+)/', $QueryString, $QueryParameters) > 1) {
+            // Assume the first p is Vanilla's path
+            $Path = trim($QueryParameters['val'][0], '/');
+            // The second p is used for our redirects
+            $Get['p'] = $QueryParameters['val'][1];
+         }
+      }
+
       Trace(array('Path' => $Path, 'Get' => $Get), 'Input');
 
       // Figure out the filename.

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -106,14 +106,16 @@ class RedirectorPlugin extends Gdn_Plugin {
       $Path = Gdn::Request()->Path();
       $Get = Gdn::Request()->Get();
 
-      // Grab the URI from the original request, see if it matches our special cases for the p parameter
-      $RequestUri = Gdn::Request()->GetValueFrom('server', 'REQUEST_URI', FALSE);
-      // Grab the query_string value from the server, if available
+      /**
+       * There may be two incoming p URL parameters.  If that is the case, we need to compensate for it.  This is done
+       * by manually parsing the server's QUERY_STRING variable, if available.
+       */
       $QueryString = Gdn::Request()->GetValueFrom('server', 'QUERY_STRING', FALSE);
-      Trace(array('REQUEST_URI' => $RequestUri, 'QUERY_STRING' => $QueryString), 'Server Variables');
-      if ($RequestUri && preg_match('/(showpost.php|showthread.php|viewtopic.php)/i', $RequestUri)) {
+      Trace(array('QUERY_STRING' => $QueryString), 'Server Variables');
+      if ($QueryString && preg_match('/(^|&)p\=(showpost\.php|showthread\.php|viewtopic\.php)/i', $QueryString)) {
          // Check for multiple values of p in our URL parameters
-         if ($QueryString && preg_match_all('/(^|\?|\&)p\=(?P<val>[^&]+)/', $QueryString, $QueryParameters) > 1) {
+         if ($QueryString && preg_match_all('/(^|\?|&)p\=(?P<val>[^&]+)/', $QueryString, $QueryParameters) > 1) {
+            Trace($QueryParameters['val'], 'p Values');
             // Assume the first p is Vanilla's path
             $Path = trim($QueryParameters['val'][0], '/');
             // The second p is used for our redirects

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -108,10 +108,10 @@ class RedirectorPlugin extends Gdn_Plugin {
 
       // Grab the URI from the original request, see if it matches our special cases for the p parameter
       $RequestUri = Gdn::Request()->GetValueFrom('server', 'REQUEST_URI', FALSE);
+      // Grab the query_string value from the server, if available
+      $QueryString = Gdn::Request()->GetValueFrom('server', 'QUERY_STRING', FALSE);
+      Trace(array('REQUEST_URI' => $RequestUri, 'QUERY_STRING' => $QueryString), 'Server Variables');
       if ($RequestUri && preg_match('/(showpost.php|showthread.php|viewtopic.php)/i', $RequestUri)) {
-         // Grab the query_string value from the server, if available
-         $QueryString = Gdn::Request()->GetValueFrom('server', 'QUERY_STRING', FALSE);
-         Trace(array('RequestUri' => $RequestUri, 'QueryString' => $QueryString), 'Input');
          // Check for multiple values of p in our URL parameters
          if ($QueryString && preg_match_all('/(^|\?|\&)p\=(?P<val>[^&]+)/', $QueryString, $QueryParameters) > 1) {
             // Assume the first p is Vanilla's path

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -2,10 +2,10 @@
 
 /**
  * Adds 301 redirects for Vanilla from common forum platforms.
- * 
+ *
  * Changes:
  *  1.0        Initial Release
- * 
+ *
  * @author Todd Burry <todd@vanillaforums.com>
  * @copyright Copyright 2008, 2009 Vanilla Forums Inc.
  * @license Proprietary
@@ -98,16 +98,16 @@ class RedirectorPlugin extends Gdn_Plugin {
          'userID' => 'UserID'
       )
    );
-   
+
    /**
     * @param Gdn_Dispatcher $Sender
     */
    public function Gdn_Dispatcher_NotFound_Handler($Dispatcher, $Args) {
       $Path = Gdn::Request()->Path();
       $Get = Gdn::Request()->Get();
-      
+
       Trace(array('Path' => $Path, 'Get' => $Get), 'Input');
-      
+
       // Figure out the filename.
       $Parts = explode('/', $Path);
       $After = array();
@@ -118,7 +118,7 @@ class RedirectorPlugin extends Gdn_Plugin {
             $Filename = $V;
             break;
          }
-         
+
          array_unshift($After, $V);
       }
       if ($Filename == 'index.php') {
@@ -145,8 +145,9 @@ class RedirectorPlugin extends Gdn_Plugin {
          $Get["_arg$i"] = $Arg;
          $i++;
       }
-      
+
       $Url = $this->FilenameRedirect($Filename, $Get);
+
       if ($Url) {
          if (Debug())
             Trace($Url, "Redirect found");
@@ -154,7 +155,7 @@ class RedirectorPlugin extends Gdn_Plugin {
             Redirect($Url, 301);
       }
    }
-   
+
    public function FilenameRedirect($Filename, $Get) {
       Trace(array('Filename' => $Filename, 'Get' => $Get), 'Testing');
       $Filename = strtolower($Filename);
@@ -162,22 +163,22 @@ class RedirectorPlugin extends Gdn_Plugin {
 
       if (!isset(self::$Files[$Filename]))
          return FALSE;
-      
+
       $Row = self::$Files[$Filename];
-      
+
       if (is_callable($Row)) {
          // Use a callback to determine the translation.
          $Row = call_user_func($Row, $Get);
       }
-      
+
       // Translate all of the get parameters into new parameters.
       $Vars = array();
       foreach ($Get as $Key => $Value) {
          if (!isset($Row[$Key]))
             continue;
-         
+
          $Opts = (array)$Row[$Key];
-         
+
          if (isset($Opts['Filter'])) {
             // Call the filter function to change the value.
             $R = call_user_func($Opts['Filter'], $Value, $Opts[0]);
@@ -195,32 +196,42 @@ class RedirectorPlugin extends Gdn_Plugin {
                $Value = $R;
             }
          }
-         
+
          if ($Value !== NULL)
             $Vars[$Opts[0]] = $Value;
       }
-      
+
       Trace($Vars, 'Translated Arguments');
       // Now let's see what kind of record we have.
       // We'll check the various primary keys in order of importance.
       $Result = FALSE;
       if (isset($Vars['CommentID'])) {
          Trace("Looking up comment {$Vars['CommentID']}.");
-         
+
          $CommentModel = new CommentModel();
-         $Comment = $CommentModel->GetID($Vars['CommentID']);
+         // If a legacy slug is provided (assigned during a merge), attempt to lookup the comment using it
+         if (isset($Get['legacy']) && Gdn::Structure()->Table('Comment')->ColumnExists('ForeignID')) {
+            $Comment = $CommentModel->GetWhere(array('ForeignID' => $Get['legacy'] . $Vars['CommentID']))->FirstRow();
+         } else {
+            $Comment = $CommentModel->GetID($Vars['CommentID']);
+         }
          if ($Comment)
             $Result = CommentUrl($Comment, '//');
       } elseif (isset($Vars['DiscussionID'])) {
          Trace("Looking up discussion {$Vars['DiscussionID']}.");
-         
-         
+
+
          $DiscussionModel = new DiscussionModel();
          $DiscussionID = $Vars['DiscussionID'];
          $Discussion = FALSE;
-         
+
          if (is_numeric($DiscussionID)) {
-            $Discussion = $DiscussionModel->GetID($Vars['DiscussionID']);
+            // If a legacy slug is provided (assigned during a merge), attempt to lookup the discussion using it
+            if (isset($Get['legacy']) && Gdn::Structure()->Table('Discussion')->ColumnExists('ForeignID')) {
+               $Discussion = $DiscussionModel->GetWhere(array('ForeignID' => $Get['legacy'] . $DiscussionID))->FirstRow();
+            } else {
+               $Discussion = $DiscussionModel->GetID($Vars['DiscussionID']);
+            }
          } else {
             // This is a slug style discussion ID. Let's see if there is a UrlCode column in the discussion table.
             $DiscussionModel->DefineSchema();
@@ -228,12 +239,12 @@ class RedirectorPlugin extends Gdn_Plugin {
                $Discussion = $DiscussionModel->GetWhere(array('UrlCode' => $DiscussionID))->FirstRow();
             }
          }
-         
+
          if ($Discussion)
             $Result = DiscussionUrl($Discussion, self::PageNumber($Vars, 'Vanilla.Comments.PerPage'), '//');
       } elseif (isset($Vars['UserID'])) {
          Trace("Looking up user {$Vars['UserID']}.");
-         
+
          $User = Gdn::UserModel()->GetID($Vars['UserID']);
          if ($User)
             $Result = Url(UserUrl($User), '//');
@@ -244,15 +255,21 @@ class RedirectorPlugin extends Gdn_Plugin {
          }
       } elseif (isset($Vars['CategoryID'])) {
          Trace("Looking up category {$Vars['CategoryID']}.");
-         
-         $Category = CategoryModel::Categories($Vars['CategoryID']);
+
+         // If a legacy slug is provided (assigned during a merge), attempt to lookup the category ID based on it
+         if (isset($Get['legacy']) && Gdn::Structure()->Table('Category')->ColumnExists('ForeignID')) {
+            $CategoryModel = new CategoryModel();
+            $Category = $CategoryModel->GetWhere(array('ForeignID' => $Get['legacy'] . $Vars['CategoryID']))->FirstRow();
+         } else {
+            $Category = CategoryModel::Categories($Vars['CategoryID']);
+         }
          if ($Category)
             $Result = CategoryUrl($Category, self::PageNumber($Vars, 'Vanilla.Discussions.PerPage'), '//');
       }
-      
+
       return $Result;
    }
-   
+
    public static function forum_Filter($Get) {
       if (GetValue('_arg2', $Get) == 'page') {
          // This is a punbb style forum.
@@ -273,22 +290,22 @@ class RedirectorPlugin extends Gdn_Plugin {
             );
       }
    }
-   
+
    public static function GetNumber($Value) {
       if (preg_match('`(\d+)`', $Value, $Matches))
          return $Matches[1];
       return NULL;
    }
-   
+
    public static function IPBPageNumber($Value) {
       if (preg_match('`page__st__(\d+)`i', $Value, $Matches))
          return array('Offset', $Matches[1]);
       return self::GetNumber($Value);
    }
-   
+
    /**
     * Return the page number from the given variables that may have an offset or a page.
-    * 
+    *
     * @param array $Vars The variables that should contain an Offset or Page key.
     * @param int|string $PageSize The pagesize or the config key of the pagesize.
     * @return int
@@ -304,13 +321,13 @@ class RedirectorPlugin extends Gdn_Plugin {
       }
       return 1;
    }
-   
+
    public static function RemoveID($Value) {
       if (preg_match('`^(\d+)`', $Value, $Matches))
          return $Matches[1];
       return NULL;
    }
-   
+
    public static function SmfAction($Value) {
       if (preg_match('`(\w+);(\w+)=(\d+)`', $Value, $M)) {
          switch (strtolower($M[1])) {
@@ -319,7 +336,7 @@ class RedirectorPlugin extends Gdn_Plugin {
          }
       }
    }
-   
+
    public static function SmfOffset($Value, $Key) {
       if (preg_match('`(\d+)\.(\d+)`', $Value, $M)) {
          return array($Key => $M[1], 'Offset' => $M[2]);
@@ -328,7 +345,7 @@ class RedirectorPlugin extends Gdn_Plugin {
          return array('CommentID' => $M[1]);
       }
    }
-   
+
    public static function topic_Filter($Get) {
       if (GetValue('_arg2', $Get) == 'page') {
          // This is a punbb style topic.
@@ -350,7 +367,7 @@ class RedirectorPlugin extends Gdn_Plugin {
             );
       }
    }
-   
+
    public static function XenforoID($Value) {
       if (preg_match('`(\d+)$`', $Value, $Matches))
          return $Matches[1];


### PR DESCRIPTION
These updates are meant to be used with the latest "Legacy Slug" updates to ForumMerge.  When a forum is merged in with these updates, you specify a slug as a kind of namespace for the old incoming forum identifiers.  This slug is then specified as the value for the legacy URL parameter.

Redirector checks to see if legacy is set in the URL.  If it is, it checks to see if ForeignID exists in the table (this column is new to Category and Comment, added by ForumMerge).  If both of those checkout, it concatenates the current forum record (category, comment or discussion) identifier with the legacy slug and searches for a row in the target table with that ForeignID.  The first match that is found is returned as the target record.

Also included is a small fix for multiple p parameters being specified in the URL.  When PHP parses the query string into the $_GET array, it only keeps the last value for non-array parameters with duplicate names.  Vanilla uses p to determine its request path and then unsets the value.  This processes causes us to lose both p values and typically causes the wrong p value to be used as the request path.  This is a problem with some other forum URLs the Redirector plug-in handles, because they use a p parameter.  For example, showpost.php?p=100 becomes index.php?p=showpost.php&p=100.  Our path in Vanilla should be set to showpost.php, but it becomes 100.  To compensate for this, the QUERY_STRING server variable is parsed and the duplicate p values are assigned with the assumption that the first p Vanilla's request path and the second p is intended to be a parameter in other forum's URL scheme.  This fix is currently restricted to requests with one p parameter set to showpost.php, showthread.php or viewtopic.php (URLs with the potential to have their own p parameter).

Example usage:
Multiple vBulletin forums are imported into Vanilla.  These new Vanilla forums are merged together, each with their own unique "Legacy Slug" given at the time of merge.  The Redirector plug-in is enabled on the base Vanilla forum. The original vBulletin sites are configured to forward their URLs to the base Vanilla forum site and appending &legacy=(legacy slug) to the end of each URL.  These URLs will trigger a redirect to the new record's location on the Vanilla forum installation.

Comment Example:
* Legacy Slug: vba
* vBulletin Original Comment ID: 2
* Vanilla Comment ID After Merge: 8
* vBulletin Original URL: showpost.php?p=2
* Vanilla Redirector URL: showpost.php?p=2&legacy=vba (index.php?p=showpost.php&p=2&legacy=vba)
* Destination URL: index.php?p=/discussion/comment/8#Comment_8

Additional vBulletin URL Examples:
* Discussion: showthread.php?t=(original discussion ID)
* Category: forumdisplay.php?f=(original category ID)