### PR TITLE
Add permission check to DiscussionOptions

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -762,7 +762,7 @@ class QnAPlugin extends Gdn_Plugin {
       if (!$Discussion)
          throw NotFoundException('Discussion');
 
-
+      $Sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $Discussion));
 
       // Both '' and 'Discussion' denote a discussion type of discussion.
       if (!GetValue('Type', $Discussion))


### PR DESCRIPTION
Currently everyone can change a discussion to a question and vice versa