### PR TITLE
Stop QnA accepted answer from hijacking #latest

### DIFF
--- a/plugins/QnA/views/answers.php
+++ b/plugins/QnA/views/answers.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-<div class="DataBox DataBox-AcceptedAnswers"><span id="latest"></span>
+<div class="DataBox DataBox-AcceptedAnswers"><span id="accepted"></span>
    <h2 class="CommentHeading"><?php echo Plural(count($Sender->Data('Answers')), 'Best Answer', 'Best Answers'); ?></h2>
    <ul class="MessageList DataList AcceptedAnswers">
       <?php


### PR DESCRIPTION
QnA creates a span element with an ID of "latest" just before the accepted comment markup.  This causes a conflict with Vanilla's "latest" element, generally shown farther down the page.  A user visiting a #latest URL for a QnA thread with an accepted answer would always be pulled to the accepted answer comment, instead of the latest comment in the thread.

This fix renames the ID of the QnA pre-accepted-answer element from latest to accepted.