### PR TITLE
Don't force notifications for QnA responses

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -367,14 +367,12 @@ class QnAPlugin extends Gdn_Plugin {
          'RecordType' => 'Comment',
          'RecordID' => $CommentID,
          'Route' => "/discussion/comment/$CommentID#Comment_$CommentID",
-         'Emailed' => ActivityModel::SENT_PENDING,
-         'Notified' => ActivityModel::SENT_PENDING,
          'Data' => array(
             'Name' => GetValue('Name', $Discussion)
          )
       );
 
-      $ActivityModel->Queue($Activity);
+      $ActivityModel->Queue($Activity, 'DiscussionComment');
    }
 
    /**


### PR DESCRIPTION
The QnA plug-in was sending notifications to users whenever their questions had any kind of response, regardless of their notification preferences.  This update attempts to apply the `DiscussionComment` preferences to any attempted notifications.