### PR TITLE
Adds linkifying of text links and translation of markup quotes to IPB Formatter

### DIFF
--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -20,7 +20,7 @@ Gdn::FactoryInstall('IPBFormatter', 'IPBFormatterPlugin', __FILE__, Gdn::Factory
 
 class IPBFormatterPlugin extends Gdn_Plugin {
    /// Methods ///
-   
+
    public function Format($String) {
       $String = str_replace(array('&quot;', '&#39;', '&#58;', 'Â'), array('"', "'", ':', ''), $String);
       $String = str_replace('<#EMO_DIR#>', 'default', $String);
@@ -54,6 +54,9 @@ class IPBFormatterPlugin extends Gdn_Plugin {
          $Result .= $this->NBBC()->Parse($String);
       }
 
+      // Linkify URLs in content
+      $Result = Gdn_Format::links($Result);
+
       // Make sure to clean filter the html in the end.
       $Config = array(
        'anti_link_spam' => array('`.`', ''),
@@ -85,12 +88,12 @@ class IPBFormatterPlugin extends Gdn_Plugin {
    public function NBBC() {
       if ($this->_NBBC === NULL) {
          require_once PATH_PLUGINS.'/HtmLawed/htmLawed/htmLawed.php';
-         
+
          $Plugin = new NBBCPlugin('BBCodeRelaxed');
          $this->_NBBC = $Plugin->NBBC();
          $this->_NBBC->ignore_newlines = TRUE;
          $this->_NBBC->enable_smileys = FALSE;
-         
+
          $this->_NBBC->AddRule('attachment', array(
             'mode' => BBCODE_MODE_CALLBACK,
             'method' => array($this, "DoAttachment"),
@@ -104,7 +107,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
       }
       return $this->_NBBC;
    }
-   
+
    protected $_Media = NULL;
    public function Media() {
       if ($this->_Media === NULL) {
@@ -114,7 +117,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
          } catch (Exception $Ex) {
             $M = array();
          }
-         
+
          $Media = array();
          foreach ($M as $Key => $Data) {
             foreach ($Data as $Row) {
@@ -125,7 +128,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
       }
       return $this->_Media;
    }
-   
+
    public function DoAttachment($bbcode, $action, $name, $default, $params, $content) {
       $Medias = $this->Media();
       $Parts = explode(':', $default);
@@ -133,14 +136,14 @@ class IPBFormatterPlugin extends Gdn_Plugin {
       if (isset($Medias[$MediaID])) {
          $Media = $Medias[$MediaID];
 //         decho($Media, 'Media');
-         
+
          $Src = htmlspecialchars(Gdn_Upload::Url(GetValue('Path', $Media)));
          $Name = htmlspecialchars(GetValue('Name', $Media));
          return <<<EOT
 <div class="Attachment"><img src="$Src" alt="$Name" /></div>
 EOT;
       }
-      
+
       return '';
    }
 }

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -77,6 +77,12 @@ class IPBFormatterPlugin extends Gdn_Plugin {
       // Linkify URLs in content
       $Result = Gdn_Format::links($Result);
 
+      // Parsing mentions
+      $Result = Gdn_Format::mentions($Result);
+
+      // Handling emoji
+      $Result = Emoji::instance()->translateToHtml($Result);
+
       // Make sure to clean filter the html in the end.
       $Config = array(
        'anti_link_spam' => array('`.`', ''),

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -41,6 +41,26 @@ class IPBFormatterPlugin extends Gdn_Plugin {
          $String
       );
 
+      /**
+       * IPB formats some quotes as HTML.  They're converted here for the sake of uniformity in presentation.
+       * Attribute order seems to be standard.  Spacing between the opening of the tag and the first attribute is variable.
+       */
+      $String = preg_replace_callback(
+         '#<blockquote\s+class="ipsBlockquote" data-author="([^"]+)" data-cid="(\d+)" data-time="(\d+)">(.*?)</blockquote>#is',
+         function ($BlockQuotes) {
+            $Author = $BlockQuotes[1];
+            $Cid = $BlockQuotes[2];
+            $Time = $BlockQuotes[3];
+            $QuoteContent = $BlockQuotes[4];
+
+            // $Time will over as a timestamp. Convert it to a date string.
+            $Date = date('F j Y, g:i A', $Time);
+
+            return "[quote name=\"{$Author}\" url=\"{$Cid}\" date=\"{$Date}\"]{$QuoteContent}[/quote]";
+         },
+         $String
+      );
+
       // If there is a really long string, it could cause a stack overflow in the bbcode parser.
       // Not much we can do except try and chop the data down a touch.
 


### PR DESCRIPTION
Previously, IPB Formatter would not transform URLs into links.  This PR applies Gdn_Format::links to IPBFormatterPlugin::format to fix that.

IPB has a mix of markup and BBCode quote tags.  This PR also translates the markup (blockquote, specifically) quotes into BBCode-style quotes.