### PR TITLE
Update CountUnreadConversations after ignore

### DIFF
--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -578,6 +578,8 @@ class IgnorePlugin extends Gdn_Plugin {
          'UserID'          => $ForUserID,
          'ConversationID'  => $Conversations
       ));
+      $conversationModel = new ConversationModel();
+      $conversationModel->countUnread($ForUserID, true);
    }
 
    protected function RemoveIgnore($ForUserID, $IgnoreUserID) {


### PR DESCRIPTION
The Ignore plug-in was not updating `CountUnreadConversations` after ignoring a user.  This was causing incorrect inbox counts.

This update adds a call to `ConversationModel::countUnread` at the end of the ignore routine to update `CountUnreadConversations` for the current user.