### PR TITLE
Let TouchIcon use updated paths

### DIFF
--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -95,7 +95,8 @@ class TouchIconPlugin extends Gdn_Plugin {
     * @return string Path to icon
     */
    public function getIconPath() {
-      return Gdn_Upload::Url(C('Garden.TouchIcon', self::DEFAULT_PATH));
+      $Icon = C('Garden.TouchIcon') ? Gdn_Upload::Url(C('Garden.TouchIcon')) : self::DEFAULT_PATH;
+      return $Icon;
    }
 
    /**

--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -25,14 +25,14 @@ class TouchIconPlugin extends Gdn_Plugin {
          'Internal'
       );
    }
-   
+
    /**
     * Remove route.
     */
    public function OnDisable() {
       Gdn::Router()->DeleteRoute('apple-touch-icon.png');
    }
-   
+
    /**
     * Touch icon management screen.
     *
@@ -43,7 +43,7 @@ class TouchIconPlugin extends Gdn_Plugin {
       $Sender->Permission('Garden.Settings.Manage');
       $Sender->AddSideMenu('dashboard/settings/touchicon');
       $Sender->Title(T('Touch Icon'));
-      
+
       if ($Sender->Form->AuthenticatedPostBack()) {
          $Upload = new Gdn_UploadImage();
          try {
@@ -53,7 +53,7 @@ class TouchIconPlugin extends Gdn_Plugin {
                // Save the uploaded image
                $Upload->SaveImageAs(
                   $TmpImage,
-                  PATH_ROOT.'/uploads/TouchIcon/apple-touch-icon.png',
+                  'apple-touch-icon.png',
                   114,
                   114,
                   array('OutputType' => 'png', 'ImageQuality' => '8')
@@ -63,13 +63,13 @@ class TouchIconPlugin extends Gdn_Plugin {
          } catch (Exception $ex) {
             $Sender->Form->AddError($ex->getMessage());
          }
-         
+
          $Sender->InformMessage(T('TouchIconSaved', "Your icon has been saved."));
       }
-      
-      $Sender->Render($this->GetView('touchicon.php'));      
+
+      $Sender->Render($this->GetView('touchicon.php'));
    }
-   
+
    /**
     * Redirect to icon.
     *
@@ -78,7 +78,7 @@ class TouchIconPlugin extends Gdn_Plugin {
     */
    public function UtilityController_ShowTouchIcon_Create($Sender) {
       $DefaultPath = 'plugins/TouchIcon/design/default.png';
-      $IconPath = Gdn_Upload::Url('TouchIcon/apple-touch-icon.png');
+      $IconPath = Gdn_Upload::Url('apple-touch-icon.png');
       $Redirect = (C('Plugins.TouchIcon.Uploaded')) ? $IconPath : $DefaultPath;
       Redirect($Redirect, 301);
       exit();

--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -15,6 +15,12 @@ $PluginInfo['TouchIcon'] = array(
 );
 
 class TouchIconPlugin extends Gdn_Plugin {
+
+   /**
+    * @var string Default icon path
+    */
+   const DEFAULT_PATH = 'plugins/TouchIcon/design/default.png';
+
    /**
 	 * Create route.
 	 */
@@ -67,7 +73,19 @@ class TouchIconPlugin extends Gdn_Plugin {
          $Sender->InformMessage(T('TouchIconSaved', "Your icon has been saved."));
       }
 
+      $Sender->SetData('Path', $this->getIconPath());
       $Sender->Render($this->GetView('touchicon.php'));
+   }
+
+
+   /**
+    * Get path to icon
+    *
+    * @return string Path to icon
+    */
+   public function getIconPath() {
+      $IconPath = Gdn_Upload::Url('apple-touch-icon.png');
+      return (C('Plugins.TouchIcon.Uploaded')) ? $IconPath : self::DEFAULT_PATH;
    }
 
    /**
@@ -77,9 +95,7 @@ class TouchIconPlugin extends Gdn_Plugin {
     * @access public
     */
    public function UtilityController_ShowTouchIcon_Create($Sender) {
-      $DefaultPath = 'plugins/TouchIcon/design/default.png';
-      $IconPath = Gdn_Upload::Url('apple-touch-icon.png');
-      $Redirect = (C('Plugins.TouchIcon.Uploaded')) ? $IconPath : $DefaultPath;
+      $Redirect = $this->getIconPath();
       Redirect($Redirect, 301);
       exit();
    }

--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -4,7 +4,7 @@
 $PluginInfo['TouchIcon'] = array(
    'Name' => 'Touch Icon',
    'Description' => 'Adds option to upload a touch icon for Apple iDevices.',
-   'Version' => '1.0',
+   'Version' => '1.1',
    'Author' => "Matt Lincoln Russell",
    'AuthorEmail' => 'lincoln@vanillaforums.com',
    'AuthorUrl' => 'http://lincolnwebs.com',
@@ -40,6 +40,17 @@ class TouchIconPlugin extends Gdn_Plugin {
    }
 
    /**
+    * Updates.
+    */
+   public function Structure() {
+      // Backwards compatibility with v1.
+      if (C('Plugins.TouchIcon.Uploaded')) {
+         SaveToConfig('Garden.TouchIcon', PATH_ROOT.'/uploads/TouchIcon/apple-touch-icon.png');
+         RemoveFromConfig('Plugins.TouchIcon.Uploaded');
+      }
+   }
+
+   /**
     * Touch icon management screen.
     *
     * @since 1.0
@@ -56,15 +67,16 @@ class TouchIconPlugin extends Gdn_Plugin {
             // Validate the upload
             $TmpImage = $Upload->ValidateUpload('TouchIcon', FALSE);
             if ($TmpImage) {
-               // Save the uploaded image
+               // Save the uploaded image.
+               $TouchIconPath ='banner/touchicon_'.substr(md5(microtime()), 16).'.png';
                $Upload->SaveImageAs(
                   $TmpImage,
-                  'apple-touch-icon.png',
+                  $TouchIconPath,
                   114,
                   114,
                   array('OutputType' => 'png', 'ImageQuality' => '8')
                );
-               SaveToConfig('Plugins.TouchIcon.Uploaded', TRUE);
+               SaveToConfig('Garden.TouchIcon', $TouchIconPath);
             }
          } catch (Exception $ex) {
             $Sender->Form->AddError($ex->getMessage());
@@ -77,15 +89,13 @@ class TouchIconPlugin extends Gdn_Plugin {
       $Sender->Render($this->GetView('touchicon.php'));
    }
 
-
    /**
-    * Get path to icon
+    * Get path to icon.
     *
     * @return string Path to icon
     */
    public function getIconPath() {
-      $IconPath = Gdn_Upload::Url('apple-touch-icon.png');
-      return (C('Plugins.TouchIcon.Uploaded')) ? $IconPath : self::DEFAULT_PATH;
+      return Gdn_Upload::Url(C('Garden.TouchIcon', self::DEFAULT_PATH));
    }
 
    /**

--- a/plugins/TouchIcon/views/touchicon.php
+++ b/plugins/TouchIcon/views/touchicon.php
@@ -16,9 +16,9 @@ echo $this->Form->Errors();
                'div',
                array('class' => 'Info')
             );
-            
+
          echo Wrap(
-            Img('/apple-touch-icon.png'),
+            Img(val('Path', $this->Data)),
             'div'
          );
          echo Wrap(
@@ -26,7 +26,7 @@ echo $this->Form->Errors();
             'div',
             array('class' => 'Info')
          );
-         
+
          echo $this->Form->Input('TouchIcon', 'file');
       ?>
    </li>


### PR DESCRIPTION
Fixes Touch Icons not being able to be uploaded on cloud with CDN.