### PR TITLE
jsConnect: Remove livequery call

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -9,7 +9,7 @@
 $PluginInfo['jsconnect'] = array(
     'Name' => 'Vanilla jsConnect',
     'Description' => 'Enables custom single sign-on solutions. They can be same-domain or cross-domain. See the <a href="http://vanillaforums.org/docs/jsconnect">documentation</a> for details.',
-    'Version' => '1.4.6',
+    'Version' => '1.4.7',
     'RequiredApplications' => array('Vanilla' => '2.0.18'),
     'MobileFriendly' => true,
     'Author' => 'Todd Burry',

--- a/plugins/jsconnect/js/jsconnect.js
+++ b/plugins/jsconnect/js/jsconnect.js
@@ -133,6 +133,6 @@ $.fn.jsconnect = function(options) {
    }
 };
 
-$('.JsConnect-Container').livequery(function() { $(this).jsconnect(); });
+$('.JsConnect-Container').jsconnect();
 
 });


### PR DESCRIPTION
Remove the livequery call and just initialize the `.JsConnect-Container` on document.ready.

I couldn't find a place where the `.JsConnect-Container` div could be added dynamically (see `JsConnectPlugin::connectButton()`).
This call has been in the plugin since the beginning, so it was most likely just defensive programming.