### PR TITLE
Signatures: Uncomment event.

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -531,7 +531,7 @@ EOT;
          'UserID'    => $SourceUserID,
          'Signature' => &$Signature
       );
-//      $this->FireEvent('BeforeDrawSignature');
+      $this->FireEvent('BeforeDrawSignature');
 
       $SigClasses = '';
       if (!is_null($Signature)) {


### PR DESCRIPTION
Fixes bug where Warnings2 jailed users still have signatures.