### PR TITLE
Pockets: enable repeat on discussion table view

### DIFF
--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -59,7 +59,10 @@ class PocketsPlugin extends Gdn_Plugin {
 
         // Switch our HTML wrapper when we're in a table view.
         if (c('Vanilla.Discussions.Layout') == 'table') {
-            $this->Locations['BetweenDiscussions']['Wrap'] = ['<tr><td colspan="0">', '</td></tr>'];
+            // Admin checks add a column.
+            $useAdminChecks = c('Vanilla.AdminCheckboxes.Use') && Gdn::session()->checkPermission('Garden.Moderation.Manage');
+            $colspan = c('Plugins.Pockets.Colspan', ($useAdminChecks) ? 6 : 5);
+            $this->Locations['BetweenDiscussions']['Wrap'] = ['<tr><td colspan="'.$colspan.'">', '</td></tr>'];
         }
     }
 

--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -52,6 +52,18 @@ class PocketsPlugin extends Gdn_Plugin {
     public $TestMode = null;
 
     /**
+     * PocketsPlugin constructor.
+     */
+    public function __construct() {
+        parent::__construct();
+
+        // Switch our HTML wrapper when we're in a table view.
+        if (c('Vanilla.Discussions.Layout') == 'table') {
+            $this->Locations['BetweenDiscussions']['Wrap'] = ['<tr><td colspan="0">', '</td></tr>'];
+        }
+    }
+
+    /**
      * Add test mode to every page.
      *
      * @param $Sender


### PR DESCRIPTION
Currently, using the "Repeat Every" or "Given Indexes" option with Location "Between Discussions" does not work when `Vanilla.Layout.Discussions` is set to `table`. This is because the wrapper is set to `<li>` for those elements by default. This pull request makes Pockets aware of `Vanilla.Layout.Discussions` and uses a full-width table row instead.