### PR TITLE
Render attachment as anchor in IPBFormatter if ImageWidth not present

### DIFF
--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -163,14 +163,14 @@ class IPBFormatterPlugin extends Gdn_Plugin {
          $Media = $Medias[$MediaID];
 //         decho($Media, 'Media');
 
-         $Src = htmlspecialchars(Gdn_Upload::Url(GetValue('Path', $Media)));
+         $Src = htmlspecialchars(Gdn_Upload::Url(val('Path', $Media)));
          $Name = htmlspecialchars(GetValue('Name', $Media));
          if (GetValue('ImageWidth', $Media)) {
             return <<<EOT
 <div class="Attachment Image"><img src="$Src" alt="$Name" /></div>
 EOT;
          } else {
-            return Anchor($Name, $Src, 'Attachment File');
+            return anchor($Name, $Src, 'Attachment File');
          }
       }
 

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -165,9 +165,13 @@ class IPBFormatterPlugin extends Gdn_Plugin {
 
          $Src = htmlspecialchars(Gdn_Upload::Url(GetValue('Path', $Media)));
          $Name = htmlspecialchars(GetValue('Name', $Media));
-         return <<<EOT
-<div class="Attachment"><img src="$Src" alt="$Name" /></div>
+         if (GetValue('ImageWidth', $Media)) {
+            return <<<EOT
+<div class="Attachment Image"><img src="$Src" alt="$Name" /></div>
 EOT;
+         } else {
+            return Anchor($Name, $Src, 'Attachment File');
+         }
       }
 
       return '';

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -164,8 +164,8 @@ class IPBFormatterPlugin extends Gdn_Plugin {
 //         decho($Media, 'Media');
 
          $Src = htmlspecialchars(Gdn_Upload::Url(val('Path', $Media)));
-         $Name = htmlspecialchars(GetValue('Name', $Media));
-         if (GetValue('ImageWidth', $Media)) {
+         $Name = htmlspecialchars(val('Name', $Media));
+         if (val('ImageWidth', $Media)) {
             return <<<EOT
 <div class="Attachment Image"><img src="$Src" alt="$Name" /></div>
 EOT;


### PR DESCRIPTION
Attachments were previously always displayed as images when using IPBFormatter.  This update takes the updated logic from NBBC and applies it to DoAttachment in IPBFormatter to only display as an image when ImageWidth is present as an attribute for the Media record.