### PR TITLE
Fix the way jsConnect handles missing values

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -9,7 +9,7 @@
 $PluginInfo['jsconnect'] = array(
     'Name' => 'Vanilla jsConnect',
     'Description' => 'Enables custom single sign-on solutions. They can be same-domain or cross-domain. See the <a href="http://vanillaforums.org/docs/jsconnect">documentation</a> for details.',
-    'Version' => '1.5.2',
+    'Version' => '1.5.3',
     'RequiredApplications' => array('Vanilla' => '2.0.18'),
     'MobileFriendly' => true,
     'Author' => 'Todd Burry',
@@ -351,20 +351,18 @@ class JsConnectPlugin extends Gdn_Plugin {
 
 
         // Map all of the standard jsConnect data.
-        $Map = array('uniqueid' => 'UniqueID', 'name' => 'Name', 'email' => 'Email', 'photourl' => 'Photo', 'fullname' => 'FullName');
+        $Map = array('uniqueid' => 'UniqueID', 'name' => 'Name', 'email' => 'Email', 'photourl' => 'Photo', 'fullname' => 'FullName', 'roles' => 'Roles');
         foreach ($Map as $Key => $Value) {
-            $Form->SetFormValue($Value, GetValue($Key, $JsData, ''));
-        }
-
-        if (isset($JsData['roles'])) {
-            $Form->SetFormValue('Roles', $JsData['roles']);
+            if (array_key_exists($Key, $JsData)) {
+                $Form->SetFormValue($Value, $JsData[$Key]);
+            }
         }
 
         // Now add any extended information that jsConnect might have sent.
         $ExtData = array_diff_key($JsData, $Map);
 
         if (class_exists('SimpleAPIPlugin')) {
-            SimpleAPIPlugin::TranslatePost($ExtData, FALSE);
+            SimpleAPIPlugin::translatePost($ExtData, FALSE);
         }
 
         Gdn::UserModel()->DefineSchema();

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -8,7 +8,7 @@
     echo '</ul>';
     ?>
 </div>
-<h1><?php echo T('JS Connect Settings'); ?></h1>
+<h1><?php echo sprintf(t('%s Settings'), 'jsConnect'); ?></h1>
 <div class="Info">
     <?php echo T('You can connect to multiple sites that support jsConnect.'); ?>
 </div>


### PR DESCRIPTION
Previously, jsConnect would take some of the standard user fields and set them to an empty string if not provided. This would have the side-effect of generating field required errors on subsequent signins which isn’t correct. What should happen is a user should be prompted for the missing field on first sign in and then have subsequent signins work.

To see the effect of this bug:

1. Create a fake jsConnect source with a username, but no email address.
2. SSO with that connection.
3. Change the username in the database or wherever.
4. Sign out and then SSO again.
5. Before the username will not be updated because there will be a hidden error about a missing email address. After this PR the username should update.

As with all SSO PRs this could have regression bugs, but I’m hoping it only affects the small number of SSO scenarios where customers don’t provide one of email or username.