### PR TITLE
SteamConnect: Don't set username on existing users

### DIFF
--- a/plugins/SteamConnect/class.steam.plugin.php
+++ b/plugins/SteamConnect/class.steam.plugin.php
@@ -120,8 +120,15 @@ class SteamPlugin extends Gdn_Plugin {
         $Form->SetFormValue('Provider', 'Steam');
         $Form->SetFormValue('ProviderName', 'Steam');
         $Form->SetFormValue('UniqueID', $SteamID);
-        $Form->SetFormValue('Name', $player->personaname);
         $Form->SetFormValue('Photo', $player->avatarfull);
+
+        /**
+         * Check to see if we already have an authentication record for this user.  If we don't, setup their username.
+         */
+        if (!Gdn::UserModel()->GetAuthentication($SteamID, 'Steam')) {
+            $Form->SetFormValue('Name', $player->personaname);
+        }
+
         if (isset($player->realname)) {
             $Form->SetFormValue('FullName', $player->realname);
         }


### PR DESCRIPTION
Users' Vanilla usernames were being reset to their current username on Steam every time they authenticated with Steam.  This fix checks to see if the user already has an established Steam ID connection and avoids resetting their Vanilla username if found.

Fixes #210 