### PR TITLE
Show spoiler label translations

### DIFF
--- a/plugins/Spoilers/class.spoilers.plugin.php
+++ b/plugins/Spoilers/class.spoilers.plugin.php
@@ -31,6 +31,11 @@ class SpoilersPlugin extends Gdn_Plugin {
       $this->RenderSpoilers = C('Plugins.Spoilers.RenderSpoilers',TRUE);
    }
 
+   public function base_render_before($sender) {
+      $sender->addDefinition('show', t('show'));
+      $sender->addDefinition('hide', t('hide'));
+   }
+
    public function AssetModel_StyleCss_Handler($Sender) {
       $Sender->AddCssFile('spoilers.css', 'plugins/Spoilers');
    }

--- a/plugins/Spoilers/class.spoilers.plugin.php
+++ b/plugins/Spoilers/class.spoilers.plugin.php
@@ -12,7 +12,7 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 $PluginInfo['Spoilers'] = array(
    'Name' => 'Spoilers',
    'Description' => "Users may prevent accidental spoiler by wrapping text in [spoiler] tags. This requires the text to be clicked in order to read it.",
-   'Version' => '1.2',
+   'Version' => '1.3',
    'MobileFriendly' => TRUE,
    'RequiredApplications' => FALSE,
    'RequiredTheme' => FALSE,

--- a/plugins/Spoilers/js/spoilers.js
+++ b/plugins/Spoilers/js/spoilers.js
@@ -1,7 +1,3 @@
-/**
- *
- */
-
 var SpoilersPlugin = {
    FindAndReplace: function() {
       jQuery('div.UserSpoiler').each(function(i, el) {
@@ -15,11 +11,6 @@ var SpoilersPlugin = {
       },this);
    },
 
-   /**
-    * ReplaceSpoiler: Add the spoiler label to the comment text.
-    * Add Gdn::Controller()->addDefinition('show', 'display') in the class.themehooks.php file of your theme
-    * This plugin needs to be reworked to avoid needing to do this.
-    */
    ReplaceSpoiler: function(Spoiler) {
       // Don't re-event spoilers that are already 'on'
       if (Spoiler.SpoilerFunctioning) return;

--- a/plugins/Spoilers/js/spoilers.js
+++ b/plugins/Spoilers/js/spoilers.js
@@ -1,27 +1,36 @@
+/**
+ *
+ */
+
 var SpoilersPlugin = {
    FindAndReplace: function() {
       jQuery('div.UserSpoiler').each(function(i, el) {
          SpoilersPlugin.ReplaceSpoiler(el);
       });
    },
-   
+
    ReplaceComment: function(Comment) {
       jQuery(Comment).find('div.UserSpoiler').each(function(i,el){
          SpoilersPlugin.ReplaceSpoiler(el);
       },this);
    },
-   
+
+   /**
+    * ReplaceSpoiler: Add the spoiler label to the comment text.
+    * Add Gdn::Controller()->addDefinition('show', 'display') in the class.themehooks.php file of your theme
+    * This plugin needs to be reworked to avoid needing to do this.
+    */
    ReplaceSpoiler: function(Spoiler) {
       // Don't re-event spoilers that are already 'on'
       if (Spoiler.SpoilerFunctioning) return;
       Spoiler.SpoilerFunctioning = true;
-      
+
       // Extend object with jQuery
       Spoiler = jQuery(Spoiler);
       var SpoilerTitle = Spoiler.find('div.SpoilerTitle').first();
       var SpoilerButton = document.createElement('input');
       SpoilerButton.type = 'button';
-      SpoilerButton.value = 'show';
+      SpoilerButton.value = gdn.definition('show', 'show');
       SpoilerButton.className = 'SpoilerToggle';
       SpoilerTitle.append(SpoilerButton);
       Spoiler.on('click', 'input.SpoilerToggle', function(event) {
@@ -29,17 +38,17 @@ var SpoilersPlugin = {
          SpoilersPlugin.ToggleSpoiler(jQuery(event.delegateTarget), jQuery(event.target));
       });
    },
-   
+
    ToggleSpoiler: function(Spoiler, SpoilerButton) {
       var ThisSpoilerText = Spoiler.find('div.SpoilerText').first();
       var ThisSpoilerStatus = ThisSpoilerText.css('display');
       var NewSpoilerStatus = (ThisSpoilerStatus == 'none') ? 'block' : 'none';
       ThisSpoilerText.css('display',NewSpoilerStatus);
-      
+
       if (NewSpoilerStatus == 'none')
-         SpoilerButton.val('show');
+         SpoilerButton.val(gdn.definition('show', 'show'));
       else
-         SpoilerButton.val('hide');
+         SpoilerButton.val(gdn.definition('hide', 'hide'));
    }
 };
 


### PR DESCRIPTION
Previously the Hide and Show labels for spoilers didn't translate when you were in a different locale.  Now you can set translations for them by setting them in the themehooks file for the theme.