### PR TITLE
IPB Formatter: Hook into Advanced Editor to add format support

### DIFF
--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -178,8 +178,8 @@ EOT;
     *
     * @param $sender Instance of EditorPlugin firing the event
     */
-   public function editorPlugin_getFormats_handler($sender) {
-      $formats =& $sender->EventArguments['formats'];
+   public function editorPlugin_getFormats_handler($sender, &$args) {
+      $formats =& $args['formats'];
 
       $formats[] = 'IPB';
    }
@@ -190,8 +190,8 @@ EOT;
     *
     * @param $sender Instance of EditorPlugin firing the event
     */
-   public function editorPlugin_getJSDefinitions_handler($sender) {
-      $definitions =& $sender->EventArguments['definitions'];
+   public function editorPlugin_getJSDefinitions_handler($sender, &$args) {
+      $definitions =& $args['definitions'];
 
       /**
        * There isn't any currently known help text for the IPB format, so it's an empty string.

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -172,4 +172,31 @@ EOT;
 
       return '';
    }
+
+   /**
+    * Hooks into the GetFormats event from the Advanced Editor plug-in and adds the IPB format.
+    *
+    * @param $sender Instance of EditorPlugin firing the event
+    */
+   public function editorPlugin_getFormats_handler($sender) {
+      $formats =& $sender->EventArguments['formats'];
+
+      $formats[] = 'IPB';
+   }
+
+   /**
+    * Hooks into the GetJSDefinitions event from the Advanced Editor plug-in and adds definitions related to
+    * the IPB format.
+    *
+    * @param $sender Instance of EditorPlugin firing the event
+    */
+   public function editorPlugin_getJSDefinitions_handler($sender) {
+      $definitions =& $sender->EventArguments['definitions'];
+
+      /**
+       * There isn't any currently known help text for the IPB format, so it's an empty string.
+       * If that changes, it can be added in the locale or changed here.
+       */
+      $definitions['ipbHelpText'] = t('editor.ipbHelpText', '');
+   }
 }

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -46,12 +46,12 @@ class IPBFormatterPlugin extends Gdn_Plugin {
        * Attribute order seems to be standard.  Spacing between the opening of the tag and the first attribute is variable.
        */
       $String = preg_replace_callback(
-         '#<blockquote\s+class="ipsBlockquote" data-author="([^"]+)" data-cid="(\d+)" data-time="(\d+)">(.*?)</blockquote>#is',
+         '#<blockquote\s+(class="ipsBlockquote" )?data-author="([^"]+)" data-cid="(\d+)" data-time="(\d+)">(.*?)</blockquote>#is',
          function ($BlockQuotes) {
-            $Author = $BlockQuotes[1];
-            $Cid = $BlockQuotes[2];
-            $Time = $BlockQuotes[3];
-            $QuoteContent = $BlockQuotes[4];
+            $Author = $BlockQuotes[2];
+            $Cid = $BlockQuotes[3];
+            $Time = $BlockQuotes[4];
+            $QuoteContent = $BlockQuotes[5];
 
             // $Time will over as a timestamp. Convert it to a date string.
             $Date = date('F j Y, g:i A', $Time);


### PR DESCRIPTION
Adds handlers for new Advanced Editor events that allow dynamic addition of support for new format slugs.

Relies on https://github.com/vanilla/vanilla/pull/2887