### PR TITLE
MeAction: Remove all assets

### DIFF
--- a/plugins/MeAction/class.meaction.plugin.php
+++ b/plugins/MeAction/class.meaction.plugin.php
@@ -1,40 +1,29 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php
 
 $PluginInfo['MeAction'] = array(
-   'Description' => 'Allows IRC-style /me actions in the middle of comments as long as they appear at start of a new line.',
-   'Version' => '1.0',
-   'RequiredApplications' => array('Vanilla' => '2.1'),
-   'MobileFriendly' => TRUE,
-   'Author' => "Lincoln Russell",
-   'AuthorEmail' => 'lincoln@vanillaforums.com',
-   'AuthorUrl' => 'http://lincolnwebs.com'
+    'Description' => 'Allows IRC-style /me actions in the middle of comments as long as they appear at start of a new line.',
+    'Version' => '1.0',
+    'RequiredApplications' => array('Vanilla' => '2.1'),
+    'MobileFriendly' => true,
+    'Author' => 'Lincoln Russell',
+    'AuthorEmail' => 'lincoln@vanillaforums.com',
+    'AuthorUrl' => 'http://lincolnwebs.com'
 );
 
 class MeActionPlugin extends Gdn_Plugin {
-   public function DiscussionController_Render_Before($Sender) {
-		$this->AddMeAction($Sender);
-	}
-	
-	public function MessagesController_Render_Before($Sender) {
-		$this->AddMeAction($Sender);
-	}
-	
-	private function AddMeAction($Sender) {
-		$Sender->AddJsFile('meaction.js', 'plugins/MeAction');
-		$Sender->AddCssFile('meaction.css', 'plugins/MeAction');
-	}
 
-	/**
-	 * Enable the formatter in Gdn_Format::Mentions.
-	 */
-   public function Setup() {
-      SaveToConfig('Garden.Format.MeActions', TRUE);
-   }
-   
-   /**
-	 * Disable the formatter in Gdn_Format::Mentions.
-	 */
-   public function OnDisable() {
-      SaveToConfig('Garden.Format.MeActions', FALSE);
-   }
+    /**
+     * Enable the formatter in Gdn_Format::Mentions.
+     */
+    public function setup() {
+        saveToConfig('Garden.Format.MeActions', true);
+    }
+
+    /**
+     * Disable the formatter in Gdn_Format::Mentions.
+     */
+    public function onDisable() {
+        saveToConfig('Garden.Format.MeActions', false);
+    }
+
 }

--- a/plugins/MeAction/design/meaction.css
+++ b/plugins/MeAction/design/meaction.css
@@ -1,6 +1,0 @@
-.Message .AuthorAction {
-   font-weight: bold;
-}
-.Message .AuthorAction:before {
-   content: '* ';
-}

--- a/plugins/MeAction/js/meaction.js
+++ b/plugins/MeAction/js/meaction.js
@@ -1,8 +1,0 @@
-jQuery(document).ready(function($) {
-   $('.Comment').livequery(function() {
-      $.each($('.MeActionName'), function(i, NameTag) {
-         var MeNameText = $(NameTag).closest('.Comment, .Discussion').find('.Author a').text();
-         $(NameTag).contents().replaceWith(MeNameText);
-      });
-   });
-});


### PR DESCRIPTION
- This plugin works just fine without the JS and CSS file. Apparently
this was rolled into the core formatter at some point.
- Updated the remaining code to match new coding standards.