### PR TITLE
Update the mulitlingual plugin to work with locale canonicalization

### DIFF
--- a/plugins/Multilingual/class.multilingual.plugin.php
+++ b/plugins/Multilingual/class.multilingual.plugin.php
@@ -39,6 +39,40 @@ $PluginInfo['Multilingual'] = array(
  */
 class MultilingualPlugin extends Gdn_Plugin {
    /**
+    * Return the enabled locales suitable for local choosing.
+    *
+    * @return array Returns an array in the form `[locale => localeName]`.
+    */
+   public static function EnabledLocales() {
+      $defaultLocale = Gdn_Locale::Canonicalize(C('Garden.Locale'));
+
+      $localeModel = new LocaleModel();
+      if (class_exists('Locale')) {
+         $localePacks = $localeModel->EnabledLocalePacks(false);
+         $locales = array();
+         foreach ($localePacks as $locale) {
+            $locales[$locale] = Locale::getDisplayName($locale, $locale);
+         }
+         $defaultName = Locale::getDisplayName($defaultLocale, $defaultLocale);
+      } else {
+         $locales = $localeModel->EnabledLocalePacks(true);
+         $locales = array_column($locales, 'Name', 'Locale');
+         $defaultName = $defaultLocale === 'en' ? 'English' : $defaultLocale;
+      }
+      asort($locales);
+
+      if (!array_key_exists($defaultLocale, $locales)) {
+         $locales = array_merge(
+            array($defaultLocale => $defaultName),
+            $locales
+         );
+      }
+
+      return $locales;
+   }
+
+
+   /**
     * Set user's preferred locale.
     *
     * Moved event from AppStart to AfterAnalyzeRequest to allow Embed to set P3P header first.

--- a/plugins/Multilingual/modules/class.localechoosermodule.php
+++ b/plugins/Multilingual/modules/class.localechoosermodule.php
@@ -27,21 +27,12 @@ class LocaleChooserModule extends Gdn_Module {
     * @return string HTML.
     */
    public function BuildLocales() {
-      // Get locales
-      $LocaleModel = new LocaleModel();
-      $Options = $LocaleModel->EnabledLocalePacks();
-      $Locales = $LocaleModel->AvailableLocalePacks();
+      $locales = MultilingualPlugin::EnabledLocales();
 
-      // Build & add links
       $Links = '';
-      foreach ($Options as $Slug => $Code) {
-         $LocaleInfo = GetValue($Slug, $Locales);
-         $LocaleName = str_replace(' Transifex', '' , GetValue('Name', $LocaleInfo)); // No 'Transifex' in names, pls.
-         $Links .= $this->BuildLocaleLink($LocaleName, $Code);
+      foreach ($locales as $code => $name) {
+         $Links .= $this->BuildLocaleLink($name, $code);
       }
-
-      // Hackily add English option
-      $Links .= $this->BuildLocaleLink('English', 'en-CA');
 
       return $Links;
    }


### PR DESCRIPTION
This update is in support of the locale PR [here](https://github.com/vanilla/vanilla/pull/2586).

- Improve the locale listing functionality.
- Include the default locale in a less hacky way.
- Use ext-intl for locale names where possible.