### PR TITLE
AgeGate MinAgeWithConsent config setting

### DIFF
--- a/plugins/AgeGate/class.agegate.plugin.php
+++ b/plugins/AgeGate/class.agegate.plugin.php
@@ -91,9 +91,9 @@ class AgeGatePlugin extends Gdn_Plugin {
      */
     public function EntryController_RegisterValidation_Handler($sender, $args) {
 
-        $day = (int)$sender->Form->GetFormValue('Day', 0);
-        $month = (int)$sender->Form->GetFormValue('Month', 0);
-        $year = (int)$sender->Form->GetFormValue('Year', 0);
+        $day = (int)$sender->Form->GetFormValue('DateOfBirth_Day', 0);
+        $month = (int)$sender->Form->GetFormValue('DateOfBirth_Month', 0);
+        $year = (int)$sender->Form->GetFormValue('DateOfBirth_Year', 0);
 
         if ($day == 0 || $year == 0 || $month == 0) {
             $sender->UserModel->Validation->AddValidationResult('', "Please select a valid Date of Birth.");

--- a/plugins/AgeGate/class.agegate.plugin.php
+++ b/plugins/AgeGate/class.agegate.plugin.php
@@ -50,16 +50,16 @@ class AgeGatePlugin extends Gdn_Plugin {
 
         $days = array_merge(
             array(0 => T('Day')),
-            array_combine(range(1, 31), range(1,31))
+            array_combine(range(1, 31), range(1, 31))
         );
         $months = array_merge(
             array(0 => T('Month')),
             array_combine(range(1, 12), range(1, 12))
         );
         $years = array_combine(
-                range(C('Plugins.AgeGate.StartYear', date('Y')), C('Plugins.AgeGate.StartYear', date('Y')-100)),
-                range(C('Plugins.AgeGate.StartYear', date('Y')), C('Plugins.AgeGate.StartYear', date('Y')-100))
-            );
+            range(C('Plugins.AgeGate.StartYear', date('Y')), C('Plugins.AgeGate.StartYear', date('Y') - 100)),
+            range(C('Plugins.AgeGate.StartYear', date('Y')), C('Plugins.AgeGate.StartYear', date('Y') - 100))
+        );
         $years = array(0 => T('Year')) + $years;
 
         $minimumAge = C('Plugins.AgeGate.MinimumAge', 0);
@@ -78,7 +78,16 @@ class AgeGatePlugin extends Gdn_Plugin {
                 $minimumAge = $minimumAgeWithConsent;
             }
             echo '<li class="agegate-confirmation js-agegate-confirmation Hidden">';
-            echo $sender->Form->CheckBox('AgeGateConfirmation', sprintf(t('I confirm that I have received consent to join this community.'), $minimumAge));
+            echo $sender->Form->CheckBox(
+                'AgeGateConfirmation',
+                '@'.sprintf(
+                    t(
+                        'I confirm that I have received consent to join this community.',
+                        'Since I\'m under %d years old, I confirm that I have received consent to join this community.'
+                    ),
+                    $minimumAge
+                )
+            );
             echo '</li>';
         }
     }
@@ -112,18 +121,18 @@ class AgeGatePlugin extends Gdn_Plugin {
 
         if ($minimumAgeWithConsent) {
             if ($addConfirmation && $age < $minimumAgeWithConsent && $age >= $minimumAge) {
-                $sender->UserModel->Validation->applyRule('AgeGateConfirmation', 'Required', T('You must receive proper consent to participate in this forum.'));
+                $sender->UserModel->Validation->applyRule('AgeGateConfirmation', 'Required', 'You must confirm you have received consent to register.');
                 return;
             }
             if ($age < $minimumAge) {
                 $sender->UserModel->Validation->addValidationResult('', sprintf("You must be at least %d years old to Register.", $minimumAge));
                 return;
             }
-        } else if ($age < $minimumAge) {
+        } elseif ($age < $minimumAge) {
             if ($addConfirmation) {
-                $sender->UserModel->Validation->applyRule('AgeGateConfirmation', 'Required', T('You must receive proper consent to participate in this forum.'));
+                $sender->UserModel->Validation->applyRule('AgeGateConfirmation', 'Required', 'You must confirm you have received consent to register.');
             } else {
-                $sender->UserModel->Validation->addValidationResult('', sprintf("You must be at least %d years old to Register.", $minimumAge));
+                $sender->UserModel->Validation->addValidationResult('', sprintf("You must be at least %d years old to register.", $minimumAge));
             }
             return;
         }

--- a/plugins/AgeGate/class.agegate.plugin.php
+++ b/plugins/AgeGate/class.agegate.plugin.php
@@ -67,12 +67,8 @@ class AgeGatePlugin extends Gdn_Plugin {
         $addConfirmation = C('Plugins.AgeGate.AddConfirmation', false);
 
         echo '<li class="agegate-dob">';
-        echo $sender->Form->Label('Birthday', 'DOB');
-        echo $sender->Form->DropDown('Day', $days, array('class' => 'AgeGate'));
-        echo ' ';
-        echo $sender->Form->DropDown('Month', $months, array('class' => 'AgeGate'));
-        echo ' ';
-        echo $sender->Form->DropDown('Year', $years, array('class' => 'AgeGate'));
+        echo $sender->Form->label('Birthday', 'DateOfBirth');
+        echo $sender->Form->date('DateOfBirth', array('class' => 'AgeGate'));
         echo '</li>';
 
         if ($addConfirmation) {

--- a/plugins/AgeGate/class.agegate.plugin.php
+++ b/plugins/AgeGate/class.agegate.plugin.php
@@ -27,8 +27,8 @@ class AgeGatePlugin extends Gdn_Plugin {
      * @param EntryController $sender Sending Controller.
      * @param array $args Arguments.
      */
-    public function EntryController_RegisterBeforeTerms_Handler($sender, $args) {
-        $this->EntryController_RegisterFormBeforeTerms_Handler($sender, $args);
+    public function entryController_registerBeforeTerms_handler($sender, $args) {
+        $this->entryController_registerFormBeforeTerms_handler($sender, $args);
     }
 
     /**
@@ -36,8 +36,8 @@ class AgeGatePlugin extends Gdn_Plugin {
      *
      * @param EntryController $sender Sending Controller.
      */
-    public function EntryController_Render_Before($sender) {
-        $sender->AddJsFile('agegate.js', 'plugins/AgeGate');
+    public function entryController_render_before($sender) {
+        $sender->addJsFile('agegate.js', 'plugins/AgeGate');
     }
 
     /**
@@ -46,7 +46,7 @@ class AgeGatePlugin extends Gdn_Plugin {
      * @param EntryController $sender Sending Controller.
      * @param array $args Arguments.
      */
-    public function EntryController_RegisterFormBeforeTerms_Handler($sender, $args) {
+    public function entryController_registerFormBeforeTerms_handler($sender, $args) {
 
         $days = array_merge(
             array(0 => T('Day')),
@@ -89,18 +89,18 @@ class AgeGatePlugin extends Gdn_Plugin {
      * @param EntryController $sender Sending Controller.
      * @param array $args Arguments.
      */
-    public function EntryController_RegisterValidation_Handler($sender, $args) {
+    public function entryController_registerValidation_handler($sender, $args) {
 
-        $day = (int)$sender->Form->GetFormValue('DateOfBirth_Day', 0);
-        $month = (int)$sender->Form->GetFormValue('DateOfBirth_Month', 0);
-        $year = (int)$sender->Form->GetFormValue('DateOfBirth_Year', 0);
+        $day = (int)$sender->Form->getFormValue('DateOfBirth_Day', 0);
+        $month = (int)$sender->Form->getFormValue('DateOfBirth_Month', 0);
+        $year = (int)$sender->Form->getFormValue('DateOfBirth_Year', 0);
 
         if ($day == 0 || $year == 0 || $month == 0) {
-            $sender->UserModel->Validation->AddValidationResult('', "Please select a valid Date of Birth.");
+            $sender->UserModel->Validation->addValidationResult('', "Please select a valid Date of Birth.");
             return;
         }
 
-        $dob = Gdn_Format::ToDateTime(mktime(0, 0, 0, $month, $day, $year));
+        $dob = Gdn_Format::toDateTime(mktime(0, 0, 0, $month, $day, $year));
         $datetime1 = new DateTime($year . '-' . $month . '-' . $day);
         $datetime2 = new DateTime();
 
@@ -112,24 +112,24 @@ class AgeGatePlugin extends Gdn_Plugin {
 
         if ($minimumAgeWithConsent) {
             if ($addConfirmation && $age < $minimumAgeWithConsent && $age >= $minimumAge) {
-                $sender->UserModel->Validation->ApplyRule('AgeGateConfirmation', 'Required', T('You must receive proper consent to participate in this forum.'));
+                $sender->UserModel->Validation->applyRule('AgeGateConfirmation', 'Required', T('You must receive proper consent to participate in this forum.'));
                 return;
             }
             if ($age < $minimumAge) {
-                $sender->UserModel->Validation->AddValidationResult('', sprintf("You must be at least %d years old to Register.", $minimumAge));
+                $sender->UserModel->Validation->addValidationResult('', sprintf("You must be at least %d years old to Register.", $minimumAge));
                 return;
             }
         } else if ($age < $minimumAge) {
             if ($addConfirmation) {
-                $sender->UserModel->Validation->ApplyRule('AgeGateConfirmation', 'Required', T('You must receive proper consent to participate in this forum.'));
+                $sender->UserModel->Validation->applyRule('AgeGateConfirmation', 'Required', T('You must receive proper consent to participate in this forum.'));
             } else {
-                $sender->UserModel->Validation->AddValidationResult('', sprintf("You must be at least %d years old to Register.", $minimumAge));
+                $sender->UserModel->Validation->addValidationResult('', sprintf("You must be at least %d years old to Register.", $minimumAge));
             }
             return;
         }
 
         // Set the value on the form so that it will be saved to user model
-        if ($sender->Form->ErrorCount() == 0 && !$sender->UserModel->Validation->Results()) {
+        if ($sender->Form->errorCount() == 0 && !$sender->UserModel->Validation->results()) {
             $sender->Form->_FormValues['DateOfBirth'] = $dob;
         }
 
@@ -140,35 +140,35 @@ class AgeGatePlugin extends Gdn_Plugin {
      *
      * @param SettingsController $sender
      */
-    public function SettingsController_AgeGate_Create($sender) {
+    public function settingsController_ageGate_create($sender) {
 
-        $sender->Permission('Garden.Settings.Manage');
-        $sender->SetData('Title', T('Age Gate Settings'));
-        $sender->AddSideMenu();
+        $sender->permission('Garden.Settings.Manage');
+        $sender->setData('Title', T('Age Gate Settings'));
+        $sender->addSideMenu();
 
-        if ($sender->Form->AuthenticatedPostBack()) {
-            $minimumAge = $sender->Form->GetValue('MinimumAge');
-            $addConfirmation = $sender->Form->GetValue('AddConfirmation');
+        if ($sender->Form->authenticatedPostBack()) {
+            $minimumAge = $sender->Form->getValue('MinimumAge');
+            $addConfirmation = $sender->Form->getValue('AddConfirmation');
 
             if (!is_numeric($minimumAge)) {
-                $sender->Form->AddError('Please enter a valid number.');
+                $sender->Form->addError('Please enter a valid number.');
             }
-            if ($sender->Form->ErrorCount() == 0) {
-                SaveToConfig('Plugins.AgeGate.MinimumAge', $minimumAge);
-                SaveToConfig('Plugins.AgeGate.AddConfirmation', $addConfirmation);
-                $sender->InformMessage(T('Saved'));
+            if ($sender->Form->errorCount() == 0) {
+                saveToConfig('Plugins.AgeGate.MinimumAge', $minimumAge);
+                saveToConfig('Plugins.AgeGate.AddConfirmation', $addConfirmation);
+                $sender->informMessage(T('Saved'));
             }
         } else {
-            $sender->Form->SetData(array(
+            $sender->Form->setData(array(
                'MinimumAge' => C('Plugins.AgeGate.MinimumAge'),
                'AddConfirmation' => C('Plugins.AgeGate.AddConfirmation')
             ));
         }
 
-        $sender->Render($sender->FetchViewLocation('settings', '', 'plugins/AgeGate'));
+        $sender->render($sender->fetchViewLocation('settings', '', 'plugins/AgeGate'));
     }
 
-    public function Setup() {
+    public function setup() {
         // No setup required
     }
 

--- a/plugins/AgeGate/js/agegate.js
+++ b/plugins/AgeGate/js/agegate.js
@@ -4,13 +4,23 @@ $(function() {
     if ($('#Form_Day').val() > 0 && $('#Form_Month').val() > 0 && $('#Form_Year').val() > 0) {
       var userDob = new Date($('#Form_Year').val(), $('#Form_Month').val()-1, $('#Form_Day').val(), 0, 0, 0, 0).getTime();
       var minAge = $('#Form_MinimumAge').val();
+      var minAgeWithConsent = $('#Form_MinimumAgeWithConsent').val();
       var now = new Date();
       var currentYear = now.getFullYear();
-      var maxDob = now.setFullYear(currentYear - minAge);
-      if (userDob > maxDob) {
-        $('.js-agegate-confirmation').removeClass('Hidden');
+      var minDob = now.setFullYear(currentYear - minAge);
+      var maxDobWithConsent = now.setFullYear(currentYear - minAgeWithConsent);
+      if (minAgeWithConsent) { // Hidden config setting is set
+        if (userDob < minDob && userDob > maxDobWithConsent) {
+          $('.js-agegate-confirmation').removeClass('Hidden');
+        } else {
+          $('.js-agegate-confirmation').addClass('Hidden');
+        }
       } else {
-        $('.js-agegate-confirmation').addClass('Hidden');
+        if (userDob > minDob) {
+          $('.js-agegate-confirmation').removeClass('Hidden');
+        } else {
+          $('.js-agegate-confirmation').addClass('Hidden');
+        }
       }
     }
   }
@@ -20,4 +30,5 @@ $(function() {
   $('.AgeGate').change(function() {
     checkAge();
   });
+
 });

--- a/plugins/AgeGate/js/agegate.js
+++ b/plugins/AgeGate/js/agegate.js
@@ -1,8 +1,8 @@
 $(function() {
 
   function checkAge() {
-    if ($('#Form_Day').val() > 0 && $('#Form_Month').val() > 0 && $('#Form_Year').val() > 0) {
-      var userDob = new Date($('#Form_Year').val(), $('#Form_Month').val()-1, $('#Form_Day').val(), 0, 0, 0, 0).getTime();
+    if ($('#Form_DateOfBirth_Day').val() > 0 && $('#Form_DateOfBirth_Month').val() > 0 && $('#Form_DateOfBirth_Year').val() > 0) {
+      var userDob = new Date($('#Form_DateOfBirth_Year').val(), $('#Form_DateOfBirth_Month').val()-1, $('#Form_DateOfBirth_Day').val(), 0, 0, 0, 0).getTime();
       var minAge = $('#Form_MinimumAge').val();
       var minAgeWithConsent = $('#Form_MinimumAgeWithConsent').val();
       var now = new Date();


### PR DESCRIPTION
Adds a hidden config setting (Plugins.AgeGate.MinimumAgeWithConsent) that allows a user between the MinimumAgeWithConsent and the MinimumAge to register after confirming they have received consent to register. If this config setting is set, no user under the MinimumAge will be able to register.

Also changes the form field to use 'DateOfBirth' and uses Gdn_Form's date function to render the DateOfBirth field.

Also casening.