### PR TITLE
Update links to help docs in jsconnect.

### DIFF
--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -3,8 +3,8 @@
     <?php
     echo '<h2>', T('Need More Help?'), '</h2>';
     echo '<ul>';
-    echo '<li>', Anchor(T('jsConnect Documentation'), 'http://vanillaforums.org/docs/jsconnect'), '</li>';
-    echo '<li>', Anchor(T('jsConnect Client Libraries'), 'http://vanillaforums.org/docs/jsconnect#libraries'), '</li>';
+    echo '<li>', Anchor(T('jsConnect Documentation'), 'http://docs.vanillaforums.com/features/sso/jsconnect/'), '</li>';
+    echo '<li>', Anchor(T('jsConnect Client Libraries'), 'http://docs.vanillaforums.com/features/sso/jsconnect/overview/#your-endpoint'), '</li>';
     echo '</ul>';
     ?>
 </div>

--- a/plugins/jsconnect/views/settings_addedit.php
+++ b/plugins/jsconnect/views/settings_addedit.php
@@ -3,8 +3,8 @@
         <?php
         echo '<h2>', T('Need More Help?'), '</h2>';
         echo '<ul>';
-        echo '<li>', Anchor(T('jsConnect Documentation'), 'http://vanillaforums.org/docs/jsconnect'), '</li>';
-        echo '<li>', Anchor(T('jsConnect Client Libraries'), 'http://vanillaforums.org/docs/jsconnect#libraries'), '</li>';
+        echo '<li>', Anchor(T('jsConnect Documentation'), 'http://docs.vanillaforums.com/features/sso/jsconnect/'), '</li>';
+        echo '<li>', Anchor(T('jsConnect Client Libraries'), 'http://docs.vanillaforums.com/features/sso/jsconnect/overview/#your-endpoint'), '</li>';
         echo '</ul>';
         ?>
     </div>


### PR DESCRIPTION
The links in the dashboard settings page for JsConnect were going to outdated pages in the docs that redirected you to more generic help section.