### PR TITLE
QnA: Add where param to discussions index invocation.

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -850,7 +850,7 @@ class QnAPlugin extends Gdn_Plugin {
    public function DiscussionsController_Unanswered_Create($Sender, $Args = array()) {
       $Sender->View = 'Index';
       $Sender->SetData('_PagerUrl', 'discussions/unanswered/{Page}');
-      $Sender->Index(GetValue(0, $Args, 'p1'));
+      $Sender->Index(GetValue(0, $Args, 'p1'), array('QnA' => array('Unanswered', 'Rejected')));
       $this->InUnanswered = TRUE;
    }
 


### PR DESCRIPTION
Fixes bug where Unanswered pagination rendered according to total number of discussions. 
Relies on this PR: https://github.com/vanilla/vanilla/pull/2535