### PR TITLE
Adding legacy forum slug to ForumMerge

### DIFF
--- a/plugins/ForumMerge/views/merge.php
+++ b/plugins/ForumMerge/views/merge.php
@@ -2,24 +2,29 @@
 echo $this->Form->Open();
 echo $this->Form->Errors();
 ?>
-<ul>
-   <li>
-      <?php
-      echo $this->Form->Label('Database');
-      echo $this->Form->TextBox('Database');
-      ?>
-   </li>
-   <li>
-      <?php
-      echo $this->Form->Label('Table Prefix', 'Prefix');
-      echo $this->Form->TextBox('Prefix');
-      ?>
-   </li>
-   <!--<li>
+   <ul>
+      <li>
+         <?php
+         echo $this->Form->Label('Database');
+         echo $this->Form->TextBox('Database');
+         ?>
+      </li>
+      <li>
+         <?php
+         echo $this->Form->Label('Table Prefix', 'Prefix');
+         echo $this->Form->TextBox('Prefix');
+         ?>
+      </li>
+      <li>
+         <?php echo $this->Form->Label('Legacy Slug', 'LegacySlug'); ?>
+         <div class="Info"><?php echo T('ForumMerge.Merge.LegacySlug', 'Optional. Enter a slug used to associate all content from this source.  All sources should use a unique slug.  This will be used for legacy redirects.  If specified, all incoming ForeignIDs for categories, comments and discussions will be lost.'); ?></div>
+         <?php echo $this->Form->TextBox('LegacySlug'); ?>
+      </li>
+      <!--<li>
       <?php
       echo $this->Form->CheckBox('MergeCategories', T('Merge categories'));
       ?>
    </li>-->
-</ul>
+   </ul>
 <?php
 echo $this->Form->Close('Begin');


### PR DESCRIPTION
Adds a legacy slug to incoming forums, which is used in the Redirector plug-in

Added check to comment table to verify rows do not exceed a threshold before attempting to apply changes in structure.  If the threshold is exceeded, the SQL for necessary updates is output for the user to run manually.  If the intended structural updates exist, the exceeded threshold check will not cease the plugin's initialization.