### PR TITLE
Don't remove Answers from the Comments array. 

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -396,7 +396,8 @@ class QnAPlugin extends Gdn_Plugin {
     * @param $Sender
     * @param $Args
     */
-   public function DiscussionController_BeforeDiscussionRender_Handler($Sender, $Args) {
+   public function DiscussionController_AfterFetchAttachmentViews_Handler($Sender, $Args)
+   {
       if ($Sender->Data('Discussion.QnA'))
          $Sender->CssClass .= ' Question';
 
@@ -414,12 +415,14 @@ class QnAPlugin extends Gdn_Plugin {
       }
 
       $Sender->SetData('Answers', $Answers);
-   }
 
-   public function discussionController_beforeWriteComment_handler($sender, &$args) {
       if (C('QnA.AcceptedAnswers.Filter', TRUE)) {
-         if (val('QnA', val(('Comment'), $args)) == 'Accepted' && val('RenderComment', $args)) {
-            $args['RenderComment'] = false;
+         if (isset($Sender->Data['Comments'])) {
+            $Comments = $Sender->Data['Comments']->Result();
+            $Comments = array_filter($Comments, function ($Row) {
+               return strcasecmp(GetValue('QnA', $Row), 'accepted');
+            });
+            $Sender->Data['Comments'] = new Gdn_DataSet(array_values($Comments));
          }
       }
    }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -414,16 +414,12 @@ class QnAPlugin extends Gdn_Plugin {
       }
 
       $Sender->SetData('Answers', $Answers);
+   }
 
-      // Remove the accepted answers from the comments.
-      // Allow this to be skipped via config.
+   public function discussionController_beforeWriteComment_handler($sender, &$args) {
       if (C('QnA.AcceptedAnswers.Filter', TRUE)) {
-         if (isset($Sender->Data['Comments'])) {
-            $Comments = $Sender->Data['Comments']->Result();
-            $Comments = array_filter($Comments, function($Row) {
-               return strcasecmp(GetValue('QnA', $Row), 'accepted');
-            });
-            $Sender->Data['Comments'] = new Gdn_DataSet(array_values($Comments));
+         if (val('QnA', val(('Comment'), $args)) == 'Accepted' && val('RenderComment', $args)) {
+            $args['RenderComment'] = false;
          }
       }
    }

--- a/plugins/QnA/views/post.php
+++ b/plugins/QnA/views/post.php
@@ -9,12 +9,12 @@ if (C('Vanilla.Categories.Use') && is_object($this->Category))
    <?php
 		if ($this->DeliveryType() == DELIVERY_TYPE_ALL)
 			echo Wrap($this->Data('Title'), 'h1', array('class' => 'H'));
-	
+
       echo '<div class="FormWrapper">';
       echo $this->Form->Open();
       echo $this->Form->Errors();
       $this->FireEvent('BeforeFormInputs');
-      
+
       if ($this->ShowCategorySelector === TRUE) {
 			echo '<div class="P">';
 				echo '<div class="Category">';
@@ -23,19 +23,19 @@ if (C('Vanilla.Categories.Use') && is_object($this->Category))
 				echo '</div>';
 			echo '</div>';
       }
-      
+
       echo '<div class="P">';
 			echo $this->Form->Label('Question', 'Name');
 			echo Wrap($this->Form->TextBox('Name', array('maxlength' => 100, 'class' => 'InputBox BigInput')), 'div', array('class' => 'TextBoxWrapper'));
 		echo '</div>';
-		
+
 		$this->FireEvent('BeforeBodyInput');
 		echo '<div class="P">';
-         echo $this->Form->BodyBox('Body', array('Table' => 'Discussion'));
+         echo $this->Form->BodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true));
 		echo '</div>';
-		
+
 		$this->FireEvent('AfterDiscussionFormOptions');
-		
+
       echo '<div class="Buttons">';
       $this->FireEvent('BeforeFormButtons');
       echo $this->Form->Button((property_exists($this, 'Discussion')) ? 'Save' : 'Ask Question', array('class' => 'Button Primary DiscussionButton'));


### PR DESCRIPTION
Don't remove accepted comments from the Comments array. 
Instead, don't render accepted comments.
Fixes bug where attached files are not rendering for 'Answers'.
Also allow file uploads in New Question form.
Relies on event in https://github.com/vanilla/vanilla/pull/2883