### PR TITLE
Fix method naming code standards

### DIFF
--- a/standards/Vanilla/Sniffs/Classes/ValidClassNameSniff.php
+++ b/standards/Vanilla/Sniffs/Classes/ValidClassNameSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Squiz_Sniffs_Classes_ValidClassNameSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Ensures classes are in camel caps, and the first letter is capitalised or begin with "Gdn_".
+ */
+class Vanilla_Sniffs_Classes_ValidClassNameSniff implements PHP_CodeSniffer_Sniff {
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register() {
+        return array(
+            T_CLASS,
+            T_INTERFACE,
+        );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The current file being processed.
+     * @param int $stackPtr The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            $error = 'Possible parse error: %s missing opening or closing brace';
+            $data = array($tokens[$stackPtr]['content']);
+            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $data);
+            return;
+        }
+
+        // Determine the name of the class or interface. Note that we cannot
+        // simply look for the first T_STRING because a class name
+        // starting with the number will be multiple tokens.
+        $opener = $tokens[$stackPtr]['scope_opener'];
+        $nameStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $opener, true);
+        $nameEnd = $phpcsFile->findNext(T_WHITESPACE, $nameStart, $opener);
+        $name = trim($phpcsFile->getTokensAsString($nameStart, ($nameEnd - $nameStart)));
+
+        // Names that begin with "Gdn_" are okay.
+        if (strpos($name, 'Gdn_') === 0) {
+            $name = substr($name, 4);
+        }
+
+        // Check for camel caps format.
+        $valid = PHP_CodeSniffer::isCamelCaps($name, true, true, false);
+        if ($valid === false) {
+            $type = ucfirst($tokens[$stackPtr]['content']);
+            $error = '%s name "%s" is not in camel caps format';
+            $data = array(
+                $type,
+                $name,
+            );
+            $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $data);
+        }
+
+    }//end process()
+
+
+}//end class

--- a/standards/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/standards/Vanilla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -298,9 +298,9 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
             $phpcsFile->addError($error, ($commentStart + 1), 'ShortNotCapital');
         }
 
-        if ($lastChar !== '.') {
-            $error = 'Function comment short description must end with a full stop';
-            $phpcsFile->addError($error, ($commentStart + 1), 'ShortFullStop');
+        if (!in_array($lastChar,  ['.', '?', '!'])) {
+            $error = 'Function comment short descriptions must end with punctuation';
+            $phpcsFile->addError($error, ($commentStart + 1), 'ShortPunctuation');
         }
 
         // Check for unknown/deprecated tags.
@@ -628,9 +628,9 @@ class Vanilla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
                     }
 
                     $lastChar = $paramComment[(strlen($paramComment) - 1)];
-                    if ($lastChar !== '.') {
-                        $error = 'Param comment must end with a full stop';
-                        $this->currentFile->addError($error, $errorPos, 'ParamCommentFullStop');
+                    if (!in_array($lastChar, ['.', '?', '!'])) {
+                        $error = 'Param comment must end with punctuation';
+                        $this->currentFile->addError($error, $errorPos, 'ParamCommentPunctuation');
                     }
                 }
 

--- a/standards/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/standards/Vanilla/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -32,6 +32,12 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false
 class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_Standards_AbstractScopeSniff
 {
 
+    protected $magicMethods = [
+        '__construct', '__destruct', '__call', '__callStatic', '__get', '__set', '__isset', '__unset',
+        '__sleep', '__wakeup', '__toString', '__invoke', '__set_state', '__clone', 'debugInfo()'
+    ];
+
+
     /**
      * Constructs a PSR1_Sniffs_Methods_CamelCapsMethodNameSniff.
      */
@@ -60,6 +66,11 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
             return;
         }
 
+        // Check for magic methods.
+        if (in_array($methodName, $this->magicMethods)) {
+            return;
+        }
+
         $testName = ltrim($methodName, '_');
 
         if (self::isVanillaMethod($testName) === true) {
@@ -70,7 +81,7 @@ class Vanilla_Sniffs_Methods_CamelCapsMethodNameSniff extends PHP_CodeSniffer_St
                 $phpcsFile->addError($error, $stackPtr, 'NotVanilla', $errorData);
             }
 
-        } elseif (PHP_CodeSniffer::isCamelCaps($testName, false, false, false) === false) {
+        } elseif (!PHP_CodeSniffer::isCamelCaps($testName, false, true, false)) {
             $error     = 'Method name "%s" is not in camel caps format';
             $className = $phpcsFile->getDeclarationName($currScope);
             $errorData = array($className.'::'.$methodName);

--- a/standards/Vanilla/ruleset.xml
+++ b/standards/Vanilla/ruleset.xml
@@ -10,6 +10,7 @@
 
     <rule ref="PSR1" >
         <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
     </rule>
     <rule ref="PSR2" >
@@ -47,6 +48,8 @@
 
     <rule ref="Vanilla.Commenting.ClassComment"/>
     <rule ref="Vanilla.Commenting.FunctionComment"/>
+
+    <rul ref="Vanilla.Classes.ValidClassName" />
 
     <!-- camelCase Properties; no underscore -->
     <rule ref="Vanilla.Classes.PropertyDeclaration"/>


### PR DESCRIPTION
Allow magic methods and don’t require an underscore on method names.