### PR TITLE
Adding vB4 "Friendly URL" Handling to Redirector Plug-in

### DIFF
--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -305,6 +305,14 @@ class RedirectorPlugin extends Gdn_Plugin {
       }
    }
 
+   /**
+    * Filter vBulletin category requests, specifically to handle "friendly URLs".
+    *
+    * @param $Get Request parameters
+    *
+    * @return array Mapping of vB parameters
+    */
+
    public static function forumdisplay_filter(&$Get) {
       self::VbFriendlyUrlID($Get, 'f');
 
@@ -353,6 +361,13 @@ class RedirectorPlugin extends Gdn_Plugin {
       return NULL;
    }
 
+   /**
+    * Filter vBulletin comment requests, specifically to handle "friendly URLs".
+    *
+    * @param $Get Request parameters
+    *
+    * @return array Mapping of vB parameters
+    */
    public static function showpost_filter(&$Get) {
       self::VbFriendlyUrlID($Get, 'p');
 
@@ -362,6 +377,13 @@ class RedirectorPlugin extends Gdn_Plugin {
 
    }
 
+   /**
+    * Filter vBulletin discussion requests, specifically to handle "friendly URLs".
+    *
+    * @param $Get Request parameters
+    *
+    * @return array Mapping of vB parameters
+    */
    public static function showthread_Filter(&$Get) {
       self::VbFriendlyUrlID($Get, 't');
 
@@ -415,9 +437,11 @@ class RedirectorPlugin extends Gdn_Plugin {
    }
 
    /**
-    * Attempt to retrieve record ID from request parameters, if target parameter isn't already populated
+    * Attempt to retrieve record ID from request parameters, if target parameter isn't already populated.
+    *
     * @param $Get Request parameters
     * @param $TargetParam Name of the request parameter the record value should be stored in
+    *
     * @return bool True if value saved, False if not (including if value was already set in target parameter)
     */
    private static function VbFriendlyUrlID(&$Get, $TargetParam, $SetPage = TRUE) {


### PR DESCRIPTION
"Friendly URLs" were added in vB4.  Example: /showthread.php?001-demo-thread/page5

PHP interprets these as named parameters with no value.  We need to extract the record ID and potentially a page number from that parameter name.  For the example, we need to extract 001 as a discussion ID and 5 as the page number.  That is accomplished with this feature.