### PR TITLE
Hide some unsupported BBCode tags with NBBC

### DIFF
--- a/plugins/NBBC/class.nbbc.plugin.php
+++ b/plugins/NBBC/class.nbbc.plugin.php
@@ -359,6 +359,12 @@ EOT;
              'plain_link' => Array('_default', '_content')
          ));
 
+          // Prevent unsupported tags from displaying
+          $BBCode->AddRule('size', array());
+          $BBCode->AddRule('table', array());
+          $BBCode->AddRule('tr', array());
+          $BBCode->AddRule('td', array());
+
          $this->EventArguments['BBCode'] = $BBCode;
          $this->FireEvent('AfterNBBCSetup');
          $this->_NBBC = $BBCode;


### PR DESCRIPTION
Prevents size, table, tr and td BBCode tags from displaying when using NBBC.  The content of the tags is not affected.