### PR TITLE
Pockets: Add 'Ad Free' functionality

### DIFF
--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -17,7 +17,7 @@ $PluginInfo['Pockets'] = array(
    'AuthorEmail' => 'todd@vanillaforums.com',
    'AuthorUrl' => 'http://vanillaforums.org/profile/todd',
    'RequiredApplications' => array('Vanilla' => '2.1'),
-   'RegisterPermissions' => array('Plugins.Pockets.Manage', 'Garden.AdFree.Allow'),
+   'RegisterPermissions' => array('Plugins.Pockets.Manage', 'Garden.NoAds.Allow'),
    'SettingsUrl' => '/settings/pockets',
    'SettingsPermission' => 'Plugins.Pockets.Manage',
    'MobileFriendly' => TRUE,
@@ -472,7 +472,7 @@ class PocketsPlugin extends Gdn_Plugin {
 
       $PermissionModel = Gdn::PermissionModel();
       $PermissionModel->Define(array(
-         'Garden.AdFree.Allow' => 0
+         'Garden.NoAds.Allow' => 0
       ));
    }
 

--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -226,9 +226,9 @@ class PocketsPlugin extends Gdn_Plugin {
          $Condition = Gdn_Condition::ToString($Sender->ConditionModule->Conditions(TRUE));
          $Form->SetFormValue('Condition', $Condition);
          if ($Form->GetFormValue('Ad', 0)) {
-            $Form->SetFormValue('Type', Pocket::AD_TYPE);
+            $Form->SetFormValue('Type', Pocket::TYPE_AD);
          } else {
-            $Form->SetFormValue('Type', Pocket::DEFAULT_TYPE);
+            $Form->SetFormValue('Type', Pocket::TYPE_DEFAULT);
          }
 
          $Saved = $Form->Save();
@@ -249,7 +249,7 @@ class PocketsPlugin extends Gdn_Plugin {
             $Pocket['EveryFrequency'] = GetValue(0, $RepeatFrequency, 1);
             $Pocket['EveryBegin'] = GetValue(1, $RepeatFrequency, 1);
             $Pocket['Indexes'] = implode(',', $RepeatFrequency);
-            $Pocket['Ad'] = $Pocket['Type'] == Pocket::AD_TYPE;
+            $Pocket['Ad'] = $Pocket['Type'] == Pocket::TYPE_AD;
             $Sender->ConditionModule->Conditions(Gdn_Condition::FromString($Pocket['Condition']));
             $Form->SetData($Pocket);
          } else {
@@ -397,9 +397,12 @@ class PocketsPlugin extends Gdn_Plugin {
       }
 
       $Result = '';
+
+      $ControllerName = Gdn::Controller()->ControllerName;
+
       foreach ($Pockets as $Pocket) {
          if (val('Location', $Pocket) == 'Custom' ) {
-            $Data['PageName'] = Pocket::PageName($Data['sender']->Controller->ControllerName);
+            $Data['PageName'] = Pocket::PageName($ControllerName);
             if ($Pocket->CanRender($Data)) {
                $Result .= $Pocket->ToString();
             }
@@ -464,7 +467,7 @@ class PocketsPlugin extends Gdn_Plugin {
          ->Column('MobileNever', 'tinyint', '0')
          ->Column('EmbeddedNever', 'tinyint', '0')
          ->Column('ShowInDashboard', 'tinyint', '0')
-         ->Column('Type', array(Pocket::DEFAULT_TYPE, Pocket::AD_TYPE), Pocket::DEFAULT_TYPE)
+         ->Column('Type', array(Pocket::TYPE_DEFAULT, Pocket::TYPE_AD), Pocket::TYPE_DEFAULT)
          ->Set($Explicit, $Drop);
 
       $PermissionModel = Gdn::PermissionModel();

--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -56,8 +56,8 @@ class Pocket {
    /** $var array The repeat frequency. */
    public $MobileNever = FALSE;
 
-   /** $var boolean Is the pocket an ad? */
-   public $IsAd = FALSE;
+   /** $var string Pocket type */
+   public $Type;
 
    /** $var bool Whether to disable the pocket for embedded comments. * */
    public $EmbeddedNever = FALSE;
@@ -83,7 +83,7 @@ class Pocket {
          return FALSE;
       }
 
-      if ($this->IsAd && Gdn::Session()->CheckPermission('Garden.AdFree.Allow')) {
+      if ($this->IsAd() && Gdn::Session()->CheckPermission('Garden.NoAds.Allow')) {
          return FALSE;
       }
 
@@ -156,13 +156,17 @@ class Pocket {
       $this->Page = $Data['Page'];
       $this->MobileOnly = $Data['MobileOnly'];
       $this->MobileNever = $Data['MobileNever'];
-      $this->IsAd = $Data['Type'] == Pocket::TYPE_AD;
+      $this->Type = val('Type', $Data, Pocket::TYPE_DEFAULT);
       $this->EmbeddedNever = GetValue('EmbeddedNever', $Data);
       $this->ShowInDashboard = GetValue('ShowInDashboard', $Data);
 
       // parse the frequency.
       $Repeat = $Data['Repeat'];
       list($this->RepeatType, $this->RepeatFrequency) = Pocket::ParseRepeat($Repeat);
+   }
+
+   public function isAd() {
+      return $this->Type == Pocket::TYPE_AD;
    }
 
    public static $NameTranslations = array('conversations' => 'inbox', 'messages' => 'inbox', 'categories' => 'discussions', 'discussion' => 'comments');

--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -22,6 +22,9 @@ class Pocket {
    const REPEAT_EVERY = 'every';
    const REPEAT_INDEX = 'index';
 
+   const AD_TYPE = 'ad';
+   const DEFAULT_TYPE = 'default';
+
 
    /** $var string The text to display in the pocket. */
    public $Body = '';
@@ -53,9 +56,12 @@ class Pocket {
    /** $var array The repeat frequency. */
    public $MobileNever = FALSE;
 
+   /** $var boolean Is the pocket an ad? */
+   public $IsAd = FALSE;
+
    /** $var bool Whether to disable the pocket for embedded comments. * */
    public $EmbeddedNever = FALSE;
-   
+
    public $ShowInDashboard = FALSE;
 
    public function __construct($Location = '') {
@@ -71,14 +77,19 @@ class Pocket {
       if (!$this->ShowInDashboard && InSection('Dashboard')) {
          return FALSE;
       }
-      
+
       $IsMobile = IsMobile();
       if (($this->MobileOnly && !$IsMobile) || ($this->MobileNever && $IsMobile)) {
          return FALSE;
       }
 
-      if ($this->EmbeddedNever && strcasecmp(Gdn::Controller()->RequestMethod, 'embed') == 0)
+      if ($this->IsAd && Gdn::Session()->CheckPermission('Garden.AdFree.Allow')) {
          return FALSE;
+      }
+
+      if ($this->EmbeddedNever && strcasecmp(Gdn::Controller()->RequestMethod, 'embed') == 0) {
+         return FALSE;
+      }
 
       // Check to see if the pocket is enabled.
       switch ($this->Disabled) {
@@ -91,37 +102,41 @@ class Pocket {
       }
 
       // Check to see if the page matches.
-      if ($this->Page && strcasecmp($this->Page, GetValue('PageName', $Data)) != 0)
+      if ($this->Page && strcasecmp($this->Page, GetValue('PageName', $Data)) != 0) {
          return FALSE;
+      }
+
 
       // Check to see if this is repeating.
       $Count = GetValue('Count', $Data);
-      switch ($this->RepeatType) {
-         case Pocket::REPEAT_AFTER:
-            if (strcasecmp($Count, Pocket::REPEAT_AFTER) != 0)
-               return FALSE;
-            break;
-         case Pocket::REPEAT_BEFORE:
-            if (strcasecmp($Count, Pocket::REPEAT_BEFORE) != 0)
-               return FALSE;
-            break;
-         case Pocket::REPEAT_ONCE:
-            if ($Count != 1)
-               return FALSE;
-            break;
-         case Pocket::REPEAT_EVERY:
-            $Frequency = (array) $this->RepeatFrequency;
-            $Every = GetValue(0, $Frequency, 1);
-            if ($Every < 1)
-               $Every = 1;
-            $Begin = GetValue(1, $Frequency, 1);
-            if (($Count % $Every) != ($Begin % $Every))
-               return FALSE;
-            break;
-         case Pocket::REPEAT_INDEX:
-            if (!in_array($Count, (array) $this->RepeatFrequency))
-               return FALSE;
-            break;
+      if ($Count) {
+         switch ($this->RepeatType) {
+            case Pocket::REPEAT_AFTER:
+               if (strcasecmp($Count, Pocket::REPEAT_AFTER) != 0)
+                  return FALSE;
+               break;
+            case Pocket::REPEAT_BEFORE:
+               if (strcasecmp($Count, Pocket::REPEAT_BEFORE) != 0)
+                  return FALSE;
+               break;
+            case Pocket::REPEAT_ONCE:
+               if ($Count != 1)
+                  return FALSE;
+               break;
+            case Pocket::REPEAT_EVERY:
+               $Frequency = (array)$this->RepeatFrequency;
+               $Every = GetValue(0, $Frequency, 1);
+               if ($Every < 1)
+                  $Every = 1;
+               $Begin = GetValue(1, $Frequency, 1);
+               if (($Count % $Every) != ($Begin % $Every))
+                  return FALSE;
+               break;
+            case Pocket::REPEAT_INDEX:
+               if (!in_array($Count, (array)$this->RepeatFrequency))
+                  return FALSE;
+               break;
+         }
       }
 
       // If we've passed all of the tests then the pocket can be processed.
@@ -141,6 +156,7 @@ class Pocket {
       $this->Page = $Data['Page'];
       $this->MobileOnly = $Data['MobileOnly'];
       $this->MobileNever = $Data['MobileNever'];
+      $this->IsAd = $Data['Type'] == Pocket::AD_TYPE;
       $this->EmbeddedNever = GetValue('EmbeddedNever', $Data);
       $this->ShowInDashboard = GetValue('ShowInDashboard', $Data);
 
@@ -215,19 +231,20 @@ class Pocket {
       static $Plugin;
       if (!isset($Plugin))
          $Plugin = Gdn::PluginManager()->GetPluginInstance('PocketsPlugin', Gdn_PluginManager::ACCESS_CLASSNAME);
+
       $Plugin->EventArguments['Pocket'] = $this;
       $Plugin->FireEvent('ToString');
-      
+
       if (strcasecmp($this->Format, 'raw') == 0)
          return $this->Body;
       else
          return Gdn_Format::To($this->Body, $this->Format);
    }
-   
+
    public static function Touch($Name, $Value) {
       $Model = new Gdn_Model('Pocket');
       $Pockets = $Model->GetWhere(array('Name' => $Name))->ResultArray();
-         
+
       if (empty($Pockets)) {
          $Pocket = array(
             'Name' => $Name,
@@ -240,7 +257,8 @@ class Pocket {
             'MobileOnly' => 0,
             'MobileNever' => 0,
             'EmbeddedNever' => 0,
-            'ShowInDashboard' => 0
+            'ShowInDashboard' => 0,
+            'Type' => 'default'
             );
          $Model->Save($Pocket);
       }

--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -22,8 +22,8 @@ class Pocket {
    const REPEAT_EVERY = 'every';
    const REPEAT_INDEX = 'index';
 
-   const AD_TYPE = 'ad';
-   const DEFAULT_TYPE = 'default';
+   const TYPE_AD = 'ad';
+   const TYPE_DEFAULT = 'default';
 
 
    /** $var string The text to display in the pocket. */
@@ -156,7 +156,7 @@ class Pocket {
       $this->Page = $Data['Page'];
       $this->MobileOnly = $Data['MobileOnly'];
       $this->MobileNever = $Data['MobileNever'];
-      $this->IsAd = $Data['Type'] == Pocket::AD_TYPE;
+      $this->IsAd = $Data['Type'] == Pocket::TYPE_AD;
       $this->EmbeddedNever = GetValue('EmbeddedNever', $Data);
       $this->ShowInDashboard = GetValue('ShowInDashboard', $Data);
 

--- a/plugins/Pockets/pockets.js
+++ b/plugins/Pockets/pockets.js
@@ -19,6 +19,25 @@ jQuery(document).ready(function($) {
       }
    };
 
+   var toggleRepeat = function() {
+      var selected = $("select[name$=Location] option:selected").text();
+      switch (selected) {
+         case 'Custom':
+            $('label[for="Form_RepeatType"]').hide();
+            $('.RadioLabel').hide();
+            $('.RepeatEveryOptions').hide();
+            $('.RepeatIndexesOptions').hide();
+            break;
+         default:
+            $('label[for="Form_RepeatType"]').show();
+            $('.RadioLabel').show();
+            revealRepeatOptions();
+      }
+   }
+
+   $("select[name$=Location]").change(toggleRepeat);
+   $(document).ready(toggleRepeat);
+
    $("input[name$=RepeatType]").click(revealRepeatOptions);
 
    revealRepeatOptions();

--- a/plugins/Pockets/pockets.js
+++ b/plugins/Pockets/pockets.js
@@ -23,15 +23,10 @@ jQuery(document).ready(function($) {
       var selected = $("select[name$=Location] option:selected").text();
       switch (selected) {
          case 'Custom':
-            $('label[for="Form_RepeatType"]').hide();
-            $('.RadioLabel').hide();
-            $('.RepeatEveryOptions').hide();
-            $('.RepeatIndexesOptions').hide();
+            $('.js-repeat').hide();
             break;
          default:
-            $('label[for="Form_RepeatType"]').show();
-            $('.RadioLabel').show();
-            revealRepeatOptions();
+            $('.js-repeat').show();
       }
    }
 

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -44,7 +44,7 @@ echo $Form->Errors();
          }
       ?>
    </li>
-   <li>
+   <li class="js-repeat">
       <?php
          echo $Form->Label('Repeat', 'RepeatType');
 //

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -91,8 +91,8 @@ echo $Form->Errors();
          echo '<div class="Info2">', T("Most pockets shouldn't be displayed in the dashboard."), '</div>';
          echo $Form->CheckBox("ShowInDashboard", T("Display in dashboard. (not recommended)"));
 
-         echo '<div class="Info2">', T("Users with the permission Garden.NoAds.Allow will not see this pocket."), '</div>';
-         echo $Form->CheckBox("Ad", T("This pocket is an Ad."));
+         echo '<div class="Info2">', T("Users with the no ads permission will not see this pocket."), '</div>';
+         echo $Form->CheckBox("Ad", T("This pocket is an ad."));
       ?>
    </li>
    <li>

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -48,12 +48,12 @@ echo $Form->Errors();
       <?php
          echo $Form->Label('Repeat', 'RepeatType');
 //
-         echo '<div>', $Form->Radio('RepeatType', 'Before', array('Value' => Pocket::REPEAT_BEFORE)), '</div>';
+         echo '<div>', $Form->Radio('RepeatType', 'Before', array('Value' => Pocket::REPEAT_BEFORE, 'Default' => true)), '</div>';
 //
          echo '<div>', $Form->Radio('RepeatType', 'After', array('Value' => Pocket::REPEAT_AFTER)), '</div>';
 //
          echo '<div>', $Form->Radio('RepeatType', 'Repeat Every', array('Value' => Pocket::REPEAT_EVERY)), '</div>';
-         
+
          // Options for repeat every.
          echo '<div class="RepeatOptions RepeatEveryOptions P">',
             '<div class="Info2">', T('Enter numbers starting at 1.'), '</div>',
@@ -78,18 +78,21 @@ echo $Form->Errors();
          echo $Form->Label('Conditions', '');
          // echo '<div class="Info2">', T('Limit the pocket to one or more roles or permissions.'), '</div>';
          // $this->ConditionModule->Render();
-         
+
          echo '<div class="Info2">', T('Limit the display of this pocket to "mobile only".'), '</div>';
          echo $Form->CheckBox("MobileOnly", T("Only display on mobile browsers."));
-         
+
          echo '<div class="Info2">', T('Limit the display of this pocket for mobile devices.'), '</div>';
          echo $Form->CheckBox("MobileNever", T("Never display on mobile browsers."));
-         
+
          echo '<div class="Info2">', T('Limit the display of this pocket for embedded comments.'), '</div>';
          echo $Form->CheckBox("EmbeddedNever", T("Don't display for embedded comments."));
-         
+
          echo '<div class="Info2">', T("Most pockets shouldn't be displayed in the dashboard."), '</div>';
          echo $Form->CheckBox("ShowInDashboard", T("Display in dashboard. (not recommended)"));
+
+         echo '<div class="Info2">', T("Users with the permission Garden.AdFree.Allow will not see this pocket."), '</div>';
+         echo $Form->CheckBox("Ad", T("This pocket is an Ad."));
       ?>
    </li>
    <li>

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -91,7 +91,7 @@ echo $Form->Errors();
          echo '<div class="Info2">', T("Most pockets shouldn't be displayed in the dashboard."), '</div>';
          echo $Form->CheckBox("ShowInDashboard", T("Display in dashboard. (not recommended)"));
 
-         echo '<div class="Info2">', T("Users with the permission Garden.AdFree.Allow will not see this pocket."), '</div>';
+         echo '<div class="Info2">', T("Users with the permission Garden.NoAds.Allow will not see this pocket."), '</div>';
          echo $Form->CheckBox("Ad", T("This pocket is an Ad."));
       ?>
    </li>

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -35,7 +35,7 @@ echo Wrap($this->Data('Title'), 'h1');
       foreach ($this->Data('PocketData') as $PocketRow) {
       	 $MobileOnly = $PocketRow['MobileOnly'];
       	 $MobileNever = $PocketRow['MobileNever'];
-          $AdFree = $PocketRow['Type'] == Pocket::AD_TYPE;
+          $AdFree = $PocketRow['Type'] == Pocket::TYPE_AD;
 
          echo '<tr'.($PocketRow['Disabled'] != Pocket::DISABLED ? '' : ' class="Disabled"').'>';
 

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -35,7 +35,7 @@ echo Wrap($this->Data('Title'), 'h1');
       foreach ($this->Data('PocketData') as $PocketRow) {
       	 $MobileOnly = $PocketRow['MobileOnly'];
       	 $MobileNever = $PocketRow['MobileNever'];
-          $AdFree = $PocketRow['Type'] == Pocket::TYPE_AD;
+          $NoAds = $PocketRow['Type'] == Pocket::TYPE_AD;
 
          echo '<tr'.($PocketRow['Disabled'] != Pocket::DISABLED ? '' : ' class="Disabled"').'>';
 
@@ -59,8 +59,8 @@ echo Wrap($this->Data('Title'), 'h1');
          if ($MobileNever && $MobileOnly) {
          	echo '<br><b>(', T('Hidden for everything!'), ')</b>';
          }
-         if ($AdFree) {
-            echo '<br>(', T('Hidden for users with the Garden.AdFree.Allow permission.'), ')';
+         if ($NoAds) {
+            echo '<br>(', T('Hidden for users with the Garden.NoAds.Allow permission.'), ')';
          }
          echo'</td>';
          echo '<td>', nl2br(htmlspecialchars(substr($PocketRow['Body'], 0, 200))), '</td>';

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -60,7 +60,7 @@ echo Wrap($this->Data('Title'), 'h1');
          	echo '<br><b>(', T('Hidden for everything!'), ')</b>';
          }
          if ($NoAds) {
-            echo '<br>(', T('Hidden for users with the Garden.NoAds.Allow permission.'), ')';
+            echo '<br>(', T('Users with the no ads permission will not see this pocket.'), ')';
          }
          echo'</td>';
          echo '<td>', nl2br(htmlspecialchars(substr($PocketRow['Body'], 0, 200))), '</td>';

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -35,6 +35,8 @@ echo Wrap($this->Data('Title'), 'h1');
       foreach ($this->Data('PocketData') as $PocketRow) {
       	 $MobileOnly = $PocketRow['MobileOnly'];
       	 $MobileNever = $PocketRow['MobileNever'];
+          $AdFree = $PocketRow['Type'] == Pocket::AD_TYPE;
+
          echo '<tr'.($PocketRow['Disabled'] != Pocket::DISABLED ? '' : ' class="Disabled"').'>';
 
          echo '<td>',
@@ -47,7 +49,7 @@ echo Wrap($this->Data('Title'), 'h1');
             '</td>';
 
          echo '<td>',htmlspecialchars($PocketRow['Page']), '</td>';
-         echo '<td  class="Alt">', htmlspecialchars($PocketRow['Location']); 
+         echo '<td  class="Alt">', htmlspecialchars($PocketRow['Location']);
          if ($MobileOnly) {
          	echo '<br>(', T('Shown only on mobile'), ')';
          }
@@ -56,6 +58,9 @@ echo Wrap($this->Data('Title'), 'h1');
          }
          if ($MobileNever && $MobileOnly) {
          	echo '<br><b>(', T('Hidden for everything!'), ')</b>';
+         }
+         if ($AdFree) {
+            echo '<br>(', T('Hidden for users with the Garden.AdFree.Allow permission.'), ')';
          }
          echo'</td>';
          echo '<td>', nl2br(htmlspecialchars(substr($PocketRow['Body'], 0, 200))), '</td>';


### PR DESCRIPTION
This PR adds functionality to hide pockets that are marked as 'ads' for any user with the Garden.AdFree.Allow permission.

Add 'Custom' pocket location
Add permission setting (Garden.AdFree.Allow) 
Add 'Ad' type to pockets
Validate Smarty-rendered pockets with 'Custom' locations (using CanRender function)
Use javascript to hide Repeat options when 'Custom' location is set.