### PR TITLE
Enhance jsconnect’s add/edit functionality

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -20,10 +20,14 @@ $PluginInfo['jsconnect'] = array(
 );
 
 class JsConnectPlugin extends Gdn_Plugin {
-    /// PROPERTIES ///
 
-    /// METHODS ///
-
+    /**
+     * Add an element to the controls collection. Used to render settings forms.
+     *
+     * @param string $key
+     * @param array $item
+     * @throws Exception
+     */
     public function addControl($key, $item) {
         // Make sure this isn't called before it's ready.
         if (!isset(Gdn::controller()->Data['_Controls'])) {

--- a/plugins/jsconnect/views/settings_addedit.php
+++ b/plugins/jsconnect/views/settings_addedit.php
@@ -11,88 +11,8 @@
     <h1><?php echo $this->Data('Title'); ?></h1>
 <?php
 echo $this->Form->Open(), $this->Form->Errors();
+echo $this->Form->simple($this->data('_Controls'));
 ?>
-    <ul>
-        <li>
-            <?php
-            echo $this->Form->Label('AuthenticationKey', 'AuthenticationKey'),
-                '<div class="Info">'.T('The client ID uniqely identifies the site.', 'The client ID uniqely identifies the site. You can generate a new ID with the button at the bottom of this page.').'</div>',
-            $this->Form->TextBox('AuthenticationKey');
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->Label('AssociationSecret', 'AssociationSecret'),
-                '<div class="Info">'.T('The secret secures the sign in process.', 'The secret secures the sign in process. Do <b>NOT</b> give the secret out to anyone.').'</div>',
-            $this->Form->TextBox('AssociationSecret');
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->Label('Site Name', 'Name'),
-                '<div class="Info">'.T('Enter a short name for the site.', 'Enter a short name for the site. This is displayed on the signin buttons.').'</div>',
-            $this->Form->TextBox('Name');
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->Label('Authenticate Url', 'AuthenticateUrl'),
-                '<div class="Info">'.T('The location of the jsonp formatted authentication data.').'</div>',
-            $this->Form->TextBox('AuthenticateUrl', array('class' => 'InputBox BigInput'));
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->Label('Sign In Url', 'SignInUrl'),
-                '<div class="Info">'.
-                T('The url that users use to sign in.').' '.
-                T('Use {target} to specify a redirect.').
-                '</div>',
-            $this->Form->TextBox('SignInUrl', array('class' => 'InputBox BigInput'));
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->Label('Register Url', 'RegisterUrl'),
-                '<div class="Info">'.T('The url that users use to register for a new account.').'</div>',
-            $this->Form->TextBox('RegisterUrl', array('class' => 'InputBox BigInput'));
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->Label('Sign Out Url', 'SignOutUrl'),
-                '<div class="Info">'.T('The url that users use to sign out of your site.').'</div>',
-            $this->Form->TextBox('SignOutUrl', array('class' => 'InputBox BigInput'));
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->CheckBox('Trusted', 'This is trusted connection and can sync roles & permissions.');
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->CheckBox('IsDefault', 'Make this connection your default signin method.');
-            ?>
-        </li>
-        <li>
-            <h2>Advanced</h2>
-        </li>
-        <li>
-            <?php
-            $HashAlgos = hash_algos();
-            $HashAlgos = ArrayCombine($HashAlgos, $HashAlgos);
-            echo $this->Form->Label('Hash Algorithm', 'HashType'),
-                '<div class="Info">'.T("Choose md5 if you're not sure what to choose.", "You can select a custom hash algorithm to sign your requests. The hash algorithm must also be used in your client library. Choose md5 if you're not sure what to choose.").'</div>',
-            $this->Form->DropDown('HashType', $HashAlgos, array('Default' => 'md5'));
-            ?>
-        </li>
-        <li>
-            <?php
-            echo $this->Form->CheckBox('TestMode', 'This connection is in test-mode.');
-            ?>
-        </li>
-    </ul>
 
 <?php
 echo '<div class="Buttons">';


### PR DESCRIPTION
* Build up the add/edit form programmatically with Gdn_Form->simple().
* Throw an event so that plugins can add controls to the form.
* Add JsConnectPlugin->addControl() so that plugins can more easily add controls.
* Standardize the saving of jsConnect connections to use proper form saving.