### PR TITLE
Whispers: Remove livequery

### DIFF
--- a/plugins/Whispers/js/whispers.js
+++ b/plugins/Whispers/js/whispers.js
@@ -15,7 +15,7 @@ jQuery(document).ready(function($) {
 
 
 
-   $('.MultiComplete').livequery(function() {
+   $('.MultiComplete').each(function() {
       $(this).autocomplete(
          gdn.url('/dashboard/user/autocomplete/'),
          {


### PR DESCRIPTION
The multicomplete on the Whispers form doesn't need livequery as it is not dynamically created or updated.