### PR TITLE
Add optional points feature to Q&A

### DIFF
--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -227,9 +227,11 @@ class CivilTonguePlugin extends Gdn_Plugin {
      */
     public function discussionsController_render_before($Sender, $Args) {
         $Discussions = val('Discussions', $Sender->Data);
-        foreach ($Discussions as &$Discussion) {
-            $Discussion->Name = $this->replace($Discussion->Name);
-            $Discussion->Body = $this->replace($Discussion->Body);
+        if (is_array($Discussions) || $Discussions instanceof \Traversable) {
+            foreach ($Discussions as &$Discussion) {
+                $Discussion->Name = $this->replace($Discussion->Name);
+                $Discussion->Body = $this->replace($Discussion->Body);
+            }
         }
     }
 

--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -364,7 +364,7 @@ class IgnorePlugin extends Gdn_Plugin {
       if (!$Recipients->NumRows()) return;
 
       $Recipients = $Recipients->ResultArray();
-      $Recipients = ConsolidateArrayValuesByKey($Recipients, 'UserID');
+      $Recipients = array_column($Recipients, 'UserID');
 
       $UserID = Gdn::Session()->UserID;
       foreach ($Recipients as $RecipientID => $Recipient) {
@@ -684,7 +684,7 @@ class IgnorePlugin extends Gdn_Plugin {
          ->Where('UserID', $IgnoreUserID)
          ->Where('Deleted', 0)
          ->Get()->ResultArray();
-      $IgnoreConversationIDs = ConsolidateArrayValuesByKey($IgnoreConversations, 'ConversationID','ConversationID');
+      $IgnoreConversationIDs = array_column($IgnoreConversations, 'ConversationID', 'ConversationID');
       unset($IgnoreConversations);
 
       // Get session user's conversation IDs
@@ -694,7 +694,7 @@ class IgnorePlugin extends Gdn_Plugin {
          ->Where('UserID', $SessionUserID)
          ->Where('Deleted', 0)
          ->Get()->ResultArray();
-      $SessionConversationIDs = ConsolidateArrayValuesByKey($SessionConversations, 'ConversationID','ConversationID');
+      $SessionConversationIDs = array_column($SessionConversations, 'ConversationID', 'ConversationID');
       unset($SessionConversations);
 
       $CommonConversations = array_intersect($IgnoreConversationIDs, $SessionConversationIDs);

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -44,6 +44,10 @@ class QnAPlugin extends Gdn_Plugin {
 
     public function setup() {
         $this->structure();
+
+        touchConfig('QnA.IsPointsAwardEnabled', false);
+        touchConfig('QnA.PointsPerAnswer', 1);
+        touchConfig('QnA.PointsPerAcceptedAnswer', 1);
     }
 
     public function structure() {
@@ -216,8 +220,79 @@ class QnAPlugin extends Gdn_Plugin {
         Gdn::structure()->reset();
     }
 
+    /**
+     * Define what to do for the /index page of this plugin.
+     *
+     * @param $sender Sending controller instance
+     */
+    public function controller_index($sender) {
+        // Prevent non-admins from accessing this page
+        $sender->permission('Garden.Settings.Manage');
+
+        $sender->setData('PluginDescription', $this->getPluginKey('Description'));
+
+        $sender->addJsFile('QnA.js', 'plugins/QnA');
+
+        $validation = new Gdn_Validation();
+        $configurationModel = new Gdn_ConfigurationModel($validation);
+        $configurationModel->setField(array(
+            'QnA.IsPointsAwardEnabled' => c('QnA.IsPointsAwardEnabled', false),
+            'QnA.PointsPerAnswer' => c('QnA.PointsPerAnswer', 1),
+            'QnA.PointsPerAcceptedAnswer' => c('QnA.PointsPerAcceptedAnswer', 1),
+        ));
+        $sender->Form->setModel($configurationModel);
+
+        // If seeing the form for the first time...
+        if ($sender->Form->authenticatedPostBack() === false) {
+            $sender->Form->setData($configurationModel->Data);
+        } else {
+            $configurationModel->Validation->applyRule('QnA.IsPointsAwardEnabled', 'Boolean');
+
+            if ($sender->Form->getFormValue('QnA.IsPointsAwardEnabled')) {
+                $configurationModel->Validation->applyRule('QnA.PointsPerAnswer', 'Required');
+                $configurationModel->Validation->applyRule('QnA.PointsPerAnswer', 'Integer');
+
+                $configurationModel->Validation->applyRule('QnA.PointsPerAcceptedAnswer', 'Required');
+                $configurationModel->Validation->applyRule('QnA.PointsPerAcceptedAnswer', 'Integer');
+
+                if ($sender->Form->getFormValue('QnA.PointsPerAnswer') < 0) {
+                    $sender->Form->setFormValue('QnA.PointsPerAnswer', 0);
+                }
+                if ($sender->Form->getFormValue('QnA.PointsPerAcceptedAnswer') < 0) {
+                    $sender->Form->setFormValue('QnA.PointsPerAcceptedAnswer', 0);
+                }
+            }
+
+            if ($sender->Form->save()) {
+                $sender->StatusMessage = t('Your changes have been saved.');
+            }
+        }
+
+        $sender->render($this->getView('configuration.php'));
+    }
 
     /// EVENTS ///
+    /**
+     * Create a method called "QnA" on the SettingController.
+     *
+     * @param $sender Sending controller instance
+     */
+    public function settingsController_QnA_create($sender) {
+        $sender->title(sprintf(t('%s settings'), t('Q&A')));
+        $sender->addSideMenu('settings/QnA');
+        $sender->Form = new Gdn_Form();
+        $this->dispatch($sender, $sender->RequestArgs);
+    }
+
+    /**
+     * Add a link to the dashboard menu.
+     *
+     * @param $sender Sending controller instance.
+     */
+    public function base_getAppSettingsMenuItems_handler($sender) {
+        $menu = $sender->EventArguments['SideMenu'];
+        $menu->addLink('Add-ons', t('Q&A'), 'settings/QnA', 'Garden.Settings.Manage');
+    }
 
     public function base_addonEnabled_handler($Sender, $Args) {
         switch (strtolower($Args['AddonName'])) {
@@ -594,6 +669,10 @@ class QnAPlugin extends Gdn_Plugin {
 
                     case 'Accepted':
                         $Change = 1;
+
+                        if (c('QnA.IsPointsAwardEnabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
+                            UserModel::givePoints($Comment['InsertUserID'], c('QnA.PointsPerAcceptedAnswer', 1), 'QnA');
+                        }
                         break;
 
                     default:
@@ -1073,5 +1152,38 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function messageController_afterGetLocationData_handler($Sender, $Args) {
         $Args['ControllerData']['Vanilla/Post/Question'] = t('New Question Form');
+    }
+
+    /**
+     * Hook on AfterSaveComment event.
+     *
+     * Give point(s) to the current user if the right conditions are met.
+     *
+     * @param $sender Sending controller instance.
+     * @param $args Event arguments.
+     */
+    public function commentModel_afterSaveComment_handler($sender, $args) {
+        if (!c('QnA.IsPointsAwardEnabled', false) || !$args['Insert']) {
+            return;
+        }
+
+        $discussion = (new DiscussionModel())->getID($args['CommentData']['DiscussionID'], DATASET_TYPE_ARRAY);
+        // If the comment is not an answer to a question
+        // or if the question already have an accepted answer
+        // or if the original poster comments on its own question, abort.
+        if ($discussion['Type'] !== 'Question' || $discussion['QnA'] === 'Accepted' || $discussion['InsertUserID'] == GDN::session()->UserID) {
+            return;
+        }
+
+        $userAnswersToQuestion = (new CommentModel())->getWhere(array(
+            'DiscussionID' => $args['CommentData']['DiscussionID'],
+            'InsertUserId' => GDN::session()->UserID,
+        ));
+        // Award point(s) only for the first answer to the question
+        if ($userAnswersToQuestion->count() > 1) {
+            return;
+        }
+
+        UserModel::givePoints(GDN::session()->UserID, c('QnA.PointsPerAnswer', 1), 'QnA');
     }
 }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1,4 +1,4 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php if (!defined('APPLICATION')) { exit(); }
 /**
  * @copyright Copyright 2008, 2009 Vanilla Forums Inc.
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPLv2
@@ -6,289 +6,289 @@
 
 // Define the plugin:
 $PluginInfo['QnA'] = array(
-   'Name' => 'Q&A',
-   'Description' => "Users may designate a discussion as a Question and then officially accept one or more of the comments as the answer.",
-   'Version' => '1.2.4',
-   'RequiredApplications' => array('Vanilla' => '2.1'),
-   'MobileFriendly' => TRUE,
-   'Author' => 'Todd Burry',
-   'AuthorEmail' => 'todd@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd'
+    'Name' => 'Q&A',
+    'Description' => "Users may designate a discussion as a Question and then officially accept one or more of the comments as the answer.",
+    'Version' => '1.2.4',
+    'RequiredApplications' => array('Vanilla' => '2.1'),
+    'MobileFriendly' => true,
+    'Author' => 'Todd Burry',
+    'AuthorEmail' => 'todd@vanillaforums.com',
+    'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd'
 );
 
 /**
  * Adds Question & Answer format to Vanilla.
  *
- * You can set Plugins.QnA.UseBigButtons = TRUE in config to separate 'New Discussion'
+ * You can set Plugins.QnA.UseBigButtons = true in config to separate 'New Discussion'
  * and 'Ask Question' into "separate" forms each with own big button in Panel.
  */
 class QnAPlugin extends Gdn_Plugin {
-   /// PROPERTIES ///
+    /// PROPERTIES ///
 
-   protected $Reactions = FALSE;
-   protected $Badges = FALSE;
+    protected $Reactions = false;
+    protected $Badges = false;
 
-   /// METHODS ///
+    /// METHODS ///
 
-   public function __construct() {
-      parent::__construct();
+    public function __construct() {
+        parent::__construct();
 
-      if (Gdn::PluginManager()->CheckPlugin('Reactions') && C('Plugins.QnA.Reactions', TRUE)) {
-         $this->Reactions = TRUE;
-      }
+        if (Gdn::pluginManager()->checkPlugin('Reactions') && c('Plugins.QnA.Reactions', true)) {
+            $this->Reactions = true;
+        }
 
-      if (Gdn::ApplicationManager()->CheckApplication('Reputation') && C('Plugins.QnA.Badges', TRUE)) {
-         $this->Badges = TRUE;
-      }
+        if (Gdn::applicationManager()->checkApplication('Reputation') && c('Plugins.QnA.Badges', true)) {
+            $this->Badges = true;
+        }
+    }
 
-   }
+    public function setup() {
+        $this->structure();
+    }
 
-   public function Setup() {
-      $this->Structure();
-   }
+    public function structure() {
+        Gdn::structure()
+            ->table('Discussion');
 
-   public function Structure() {
-      Gdn::Structure()
-         ->Table('Discussion');
+        $QnAExists = Gdn::structure()->columnExists('QnA');
+        $DateAcceptedExists = Gdn::structure()->columnExists('DateAccepted');
 
-      $QnAExists = Gdn::Structure()->ColumnExists('QnA');
-      $DateAcceptedExists = Gdn::Structure()->ColumnExists('DateAccepted');
+        Gdn::structure()
+            ->column('QnA', array('Unanswered', 'Answered', 'Accepted', 'Rejected'), null, 'index')
+            ->column('DateAccepted', 'datetime', true) // The
+            ->column('DateOfAnswer', 'datetime', true) // The time to answer an accepted question.
+            ->set();
 
-      Gdn::Structure()
-         ->Column('QnA', array('Unanswered', 'Answered', 'Accepted', 'Rejected'), NULL, 'index')
-         ->Column('DateAccepted', 'datetime', TRUE) // The
-         ->Column('DateOfAnswer', 'datetime', TRUE) // The time to answer an accepted question.
-         ->Set();
+        Gdn::structure()
+            ->table('Comment')
+            ->column('QnA', array('Accepted', 'Rejected'), null)
+            ->column('DateAccepted', 'datetime', true)
+            ->column('AcceptedUserID', 'int', true)
+            ->set();
 
-      Gdn::Structure()
-         ->Table('Comment')
-         ->Column('QnA', array('Accepted', 'Rejected'), NULL)
-         ->Column('DateAccepted', 'datetime', TRUE)
-         ->Column('AcceptedUserID', 'int', TRUE)
-         ->Set();
+        Gdn::structure()
+            ->table('User')
+            ->column('CountAcceptedAnswers', 'int', '0')
+            ->set();
 
-      Gdn::Structure()
-         ->Table('User')
-         ->Column('CountAcceptedAnswers', 'int', '0')
-         ->Set();
+        Gdn::SQL()->replace(
+            'ActivityType',
+            array('AllowComments' => '0', 'RouteCode' => 'question', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''),
+            array('Name' => 'QuestionAnswer'), true);
+        Gdn::SQL()->replace(
+            'ActivityType',
+            array('AllowComments' => '0', 'RouteCode' => 'answer', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''),
+            array('Name' => 'AnswerAccepted'), true);
 
-      Gdn::SQL()->Replace(
-         'ActivityType',
-         array('AllowComments' => '0', 'RouteCode' => 'question', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''),
-         array('Name' => 'QuestionAnswer'), TRUE);
-      Gdn::SQL()->Replace(
-         'ActivityType',
-         array('AllowComments' => '0', 'RouteCode' => 'answer', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''),
-         array('Name' => 'AnswerAccepted'), TRUE);
+        if ($QnAExists && !$DateAcceptedExists) {
+            // Default the date accepted to the accepted answer's date.
+            $Px = Gdn::database()->DatabasePrefix;
+            $Sql = "update {$Px}Discussion d set DateAccepted = (select min(c.DateInserted) from {$Px}Comment c where c.DiscussionID = d.DiscussionID and c.QnA = 'Accepted')";
+            Gdn::SQL()->query($Sql, 'update');
+            Gdn::SQL()->update('Discussion')
+                ->set('DateOfAnswer', 'DateAccepted', false, false)
+                ->put();
 
-      if ($QnAExists && !$DateAcceptedExists) {
-         // Default the date accepted to the accepted answer's date.
-         $Px = Gdn::Database()->DatabasePrefix;
-         $Sql = "update {$Px}Discussion d set DateAccepted = (select min(c.DateInserted) from {$Px}Comment c where c.DiscussionID = d.DiscussionID and c.QnA = 'Accepted')";
-         Gdn::SQL()->Query($Sql, 'update');
-         Gdn::SQL()->Update('Discussion')
-            ->Set('DateOfAnswer', 'DateAccepted', FALSE, FALSE)
-            ->Put();
+            Gdn::SQL()->update('Comment c')
+                ->join('Discussion d', 'c.CommentID = d.DiscussionID')
+                ->set('c.DateAccepted', 'c.DateInserted', false, false)
+                ->set('c.AcceptedUserID', 'd.InsertUserID', false, false)
+                ->where('c.QnA', 'Accepted')
+                ->where('c.DateAccepted', null)
+                ->put();
+        }
 
-         Gdn::SQL()->Update('Comment c')
-            ->Join('Discussion d', 'c.CommentID = d.DiscussionID')
-            ->Set('c.DateAccepted', 'c.DateInserted', FALSE, FALSE)
-            ->Set('c.AcceptedUserID', 'd.InsertUserID', FALSE, FALSE)
-            ->Where('c.QnA', 'Accepted')
-            ->Where('c.DateAccepted', NULL)
-            ->Put();
-      }
+        $this->structureReactions();
+        $this->structureBadges();
+    }
 
-      $this->StructureReactions();
-      $this->StructureBadges();
-   }
+    /**
+     * Define all of the structure related to badges.
+     */
+    public function structureBadges() {
+        // Define 'Answer' badges
+        if (!$this->Badges || !class_exists('BadgeModel')) {
+            return;
+        }
 
-   /**
-    * Define all of the structure related to badges.
-    */
-   public function StructureBadges() {
-      // Define 'Answer' badges
-      if (!$this->Badges || !class_exists('BadgeModel'))
-         return;
+        $BadgeModel = new BadgeModel();
 
-      $BadgeModel = new BadgeModel();
+        // Answer Counts
+        $BadgeModel->define(array(
+            'Name' => 'First Answer',
+            'Slug' => 'answer',
+            'Type' => 'UserCount',
+            'Body' => 'Answering questions is a great way to show your support for a community!',
+            'Photo' => 'http://badges.vni.la/100/answer.png',
+            'Points' => 2,
+            'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+            'Threshold' => 1,
+            'Class' => 'Answerer',
+            'Level' => 1,
+            'CanDelete' => 0
+        ));
+        $BadgeModel->define(array(
+            'Name' => '5 Answers',
+            'Slug' => 'answer-5',
+            'Type' => 'UserCount',
+            'Body' => 'Your willingness to share knowledge has definitely been noticed.',
+            'Photo' => 'http://badges.vni.la/100/answer-2.png',
+            'Points' => 3,
+            'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+            'Threshold' => 5,
+            'Class' => 'Answerer',
+            'Level' => 2,
+            'CanDelete' => 0
+        ));
+        $BadgeModel->define(array(
+            'Name' => '25 Answers',
+            'Slug' => 'answer-25',
+            'Type' => 'UserCount',
+            'Body' => 'Looks like you&rsquo;re starting to make a name for yourself as someone who knows the score!',
+            'Photo' => 'http://badges.vni.la/100/answer-3.png',
+            'Points' => 5,
+            'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+            'Threshold' => 25,
+            'Class' => 'Answerer',
+            'Level' => 3,
+            'CanDelete' => 0
+        ));
+        $BadgeModel->define(array(
+            'Name' => '50 Answers',
+            'Slug' => 'answer-50',
+            'Type' => 'UserCount',
+            'Body' => 'Why use Google when we could just ask you?',
+            'Photo' => 'http://badges.vni.la/100/answer-4.png',
+            'Points' => 10,
+            'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+            'Threshold' => 50,
+            'Class' => 'Answerer',
+            'Level' => 4,
+            'CanDelete' => 0
+        ));
+        $BadgeModel->define(array(
+            'Name' => '100 Answers',
+            'Slug' => 'answer-100',
+            'Type' => 'UserCount',
+            'Body' => 'Admit it, you read Wikipedia in your spare time.',
+            'Photo' => 'http://badges.vni.la/100/answer-5.png',
+            'Points' => 15,
+            'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+            'Threshold' => 100,
+            'Class' => 'Answerer',
+            'Level' => 5,
+            'CanDelete' => 0
+        ));
+        $BadgeModel->define(array(
+            'Name' => '250 Answers',
+            'Slug' => 'answer-250',
+            'Type' => 'UserCount',
+            'Body' => 'Is there *anything* you don&rsquo;t know?',
+            'Photo' => 'http://badges.vni.la/100/answer-6.png',
+            'Points' => 20,
+            'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+            'Threshold' => 250,
+            'Class' => 'Answerer',
+            'Level' => 6,
+            'CanDelete' => 0
+        ));
+    }
 
-      // Answer Counts
-      $BadgeModel->Define(array(
-          'Name' => 'First Answer',
-          'Slug' => 'answer',
-          'Type' => 'UserCount',
-          'Body' => 'Answering questions is a great way to show your support for a community!',
-          'Photo' => 'http://badges.vni.la/100/answer.png',
-          'Points' => 2,
-          'Attributes' => array('Column' => 'CountAcceptedAnswers'),
-          'Threshold' => 1,
-          'Class' => 'Answerer',
-          'Level' => 1,
-          'CanDelete' => 0
-      ));
-      $BadgeModel->Define(array(
-          'Name' => '5 Answers',
-          'Slug' => 'answer-5',
-          'Type' => 'UserCount',
-          'Body' => 'Your willingness to share knowledge has definitely been noticed.',
-          'Photo' => 'http://badges.vni.la/100/answer-2.png',
-          'Points' => 3,
-          'Attributes' => array('Column' => 'CountAcceptedAnswers'),
-          'Threshold' => 5,
-          'Class' => 'Answerer',
-          'Level' => 2,
-          'CanDelete' => 0
-      ));
-      $BadgeModel->Define(array(
-          'Name' => '25 Answers',
-          'Slug' => 'answer-25',
-          'Type' => 'UserCount',
-          'Body' => 'Looks like you&rsquo;re starting to make a name for yourself as someone who knows the score!',
-          'Photo' => 'http://badges.vni.la/100/answer-3.png',
-          'Points' => 5,
-          'Attributes' => array('Column' => 'CountAcceptedAnswers'),
-          'Threshold' => 25,
-          'Class' => 'Answerer',
-          'Level' => 3,
-          'CanDelete' => 0
-      ));
-      $BadgeModel->Define(array(
-          'Name' => '50 Answers',
-          'Slug' => 'answer-50',
-          'Type' => 'UserCount',
-          'Body' => 'Why use Google when we could just ask you?',
-          'Photo' => 'http://badges.vni.la/100/answer-4.png',
-          'Points' => 10,
-          'Attributes' => array('Column' => 'CountAcceptedAnswers'),
-          'Threshold' => 50,
-          'Class' => 'Answerer',
-          'Level' => 4,
-          'CanDelete' => 0
-      ));
-      $BadgeModel->Define(array(
-          'Name' => '100 Answers',
-          'Slug' => 'answer-100',
-          'Type' => 'UserCount',
-          'Body' => 'Admit it, you read Wikipedia in your spare time.',
-          'Photo' => 'http://badges.vni.la/100/answer-5.png',
-          'Points' => 15,
-          'Attributes' => array('Column' => 'CountAcceptedAnswers'),
-          'Threshold' => 100,
-          'Class' => 'Answerer',
-          'Level' => 5,
-          'CanDelete' => 0
-      ));
-      $BadgeModel->Define(array(
-          'Name' => '250 Answers',
-          'Slug' => 'answer-250',
-          'Type' => 'UserCount',
-          'Body' => 'Is there *anything* you don&rsquo;t know?',
-          'Photo' => 'http://badges.vni.la/100/answer-6.png',
-          'Points' => 20,
-          'Attributes' => array('Column' => 'CountAcceptedAnswers'),
-          'Threshold' => 250,
-          'Class' => 'Answerer',
-          'Level' => 6,
-          'CanDelete' => 0
-      ));
-   }
+    /**
+     * Define all of the structure releated to reactions.
+     * @return type
+     */
+    public function structureReactions() {
+        // Define 'Accept' reaction
+        if (!$this->Reactions) {
+            return;
+        }
 
-   /**
-    * Define all of the structure releated to reactions.
-    * @return type
-    */
-   public function StructureReactions() {
-      // Define 'Accept' reaction
-      if (!$this->Reactions)
-         return;
+        $Rm = new ReactionModel();
 
-      $Rm = new ReactionModel();
+        if (Gdn::structure()->table('ReactionType')->columnExists('Hidden')) {
 
-      if (Gdn::Structure()->Table('ReactionType')->ColumnExists('Hidden')) {
+            // AcceptAnswer
+            $Rm->defineReactionType(array('UrlCode' => 'AcceptAnswer', 'Name' => 'Accept Answer', 'Sort' => 0, 'Class' => 'Positive', 'IncrementColumn' => 'Score', 'IncrementValue' => 5, 'Points' => 3, 'Permission' => 'Garden.Curation.Manage', 'Hidden' => 1,
+                'Description' => "When someone correctly answers a question, they are rewarded with this reaction."));
+        }
 
-         // AcceptAnswer
-         $Rm->DefineReactionType(array('UrlCode' => 'AcceptAnswer', 'Name' => 'Accept Answer', 'Sort' => 0, 'Class' => 'Positive', 'IncrementColumn' => 'Score', 'IncrementValue' => 5, 'Points' => 3, 'Permission' => 'Garden.Curation.Manage', 'Hidden' => 1,
-            'Description' => "When someone correctly answers a question, they are rewarded with this reaction."));
-
-      }
-
-      Gdn::Structure()->Reset();
-   }
+        Gdn::structure()->reset();
+    }
 
 
-   /// EVENTS ///
+    /// EVENTS ///
 
-   public function Base_AddonEnabled_Handler($Sender, $Args) {
-      switch (strtolower($Args['AddonName'])) {
-         case 'reactions':
-            $this->Reactions = TRUE;
-            $this->StructureReactions();
-            break;
-         case 'reputation':
-            $this->Badges = TRUE;
-            $this->StructureBadges();
-            break;
-      }
-   }
+    public function base_addonEnabled_handler($Sender, $Args) {
+        switch (strtolower($Args['AddonName'])) {
+            case 'reactions':
+                $this->Reactions = true;
+                $this->structureReactions();
+                break;
+            case 'reputation':
+                $this->Badges = true;
+                $this->structureBadges();
+                break;
+        }
+    }
 
-   public function Base_BeforeCommentDisplay_Handler($Sender, $Args) {
-      $QnA = GetValueR('Comment.QnA', $Args);
+    public function base_beforeCommentDisplay_handler($Sender, $Args) {
+        $QnA = valr('Comment.QnA', $Args);
 
-      if ($QnA && isset($Args['CssClass'])) {
-         $Args['CssClass'] = ConcatSep(' ', $Args['CssClass'], "QnA-Item-$QnA");
-      }
-   }
+        if ($QnA && isset($Args['CssClass'])) {
+            $Args['CssClass'] = concatSep(' ', $Args['CssClass'], "QnA-Item-$QnA");
+        }
+    }
 
-   public function Base_DiscussionTypes_Handler($Sender, $Args) {
-      $Args['Types']['Question'] = array(
+    public function base_discussionTypes_handler($Sender, $Args) {
+        $Args['Types']['Question'] = array(
             'Singular' => 'Question',
             'Plural' => 'Questions',
             'AddUrl' => '/post/question',
             'AddText' => 'Ask a Question'
-            );
-   }
+        );
+    }
 
-   /**
-    *
-    * @param Gdn_Controller $Sender
-    * @param array $Args
-    */
+    /**
+     *
+     * @param Gdn_Controller $Sender
+     * @param array $Args
+     */
 //   public function Base_AfterReactions_Handler($Sender, $Args) {
 //   // public function Base_CommentOptions_Handler($Sender, $Args) {
-//      $Discussion = GetValue('Discussion', $Args);
-//      $Comment = GetValue('Comment', $Args);
+//      $Discussion = val('Discussion', $Args);
+//      $Comment = val('Comment', $Args);
 //
 //      if (!$Comment)
 //         return;
 //
-//      $CommentID = GetValue('CommentID', $Comment);
+//      $CommentID = val('CommentID', $Comment);
 //      if (!is_numeric($CommentID))
 //         return;
 //
 //      if (!$Discussion) {
-//         static $DiscussionModel = NULL;
-//         if ($DiscussionModel === NULL)
+//         static $DiscussionModel = null;
+//         if ($DiscussionModel === null)
 //            $DiscussionModel = new DiscussionModel();
-//         $Discussion = $DiscussionModel->GetID(GetValue('DiscussionID', $Comment));
+//         $Discussion = $DiscussionModel->GetID(val('DiscussionID', $Comment));
 //      }
 //
-//      if (!$Discussion || strtolower(GetValue('Type', $Discussion)) != 'question')
+//      if (!$Discussion || strtolower(val('Type', $Discussion)) != 'question')
 //         return;
 //
 //      // Check permissions.
 //      $CanAccept = Gdn::Session()->CheckPermission('Garden.Moderation.Manage');
-//      $CanAccept |= Gdn::Session()->UserID == GetValue('InsertUserID', $Discussion) && Gdn::Session()->UserID != GetValue('InsertUserID', $Comment);
+//      $CanAccept |= Gdn::Session()->UserID == val('InsertUserID', $Discussion) && Gdn::Session()->UserID != val('InsertUserID', $Comment);
 //
 //      if (!$CanAccept)
 //         return;
 //
-//      $QnA = GetValue('QnA', $Comment);
+//      $QnA = val('QnA', $Comment);
 //      if ($QnA)
 //         return;
 //
 //      // Write the links.
-//      $Types = GetValue('ReactionTypes', $Sender->EventArguments);
+//      $Types = val('ReactionTypes', $Sender->EventArguments);
 //      if ($Types)
 //         echo Bullet();
 //
@@ -296,697 +296,735 @@ class QnAPlugin extends Gdn_Plugin {
 //      echo Anchor(Sprite('ReactAccept', 'ReactSprite').T('Accept', 'Accept'), '/discussion/qna/accept?'.$Query, array('class' => 'React QnA-Yes', 'title' => T('Accept this answer.')));
 //      echo Anchor(Sprite('ReactReject', 'ReactSprite').T('Reject', 'Reject'), '/discussion/qna/reject?'.$Query, array('class' => 'React QnA-No', 'title' => T('Reject this answer.')));
 //
-//      static $InformMessage = TRUE;
+//      static $InformMessage = true;
 //
-//      if ($InformMessage && Gdn::Session()->UserID == GetValue('InsertUserID', $Discussion) && in_array(GetValue('QnA', $Discussion), array('', 'Answered'))) {
+//      if ($InformMessage && Gdn::Session()->UserID == val('InsertUserID', $Discussion) && in_array(val('QnA', $Discussion), array('', 'Answered'))) {
 //         $Sender->InformMessage(T('Click accept or reject beside an answer.'), 'Dismissable');
-//         $InformMessage = FALSE;
+//         $InformMessage = false;
 //      }
 //   }
 
-   public function Base_CommentInfo_Handler($Sender, $Args) {
-      $Type = GetValue('Type', $Args);
-      if ($Type != 'Comment')
-         return;
+    public function base_commentInfo_handler($Sender, $Args) {
+        $Type = val('Type', $Args);
+        if ($Type != 'Comment') {
+            return;
+        }
 
-      $QnA = GetValueR('Comment.QnA', $Args);
+        $QnA = valr('Comment.QnA', $Args);
 
-      if ($QnA && ($QnA == 'Accepted' || Gdn::Session()->CheckPermission('Garden.Moderation.Manage'))) {
-         $Title = T("QnA $QnA Answer", "$QnA Answer");
-         echo ' <span class="Tag QnA-Box QnA-'.$QnA.'" title="'.htmlspecialchars($Title).'"><span>'.$Title.'</span></span> ';
-      }
-   }
+        if ($QnA && ($QnA == 'Accepted' || Gdn::session()->checkPermission('Garden.Moderation.Manage'))) {
+            $Title = t("QnA $QnA Answer", "$QnA Answer");
+            echo ' <span class="Tag QnA-Box QnA-'.$QnA.'" title="'.htmlspecialchars($Title).'"><span>'.$Title.'</span></span> ';
+        }
+    }
 
-   public function DiscussionController_CommentOptions_Handler($Sender, $Args) {
-      $Comment = $Args['Comment'];
-      if (!$Comment)
-         return;
-      $Discussion = Gdn::Controller()->Data('Discussion');
+    public function discussionController_commentOptions_handler($Sender, $Args) {
+        $Comment = $Args['Comment'];
+        if (!$Comment) {
+            return;
+        }
+        $Discussion = Gdn::controller()->data('Discussion');
 
-      if (GetValue('Type', $Discussion) != 'Question')
-         return;
+        if (val('Type', $Discussion) != 'Question') {
+            return;
+        }
 
-      if (!Gdn::Session()->CheckPermission('Vanilla.Discussions.Edit', TRUE, 'Category', $Discussion->PermissionCategoryID))
-         return;
+        if (!Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $Discussion->PermissionCategoryID)) {
+            return;
+        }
 
-      $Args['CommentOptions']['QnA'] = array('Label' => T('Q&A').'...', 'Url' => '/discussion/qnaoptions?commentid='.$Comment->CommentID, 'Class' => 'Popup');
-   }
+        $Args['CommentOptions']['QnA'] = array('Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?commentid='.$Comment->CommentID, 'Class' => 'Popup');
+    }
 
-   public function Base_DiscussionOptions_Handler($Sender, $Args) {
-      $Discussion = $Args['Discussion'];
-      if (!Gdn::Session()->CheckPermission('Vanilla.Discussions.Edit', TRUE, 'Category', $Discussion->PermissionCategoryID))
-         return;
+    public function base_discussionOptions_handler($Sender, $Args) {
+        $Discussion = $Args['Discussion'];
+        if (!Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $Discussion->PermissionCategoryID)) {
+            return;
+        }
 
-      if (isset($Args['DiscussionOptions'])) {
-         $Args['DiscussionOptions']['QnA'] = array('Label' => T('Q&A').'...', 'Url' => '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Class' => 'Popup');
-      } elseif (isset($Sender->Options)) {
-         $Sender->Options .= '<li>'.Anchor(T('Q&A').'...', '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Popup QnAOptions') . '</li>';
-      }
-   }
+        if (isset($Args['DiscussionOptions'])) {
+            $Args['DiscussionOptions']['QnA'] = array('Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Class' => 'Popup');
+        } elseif (isset($Sender->Options)) {
+            $Sender->Options .= '<li>'.anchor(t('Q&A').'...', '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Popup QnAOptions') . '</li>';
+        }
+    }
 
-   public function CommentModel_BeforeNotification_Handler($Sender, $Args) {
-      $ActivityModel = $Args['ActivityModel'];
-      $Comment = (array)$Args['Comment'];
-      $CommentID = $Comment['CommentID'];
-      $Discussion = (array)$Args['Discussion'];
+    public function commentModel_beforeNotification_handler($Sender, $Args) {
+        $ActivityModel = $Args['ActivityModel'];
+        $Comment = (array)$Args['Comment'];
+        $CommentID = $Comment['CommentID'];
+        $Discussion = (array)$Args['Discussion'];
 
-      if ($Comment['InsertUserID'] == $Discussion['InsertUserID'])
-         return;
-      if (strtolower($Discussion['Type']) != 'question')
-         return;
-      if (!C('Plugins.QnA.Notifications', TRUE))
-         return;
+        if ($Comment['InsertUserID'] == $Discussion['InsertUserID']) {
+            return;
+        }
+        if (strtolower($Discussion['Type']) != 'question') {
+            return;
+        }
+        if (!c('Plugins.QnA.Notifications', true)) {
+            return;
+        }
 
-      $HeadlineFormat = T('HeadlingFormat.Answer', '{ActivityUserID,user} answered your question: <a href="{Url,html}">{Data.Name,text}</a>');
+        $HeadlineFormat = t('HeadlingFormat.Answer', '{ActivityUserID,user} answered your question: <a href="{Url,html}">{Data.Name,text}</a>');
 
-      $Activity = array(
-         'ActivityType' => 'Comment',
-         'ActivityUserID' => $Comment['InsertUserID'],
-         'NotifyUserID' => $Discussion['InsertUserID'],
-         'HeadlineFormat' => $HeadlineFormat,
-         'RecordType' => 'Comment',
-         'RecordID' => $CommentID,
-         'Route' => "/discussion/comment/$CommentID#Comment_$CommentID",
-         'Data' => array(
-            'Name' => GetValue('Name', $Discussion)
-         )
-      );
+        $Activity = array(
+            'ActivityType' => 'Comment',
+            'ActivityUserID' => $Comment['InsertUserID'],
+            'NotifyUserID' => $Discussion['InsertUserID'],
+            'HeadlineFormat' => $HeadlineFormat,
+            'RecordType' => 'Comment',
+            'RecordID' => $CommentID,
+            'Route' => "/discussion/comment/$CommentID#Comment_$CommentID",
+            'Data' => array(
+                'Name' => val('Name', $Discussion)
+            )
+        );
 
-      $ActivityModel->Queue($Activity, 'DiscussionComment');
-   }
+        $ActivityModel->queue($Activity, 'DiscussionComment');
+    }
 
-   /**
-    * @param CommentModel $Sender
-    * @param array $Args
-    */
-   public function CommentModel_BeforeUpdateCommentCount_Handler($Sender, $Args) {
-      $Discussion =& $Args['Discussion'];
+    /**
+     * @param CommentModel $Sender
+     * @param array $Args
+     */
+    public function commentModel_beforeUpdateCommentCount_handler($Sender, $Args) {
+        $Discussion =& $Args['Discussion'];
 
-      // Mark the question as answered.
-      if (strtolower($Discussion['Type']) == 'question' && !$Discussion['Sink'] && !in_array($Discussion['QnA'], array('Answered', 'Accepted'))) {
-         $Sender->SQL->Set('QnA', 'Answered');
-      }
-   }
+        // Mark the question as answered.
+        if (strtolower($Discussion['Type']) == 'question' && !$Discussion['Sink'] && !in_array($Discussion['QnA'], array('Answered', 'Accepted'))) {
+            $Sender->SQL->set('QnA', 'Answered');
+        }
+    }
 
-   /**
-    * Modify flow of discussion by pinning accepted answers.
-    *
-    * @param $Sender
-    * @param $Args
-    */
-   public function DiscussionController_BeforeDiscussionRender_Handler($Sender, $Args) {
-      if ($Sender->Data('Discussion.QnA'))
-         $Sender->CssClass .= ' Question';
+    /**
+     * Modify flow of discussion by pinning accepted answers.
+     *
+     * @param $Sender
+     * @param $Args
+     */
+    public function discussionController_beforeDiscussionRender_handler($Sender, $Args) {
+        if ($Sender->data('Discussion.QnA')) {
+            $Sender->CssClass .= ' Question';
+        }
 
-      if (strcasecmp($Sender->Data('Discussion.QnA'), 'Accepted') != 0)
-         return;
+        if (strcasecmp($Sender->data('Discussion.QnA'), 'Accepted') != 0) {
+            return;
+        }
 
-      // Find the accepted answer(s) to the question.
-      $CommentModel = new CommentModel();
-      $Answers = $CommentModel->GetWhere(array('DiscussionID' => $Sender->Data('Discussion.DiscussionID'), 'Qna' => 'Accepted'))->Result();
+        // Find the accepted answer(s) to the question.
+        $CommentModel = new CommentModel();
+        $Answers = $CommentModel->getWhere(array('DiscussionID' => $Sender->data('Discussion.DiscussionID'), 'Qna' => 'Accepted'))->result();
 
-      if (class_exists('ReplyModel')) {
-         $ReplyModel = new ReplyModel();
-         $Discussion = NULL;
-         $ReplyModel->JoinReplies($Discussion, $Answers);
-      }
+        if (class_exists('ReplyModel')) {
+            $ReplyModel = new ReplyModel();
+            $Discussion = null;
+            $ReplyModel->joinReplies($Discussion, $Answers);
+        }
 
-      $Sender->SetData('Answers', $Answers);
+        $Sender->setData('Answers', $Answers);
 
-      // Remove the accepted answers from the comments.
-      // Allow this to be skipped via config.
-      if (C('QnA.AcceptedAnswers.Filter', TRUE)) {
-         if (isset($Sender->Data['Comments'])) {
-            $Comments = $Sender->Data['Comments']->Result();
-            $Comments = array_filter($Comments, function($Row) {
-               return strcasecmp(GetValue('QnA', $Row), 'accepted');
-            });
-            $Sender->Data['Comments'] = new Gdn_DataSet(array_values($Comments));
-         }
-      }
-   }
+        // Remove the accepted answers from the comments.
+        // Allow this to be skipped via config.
+        if (c('QnA.AcceptedAnswers.Filter', true)) {
+            if (isset($Sender->Data['Comments'])) {
+                $Comments = $Sender->Data['Comments']->result();
+                $Comments = array_filter($Comments, function($Row) {
+                    return strcasecmp(val('QnA', $Row), 'accepted');
+                });
+                $Sender->Data['Comments'] = new Gdn_DataSet(array_values($Comments));
+            }
+        }
+    }
 
-   /**
-    * Write the accept/reject buttons.
-    * @staticvar null $DiscussionModel
-    * @staticvar boolean $InformMessage
-    * @param type $Sender
-    * @param type $Args
-    * @return type
-    */
-   public function DiscussionController_AfterCommentBody_Handler($Sender, $Args) {
-      $Discussion = $Sender->Data('Discussion');
-      $Comment = GetValue('Comment', $Args);
+    /**
+     * Write the accept/reject buttons.
+     * @staticvar null $DiscussionModel
+     * @staticvar boolean $InformMessage
+     * @param type $Sender
+     * @param type $Args
+     * @return type
+     */
+    public function discussionController_afterCommentBody_handler($Sender, $Args) {
+        $Discussion = $Sender->data('Discussion');
+        $Comment = val('Comment', $Args);
 
-      if (!$Comment)
-         return;
+        if (!$Comment) {
+            return;
+        }
 
-      $CommentID = GetValue('CommentID', $Comment);
-      if (!is_numeric($CommentID))
-         return;
+        $CommentID = val('CommentID', $Comment);
+        if (!is_numeric($CommentID)) {
+            return;
+        }
 
-      if (!$Discussion) {
-         static $DiscussionModel = NULL;
-         if ($DiscussionModel === NULL)
-            $DiscussionModel = new DiscussionModel();
-         $Discussion = $DiscussionModel->GetID(GetValue('DiscussionID', $Comment));
-      }
+        if (!$Discussion) {
+            static $DiscussionModel = null;
+            if ($DiscussionModel === null) {
+                $DiscussionModel = new DiscussionModel();
+            }
+            $Discussion = $DiscussionModel->getID(val('DiscussionID', $Comment));
+        }
 
-      if (!$Discussion || strtolower(GetValue('Type', $Discussion)) != 'question')
-         return;
+        if (!$Discussion || strtolower(val('Type', $Discussion)) != 'question') {
+            return;
+        }
 
-      // Check permissions.
-      $CanAccept = Gdn::Session()->CheckPermission('Garden.Moderation.Manage');
-      $CanAccept |= Gdn::Session()->UserID == GetValue('InsertUserID', $Discussion);
+        // Check permissions.
+        $CanAccept = Gdn::session()->checkPermission('Garden.Moderation.Manage');
+        $CanAccept |= Gdn::session()->UserID == val('InsertUserID', $Discussion);
 
-      if (!$CanAccept)
-         return;
+        if (!$CanAccept) {
+            return;
+        }
 
-      $QnA = GetValue('QnA', $Comment);
-      if ($QnA)
-         return;
+        $QnA = val('QnA', $Comment);
+        if ($QnA) {
+            return;
+        }
 
-      // Write the links.
-//      $Types = GetValue('ReactionTypes', $Sender->EventArguments);
+        // Write the links.
+//      $Types = val('ReactionTypes', $Sender->EventArguments);
 //      if ($Types)
 //         echo Bullet();
 
-      $Query = http_build_query(array('commentid' => $CommentID, 'tkey' => Gdn::Session()->TransientKey()));
+        $Query = http_build_query(array('commentid' => $CommentID, 'tkey' => Gdn::session()->transientKey()));
 
-      echo '<div class="ActionBlock QnA-Feedback">';
+        echo '<div class="ActionBlock QnA-Feedback">';
 
 //      echo '<span class="FeedbackLabel">'.T('Feedback').'</span>';
 
-      echo '<span class="DidThisAnswer">'.T('Did this answer the question?').'</span> ';
+        echo '<span class="DidThisAnswer">'.t('Did this answer the question?').'</span> ';
 
-      echo '<span class="QnA-YesNo">';
+        echo '<span class="QnA-YesNo">';
 
-      echo Anchor(T('Yes'), '/discussion/qna/accept?'.$Query, array('class' => 'React QnA-Yes', 'title' => T('Accept this answer.')));
-      echo ' '.Bullet().' ';
-      echo Anchor(T('No'), '/discussion/qna/reject?'.$Query, array('class' => 'React QnA-No', 'title' => T('Reject this answer.')));
+        echo anchor(t('Yes'), '/discussion/qna/accept?'.$Query, array('class' => 'React QnA-Yes', 'title' => t('Accept this answer.')));
+        echo ' '.bullet().' ';
+        echo anchor(t('No'), '/discussion/qna/reject?'.$Query, array('class' => 'React QnA-No', 'title' => t('Reject this answer.')));
 
-      echo '</span>';
+        echo '</span>';
 
-      echo '</div>';
+        echo '</div>';
 
-//      static $InformMessage = TRUE;
+//      static $InformMessage = true;
 //
-//      if ($InformMessage && Gdn::Session()->UserID == GetValue('InsertUserID', $Discussion) && in_array(GetValue('QnA', $Discussion), array('', 'Answered'))) {
+//      if ($InformMessage && Gdn::Session()->UserID == val('InsertUserID', $Discussion) && in_array(val('QnA', $Discussion), array('', 'Answered'))) {
 //         $Sender->InformMessage(T('Click accept or reject beside an answer.'), 'Dismissable');
-//         $InformMessage = FALSE;
+//         $InformMessage = false;
 //      }
-   }
+    }
 
-   /**
-    *
-    * @param DiscussionController $Sender
-    * @param type $Args
-    * @return type
-    */
-   public function DiscussionController_AfterDiscussion_Handler($Sender, $Args) {
-      if ($Sender->Data('Answers'))
-         include $Sender->FetchViewLocation('Answers', '', 'plugins/QnA');
-   }
+    /**
+     *
+     * @param DiscussionController $Sender
+     * @param type $Args
+     * @return type
+     */
+    public function discussionController_afterDiscussion_handler($Sender, $Args) {
+        if ($Sender->data('Answers')) {
+            include $Sender->fetchViewLocation('Answers', '', 'plugins/QnA');
+        }
+    }
 
 
-   /**
-    *
-    * @param DiscussionController $Sender
-    * @param array $Args
-    */
-   public function DiscussionController_QnA_Create($Sender, $Args = array()) {
-      $Comment = Gdn::SQL()->GetWhere('Comment', array('CommentID' => $Sender->Request->Get('commentid')))->FirstRow(DATASET_TYPE_ARRAY);
-      if (!$Comment)
-         throw NotFoundException('Comment');
+    /**
+     *
+     * @param DiscussionController $Sender
+     * @param array $Args
+     */
+    public function discussionController_QnA_create($Sender, $Args = array()) {
+        $Comment = Gdn::SQL()->getWhere('Comment', array('CommentID' => $Sender->Request->get('commentid')))->firstRow(DATASET_TYPE_ARRAY);
+        if (!$Comment) {
+            throw notFoundException('Comment');
+        }
 
-      $Discussion = Gdn::SQL()->GetWhere('Discussion', array('DiscussionID' => $Comment['DiscussionID']))->FirstRow(DATASET_TYPE_ARRAY);
+        $Discussion = Gdn::SQL()->getWhere('Discussion', array('DiscussionID' => $Comment['DiscussionID']))->firstRow(DATASET_TYPE_ARRAY);
 
-      // Check for permission.
-      if (!(Gdn::Session()->UserID == GetValue('InsertUserID', $Discussion) || Gdn::Session()->CheckPermission('Garden.Moderation.Manage'))) {
-         throw PermissionException('Garden.Moderation.Manage');
-      }
-      if (!Gdn::Session()->ValidateTransientKey($Sender->Request->Get('tkey')))
-         throw PermissionException();
+        // Check for permission.
+        if (!(Gdn::session()->UserID == val('InsertUserID', $Discussion) || Gdn::session()->checkPermission('Garden.Moderation.Manage'))) {
+            throw permissionException('Garden.Moderation.Manage');
+        }
+        if (!Gdn::session()->validateTransientKey($Sender->Request->get('tkey'))) {
+            throw permissionException();
+        }
 
-      switch ($Args[0]) {
-         case 'accept':
-            $QnA = 'Accepted';
-            break;
-         case 'reject':
-            $QnA = 'Rejected';
-            break;
-      }
+        switch ($Args[0]) {
+            case 'accept':
+                $QnA = 'Accepted';
+                break;
+            case 'reject':
+                $QnA = 'Rejected';
+                break;
+        }
 
-      if (isset($QnA)) {
-         $DiscussionSet = array('QnA' => $QnA);
-         $CommentSet = array('QnA' => $QnA);
-
-         if ($QnA == 'Accepted') {
-            $CommentSet['DateAccepted'] = Gdn_Format::ToDateTime();
-            $CommentSet['AcceptedUserID'] = Gdn::Session()->UserID;
-
-            if (!$Discussion['DateAccepted']) {
-               $DiscussionSet['DateAccepted'] = Gdn_Format::ToDateTime();
-               $DiscussionSet['DateOfAnswer'] = $Comment['DateInserted'];
-            }
-         }
-
-         // Update the comment.
-         Gdn::SQL()->Put('Comment', $CommentSet, array('CommentID' => $Comment['CommentID']));
-
-         // Update the discussion.
-         if ($Discussion['QnA'] != $QnA && (!$Discussion['QnA'] || in_array($Discussion['QnA'], array('Unanswered', 'Answered', 'Rejected'))))
-            Gdn::SQL()->Put(
-               'Discussion',
-               $DiscussionSet,
-               array('DiscussionID' => $Comment['DiscussionID']));
-
-         // Determine QnA change
-         if ($Comment['QnA'] != $QnA) {
-
-            $Change = 0;
-            switch ($QnA) {
-               case 'Rejected':
-                  $Change = -1;
-                  if ($Comment['QnA'] != 'Accepted') $Change = 0;
-                  break;
-
-               case 'Accepted':
-                  $Change = 1;
-                  break;
-
-               default:
-                  if ($Comment['QnA'] == 'Rejected') $Change = 0;
-                  if ($Comment['QnA'] == 'Accepted') $Change = -1;
-                  break;
-            }
-
-         }
-
-         // Apply change effects
-         if ($Change) {
-            // Update the user
-            $UserID = GetValue('InsertUserID', $Comment);
-            $this->RecalculateUserQnA($UserID);
-
-            // Update reactions
-            if ($this->Reactions) {
-               include_once(Gdn::Controller()->FetchViewLocation('reaction_functions', '', 'plugins/Reactions'));
-               $Rm = new ReactionModel();
-
-               // If there's change, reactions will take care of it
-               $Rm->React('Comment', $Comment['CommentID'], 'AcceptAnswer', NULL, true);
-            }
-         }
-
-         // Record the activity.
-         if ($QnA == 'Accepted') {
-            $Activity = array(
-               'ActivityType' => 'AnswerAccepted',
-               'NotifyUserID' => $Comment['InsertUserID'],
-               'HeadlineFormat' => '{ActivityUserID,You} accepted {NotifyUserID,your} answer.',
-               'RecordType' => 'Comment',
-               'RecordID' => $Comment['CommentID'],
-               'Route' => CommentUrl($Comment, '/'),
-               'Emailed' => ActivityModel::SENT_PENDING,
-               'Notified' => ActivityModel::SENT_PENDING,
-            );
-
-            $ActivityModel = new ActivityModel();
-            $ActivityModel->Save($Activity);
-         }
-      }
-      Redirect("/discussion/comment/{$Comment['CommentID']}#Comment_{$Comment['CommentID']}");
-   }
-
-   public function DiscussionController_QnAOptions_Create($Sender, $DiscussionID = '', $CommentID = '') {
-    if ($DiscussionID)
-        $this->_DiscussionOptions($Sender, $DiscussionID);
-    elseif ($CommentID)
-        $this->_CommentOptions($Sender, $CommentID);
-
-}
-
-   public function RecalculateDiscussionQnA($Discussion) {
-      // Find comments in this discussion with a QnA value.
-      $Set = array();
-
-      $Row = Gdn::SQL()->GetWhere('Comment',
-         array('DiscussionID' => GetValue('DiscussionID', $Discussion), 'QnA is not null' => ''), 'QnA, DateAccepted', 'asc', 1)->FirstRow(DATASET_TYPE_ARRAY);
-
-      if (!$Row) {
-         if (GetValue('CountComments', $Discussion) > 0)
-            $Set['QnA'] = 'Unanswered';
-         else
-            $Set['QnA'] = 'Answered';
-
-         $Set['DateAccepted'] = NULL;
-         $Set['DateOfAnswer'] = NULL;
-      } elseif ($Row['QnA'] == 'Accepted') {
-         $Set['QnA'] = 'Accepted';
-         $Set['DateAccepted'] = $Row['DateAccepted'];
-         $Set['DateOfAnswer'] = $Row['DateInserted'];
-      } elseif ($Row['QnA'] == 'Rejected') {
-         $Set['QnA'] = 'Rejected';
-         $Set['DateAccepted'] = NULL;
-         $Set['DateOfAnswer'] = NULL;
-      }
-
-      Gdn::Controller()->DiscussionModel->SetField(GetValue('DiscussionID', $Discussion), $Set);
-   }
-
-   public function RecalculateUserQnA($UserID) {
-      $CountAcceptedAnswers = Gdn::SQL()->GetCount('Comment', array('InsertUserID' => $UserID, 'QnA' => 'Accepted'));
-      Gdn::UserModel()->SetField($UserID, 'CountAcceptedAnswers', $CountAcceptedAnswers);
-   }
-
-   public function _CommentOptions($Sender, $CommentID) {
-      $Sender->Form = new Gdn_Form();
-
-      $Comment = $Sender->CommentModel->GetID($CommentID, DATASET_TYPE_ARRAY);
-
-      if (!$Comment)
-         throw NotFoundException('Comment');
-
-      $Discussion = $Sender->DiscussionModel->GetID(GetValue('DiscussionID', $Comment));
-
-      $Sender->Permission('Vanilla.Discussions.Edit', TRUE, 'Category', GetValue('PermissionCategoryID', $Discussion));
-
-      if ($Sender->Form->AuthenticatedPostBack()) {
-         $QnA = $Sender->Form->GetFormValue('QnA');
-         if (!$QnA)
-            $QnA = NULL;
-
-         $CurrentQnA = GetValue('QnA', $Comment);
-
-//         ->Column('DateAccepted', 'datetime', TRUE)
-//         ->Column('AcceptedUserID', 'int', TRUE)
-
-         if ($CurrentQnA != $QnA) {
-            $Set = array('QnA' => $QnA);
+        if (isset($QnA)) {
+            $DiscussionSet = array('QnA' => $QnA);
+            $CommentSet = array('QnA' => $QnA);
 
             if ($QnA == 'Accepted') {
-               $Set['DateAccepted'] = Gdn_Format::ToDateTime();
-               $Set['AcceptedUserID'] = Gdn::Session()->UserID;
-            } else {
-               $Set['DateAccepted'] = NULL;
-               $Set['AcceptedUserID'] = NULL;
+                $CommentSet['DateAccepted'] = Gdn_Format::toDateTime();
+                $CommentSet['AcceptedUserID'] = Gdn::session()->UserID;
+
+                if (!$Discussion['DateAccepted']) {
+                    $DiscussionSet['DateAccepted'] = Gdn_Format::toDateTime();
+                    $DiscussionSet['DateOfAnswer'] = $Comment['DateInserted'];
+                }
             }
 
-            $Sender->CommentModel->SetField($CommentID, $Set);
-            $Sender->Form->SetValidationResults($Sender->CommentModel->ValidationResults());
+            // Update the comment.
+            Gdn::SQL()->put('Comment', $CommentSet, array('CommentID' => $Comment['CommentID']));
+
+            // Update the discussion.
+            if ($Discussion['QnA'] != $QnA && (!$Discussion['QnA'] || in_array($Discussion['QnA'], array('Unanswered', 'Answered', 'Rejected')))) {
+                Gdn::SQL()->put(
+                    'Discussion',
+                    $DiscussionSet,
+                    array('DiscussionID' => $Comment['DiscussionID']));
+            }
 
             // Determine QnA change
             if ($Comment['QnA'] != $QnA) {
+                $Change = 0;
+                switch ($QnA) {
+                    case 'Rejected':
+                        $Change = -1;
+                        if ($Comment['QnA'] != 'Accepted') {
+                            $Change = 0;
+                        }
+                        break;
 
-               $Change = 0;
-               switch ($QnA) {
-                  case 'Rejected':
-                     $Change = -1;
-                     if ($Comment['QnA'] != 'Accepted') $Change = 0;
-                     break;
+                    case 'Accepted':
+                        $Change = 1;
+                        break;
 
-                  case 'Accepted':
-                     $Change = 1;
-                     break;
-
-                  default:
-                     if ($Comment['QnA'] == 'Rejected') $Change = 0;
-                     if ($Comment['QnA'] == 'Accepted') $Change = -1;
-                     break;
-               }
-
+                    default:
+                        if ($Comment['QnA'] == 'Rejected') {
+                            $Change = 0;
+                        }
+                        if ($Comment['QnA'] == 'Accepted') {
+                            $Change = -1;
+                        }
+                        break;
+                }
             }
 
             // Apply change effects
             if ($Change) {
+                // Update the user
+                $UserID = val('InsertUserID', $Comment);
+                $this->recalculateUserQnA($UserID);
 
-               // Update the user
-               $UserID = GetValue('InsertUserID', $Comment);
-               $this->RecalculateUserQnA($UserID);
+                // Update reactions
+                if ($this->Reactions) {
+                    include_once(Gdn::controller()->fetchViewLocation('reaction_functions', '', 'plugins/Reactions'));
+                    $Rm = new ReactionModel();
 
-               // Update reactions
-               if ($this->Reactions) {
-                  include_once(Gdn::Controller()->FetchViewLocation('reaction_functions', '', 'plugins/Reactions'));
-                  $Rm = new ReactionModel();
-
-                  // If there's change, reactions will take care of it
-                  $Rm->React('Comment', $Comment['CommentID'], 'AcceptAnswer');
-               }
+                    // If there's change, reactions will take care of it
+                    $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer', null, true);
+                }
             }
 
-         }
+            // Record the activity.
+            if ($QnA == 'Accepted') {
+                $Activity = array(
+                    'ActivityType' => 'AnswerAccepted',
+                    'NotifyUserID' => $Comment['InsertUserID'],
+                    'HeadlineFormat' => '{ActivityUserID,You} accepted {NotifyUserID,your} answer.',
+                    'RecordType' => 'Comment',
+                    'RecordID' => $Comment['CommentID'],
+                    'Route' => commentUrl($Comment, '/'),
+                    'Emailed' => ActivityModel::SENT_PENDING,
+                    'Notified' => ActivityModel::SENT_PENDING,
+                );
 
-         // Recalculate the Q&A status of the discussion.
-         $this->RecalculateDiscussionQnA($Discussion);
+                $ActivityModel = new ActivityModel();
+                $ActivityModel->save($Activity);
+            }
+        }
+        redirect("/discussion/comment/{$Comment['CommentID']}#Comment_{$Comment['CommentID']}");
+    }
 
-         Gdn::Controller()->JsonTarget('', '', 'Refresh');
-      } else {
-         $Sender->Form->SetData($Comment);
-      }
+    public function discussionController_QnAOptions_create($Sender, $DiscussionID = '', $CommentID = '') {
+        if ($DiscussionID) {
+            $this->_discussionOptions($Sender, $DiscussionID);
+        } elseif ($CommentID) {
+            $this->_commentOptions($Sender, $CommentID);
+        }
+    }
 
-      $Sender->SetData('Comment', $Comment);
-      $Sender->SetData('Discussion', $Discussion);
-      $Sender->SetData('_QnAs', array('Accepted' => T('Yes'), 'Rejected' => T('No'), '' => T("Don't know")));
-      $Sender->SetData('Title', T('Q&A Options'));
-      $Sender->Render('CommentOptions', '', 'plugins/QnA');
-   }
+    public function recalculateDiscussionQnA($Discussion) {
+        // Find comments in this discussion with a QnA value.
+        $Set = array();
 
-   protected function _DiscussionOptions($Sender, $DiscussionID) {
-      $Sender->Form = new Gdn_Form();
+        $Row = Gdn::SQL()->getWhere('Comment',
+            array('DiscussionID' => val('DiscussionID', $Discussion), 'QnA is not null' => ''), 'QnA, DateAccepted', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
 
-      $Discussion = $Sender->DiscussionModel->GetID($DiscussionID);
+        if (!$Row) {
+            if (val('CountComments', $Discussion) > 0) {
+                $Set['QnA'] = 'Unanswered';
+            } else {
+                $Set['QnA'] = 'Answered';
+            }
 
-      if (!$Discussion)
-         throw NotFoundException('Discussion');
+            $Set['DateAccepted'] = null;
+            $Set['DateOfAnswer'] = null;
+        } elseif ($Row['QnA'] == 'Accepted') {
+            $Set['QnA'] = 'Accepted';
+            $Set['DateAccepted'] = $Row['DateAccepted'];
+            $Set['DateOfAnswer'] = $Row['DateInserted'];
+        } elseif ($Row['QnA'] == 'Rejected') {
+            $Set['QnA'] = 'Rejected';
+            $Set['DateAccepted'] = null;
+            $Set['DateOfAnswer'] = null;
+        }
 
-      $Sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $Discussion));
+        Gdn::controller()->DiscussionModel->setField(val('DiscussionID', $Discussion), $Set);
+    }
 
-      // Both '' and 'Discussion' denote a discussion type of discussion.
-      if (!GetValue('Type', $Discussion))
-         SetValue('Type', $Discussion, 'Discussion');
+    public function recalculateUserQnA($UserID) {
+        $CountAcceptedAnswers = Gdn::SQL()->getCount('Comment', array('InsertUserID' => $UserID, 'QnA' => 'Accepted'));
+        Gdn::userModel()->setField($UserID, 'CountAcceptedAnswers', $CountAcceptedAnswers);
+    }
 
-      if ($Sender->Form->IsPostBack()) {
-         $Sender->DiscussionModel->SetField($DiscussionID, 'Type', $Sender->Form->GetFormValue('Type'));
+    public function _commentOptions($Sender, $CommentID) {
+        $Sender->Form = new Gdn_Form();
+
+        $Comment = $Sender->CommentModel->getID($CommentID, DATASET_TYPE_ARRAY);
+
+        if (!$Comment) {
+            throw notFoundException('Comment');
+        }
+
+        $Discussion = $Sender->DiscussionModel->getID(val('DiscussionID', $Comment));
+
+        $Sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $Discussion));
+
+        if ($Sender->Form->authenticatedPostBack()) {
+            $QnA = $Sender->Form->getFormValue('QnA');
+            if (!$QnA) {
+                $QnA = null;
+            }
+
+            $CurrentQnA = val('QnA', $Comment);
+
+//         ->Column('DateAccepted', 'datetime', true)
+//         ->Column('AcceptedUserID', 'int', true)
+
+            if ($CurrentQnA != $QnA) {
+                $Set = array('QnA' => $QnA);
+
+                if ($QnA == 'Accepted') {
+                    $Set['DateAccepted'] = Gdn_Format::toDateTime();
+                    $Set['AcceptedUserID'] = Gdn::session()->UserID;
+                } else {
+                    $Set['DateAccepted'] = null;
+                    $Set['AcceptedUserID'] = null;
+                }
+
+                $Sender->CommentModel->setField($CommentID, $Set);
+                $Sender->Form->setValidationResults($Sender->CommentModel->validationResults());
+
+                // Determine QnA change
+                if ($Comment['QnA'] != $QnA) {
+                    $Change = 0;
+                    switch ($QnA) {
+                        case 'Rejected':
+                            $Change = -1;
+                            if ($Comment['QnA'] != 'Accepted') {
+                                $Change = 0;
+                            }
+                            break;
+
+                        case 'Accepted':
+                            $Change = 1;
+                            break;
+
+                        default:
+                            if ($Comment['QnA'] == 'Rejected') {
+                                $Change = 0;
+                            }
+                            if ($Comment['QnA'] == 'Accepted') {
+                                $Change = -1;
+                            }
+                            break;
+                    }
+                }
+
+                // Apply change effects
+                if ($Change) {
+
+                    // Update the user
+                    $UserID = val('InsertUserID', $Comment);
+                    $this->recalculateUserQnA($UserID);
+
+                    // Update reactions
+                    if ($this->Reactions) {
+                        include_once(Gdn::controller()->fetchViewLocation('reaction_functions', '', 'plugins/Reactions'));
+                        $Rm = new ReactionModel();
+
+                        // If there's change, reactions will take care of it
+                        $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer');
+                    }
+                }
+            }
+
+            // Recalculate the Q&A status of the discussion.
+            $this->recalculateDiscussionQnA($Discussion);
+
+            Gdn::controller()->jsonTarget('', '', 'Refresh');
+        } else {
+            $Sender->Form->setData($Comment);
+        }
+
+        $Sender->setData('Comment', $Comment);
+        $Sender->setData('Discussion', $Discussion);
+        $Sender->setData('_QnAs', array('Accepted' => t('Yes'), 'Rejected' => t('No'), '' => t("Don't know")));
+        $Sender->setData('Title', t('Q&A Options'));
+        $Sender->render('CommentOptions', '', 'plugins/QnA');
+    }
+
+    protected function _discussionOptions($Sender, $DiscussionID) {
+        $Sender->Form = new Gdn_Form();
+
+        $Discussion = $Sender->DiscussionModel->getID($DiscussionID);
+
+        if (!$Discussion) {
+            throw notFoundException('Discussion');
+        }
+
+        $Sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $Discussion));
+
+        // Both '' and 'Discussion' denote a discussion type of discussion.
+        if (!val('Type', $Discussion)) {
+            setValue('Type', $Discussion, 'Discussion');
+        }
+
+        if ($Sender->Form->isPostBack()) {
+            $Sender->DiscussionModel->setField($DiscussionID, 'Type', $Sender->Form->getFormValue('Type'));
 //         $Form = new Gdn_Form();
-         $Sender->Form->SetValidationResults($Sender->DiscussionModel->ValidationResults());
+            $Sender->Form->setValidationResults($Sender->DiscussionModel->validationResults());
 
 //         if ($Sender->DeliveryType() == DELIVERY_TYPE_ALL || $Redirect)
 //            $Sender->RedirectUrl = Gdn::Controller()->Request->PathAndQuery();
-         Gdn::Controller()->JsonTarget('', '', 'Refresh');
-      } else {
-         $Sender->Form->SetData($Discussion);
-      }
+            Gdn::controller()->jsonTarget('', '', 'Refresh');
+        } else {
+            $Sender->Form->setData($Discussion);
+        }
 
-      $Sender->SetData('Discussion', $Discussion);
-      $Sender->SetData('_Types', array('Question' => '@'.T('Question Type', 'Question'), 'Discussion' => '@'.T('Discussion Type', 'Discussion')));
-      $Sender->SetData('Title', T('Q&A Options'));
-      $Sender->Render('DiscussionOptions', '', 'plugins/QnA');
-   }
+        $Sender->setData('Discussion', $Discussion);
+        $Sender->setData('_Types', array('Question' => '@'.t('Question Type', 'Question'), 'Discussion' => '@'.t('Discussion Type', 'Discussion')));
+        $Sender->setData('Title', t('Q&A Options'));
+        $Sender->render('DiscussionOptions', '', 'plugins/QnA');
+    }
 
-   public function DiscussionModel_BeforeGet_Handler($Sender, $Args) {
-      if (Gdn::Controller()) {
-         $Unanswered = Gdn::Controller()->ClassName == 'DiscussionsController' && Gdn::Controller()->RequestMethod == 'unanswered';
+    public function discussionModel_beforeGet_handler($Sender, $Args) {
+        if (Gdn::controller()) {
+            $Unanswered = Gdn::controller()->ClassName == 'DiscussionsController' && Gdn::controller()->RequestMethod == 'unanswered';
 
-         if ($Unanswered) {
-            $Args['Wheres']['Type'] = 'Question';
-            $Sender->SQL->WhereIn('d.QnA', array('Unanswered', 'Rejected'));
-            Gdn::Controller()->Title('Unanswered Questions');
-         } elseif ($QnA = Gdn::Request()->Get('qna')) {
-            $Args['Wheres']['QnA'] = $QnA;
-         }
-      }
-   }
-
-   /**
-    *
-    * @param DiscussionModel $Sender
-    * @param array $Args
-    */
-   public function DiscussionModel_BeforeSaveDiscussion_Handler($Sender, $Args) {
-//      $Sender->Validation->ApplyRule('Type', 'Required', T('Choose whether you want to ask a question or start a discussion.'));
-
-      $Post =& $Args['FormPostValues'];
-      if ($Args['Insert'] && GetValue('Type', $Post) == 'Question') {
-         $Post['QnA'] = 'Unanswered';
-      }
-   }
-
-   /* New Html method of adding to discussion filters */
-   public function Base_AfterDiscussionFilters_Handler($Sender) {
-      $Count = Gdn::Cache()->Get('QnA-UnansweredCount');
-      if ($Count === Gdn_Cache::CACHEOP_FAILURE)
-         $Count = ' <span class="Aside"><span class="Popin Count" rel="/discussions/unansweredcount"></span>';
-      else
-         $Count = ' <span class="Aside"><span class="Count">'.$Count.'</span></span>';
-
-      echo '<li class="QnA-UnansweredQuestions '.($Sender->RequestMethod == 'unanswered' ? ' Active' : '').'">'
-			.Anchor(Sprite('SpUnansweredQuestions').' '.T('Unanswered').$Count, '/discussions/unanswered', 'UnansweredQuestions')
-		.'</li>';
-   }
-
-   /* Old Html method of adding to discussion filters */
-   public function DiscussionsController_AfterDiscussionTabs_Handler($Sender, $Args) {
-      if (StringEndsWith(Gdn::Request()->Path(), '/unanswered', TRUE))
-         $CssClass = ' class="Active"';
-      else
-         $CssClass = '';
-
-      $Count = Gdn::Cache()->Get('QnA-UnansweredCount');
-      if ($Count === Gdn_Cache::CACHEOP_FAILURE)
-         $Count = ' <span class="Popin Count" rel="/discussions/unansweredcount">';
-      else
-         $Count = ' <span class="Count">'.$Count.'</span>';
-
-      echo '<li'.$CssClass.'><a class="TabLink QnA-UnansweredQuestions" href="'.Url('/discussions/unanswered').'">'.T('Unanswered Questions', 'Unanswered').$Count.'</span></a></li>';
-   }
-
-   /**
-    * @param DiscussionsController $Sender
-    * @param array $Args
-    */
-   public function DiscussionsController_Unanswered_Create($Sender, $Args = array()) {
-      $Sender->View = 'Index';
-      $Sender->SetData('_PagerUrl', 'discussions/unanswered/{Page}');
-      $Sender->Index(GetValue(0, $Args, 'p1'));
-      $this->InUnanswered = TRUE;
-   }
-
-   public function DiscussionsController_BeforeBuildPager_Handler($Sender, &$Args = array()) {
-      if (Gdn::Controller()->RequestMethod == 'unanswered') {
-         $Count = $this->GetUnansweredCount();
-         $Sender->SetData('CountDiscussions', $Count);
-      }
-   }
-
-   public function GetUnansweredCount() {
-      $Count = Gdn::Cache()->Get('QnA-UnansweredCount');
-      if ($Count === Gdn_Cache::CACHEOP_FAILURE) {
-         Gdn::SQL()->WhereIn('QnA', array('Unanswered', 'Rejected'));
-         $Count = Gdn::SQL()->GetCount('Discussion', array('Type' => 'Question'));
-         Gdn::Cache()->Store('QnA-UnansweredCount', $Count, array(Gdn_Cache::FEATURE_EXPIRY => 15 * 60));
-      }
-      return $Count;
-   }
-
-   /**
-    *
-    * @param DiscussionsController $Sender
-    * @param type $Args
-    */
-   public function DiscussionsController_Unanswered_Render($Sender, $Args) {
-      $Sender->SetData('CountDiscussions', FALSE);
-
-      // Add 'Ask a Question' button if using BigButtons.
-      if (C('Plugins.QnA.UseBigButtons')) {
-         $QuestionModule = new NewQuestionModule($Sender, 'plugins/QnA');
-         $Sender->AddModule($QuestionModule);
-      }
-
-      // Remove announcements that aren't questions...
-      if (is_a($Sender->Data('Announcements'), 'Gdn_DataSet')) {
-         $Sender->Data('Announcements')->Result();
-         $Announcements = array();
-         foreach ($Sender->Data('Announcements') as $i => $Row) {
-            if (GetValue('Type', $Row) == 'Question')
-               $Announcements[] = $Row;
-         }
-         Trace($Announcements);
-         $Sender->SetData('Announcements', $Announcements);
-         $Sender->AnnounceData = $Announcements;
-      }
-   }
+            if ($Unanswered) {
+                $Args['Wheres']['Type'] = 'Question';
+                $Sender->SQL->whereIn('d.QnA', array('Unanswered', 'Rejected'));
+                Gdn::controller()->title('Unanswered Questions');
+            } elseif ($QnA = Gdn::request()->get('qna')) {
+                $Args['Wheres']['QnA'] = $QnA;
+            }
+        }
+    }
 
     /**
-    * @param DiscussionsController $Sender
-    * @param array $Args
-    */
-   public function DiscussionsController_UnansweredCount_Create($Sender, $Args = array()) {
-      $Count = $this->GetUnansweredCount();
+     *
+     * @param DiscussionModel $Sender
+     * @param array $Args
+     */
+    public function discussionModel_beforeSaveDiscussion_handler($Sender, $Args) {
+        //      $Sender->Validation->ApplyRule('Type', 'Required', T('Choose whether you want to ask a question or start a discussion.'));
 
-      $Sender->SetData('UnansweredCount', $Count);
-      $Sender->SetData('_Value', $Count);
-      $Sender->Render('Value', 'Utility', 'Dashboard');
-   }
+        $Post =& $Args['FormPostValues'];
+        if ($Args['Insert'] && val('Type', $Post) == 'Question') {
+            $Post['QnA'] = 'Unanswered';
+        }
+    }
 
-   public function Base_BeforeDiscussionMeta_Handler($Sender, $Args) {
-      $Discussion = $Args['Discussion'];
+    /* New Html method of adding to discussion filters */
+    public function base_afterDiscussionFilters_handler($Sender) {
+        $Count = Gdn::cache()->get('QnA-UnansweredCount');
+        if ($Count === Gdn_Cache::CACHEOP_FAILURE) {
+            $Count = ' <span class="Aside"><span class="Popin Count" rel="/discussions/unansweredcount"></span>';
+        } else {
+            $Count = ' <span class="Aside"><span class="Count">'.$Count.'</span></span>';
+        }
 
-      if (strtolower(GetValue('Type', $Discussion)) != 'question')
-         return;
+        echo '<li class="QnA-UnansweredQuestions '.($Sender->RequestMethod == 'unanswered' ? ' Active' : '').'">'
+            .anchor(sprite('SpUnansweredQuestions').' '.t('Unanswered').$Count, '/discussions/unanswered', 'UnansweredQuestions')
+            .'</li>';
+    }
 
-      $QnA = GetValue('QnA', $Discussion);
-      $Title = '';
-      switch ($QnA) {
-         case '':
-         case 'Unanswered':
-         case 'Rejected':
-            $Text = 'Question';
-            $QnA = 'Question';
-            break;
-         case 'Answered':
-            $Text = 'Answered';
-            if (GetValue('InsertUserID', $Discussion) == Gdn::Session()->UserID) {
-               $QnA = 'Answered';
-               $Title = ' title="'.T("Someone's answered your question. You need to accept/reject the answer.").'"';
+    /* Old Html method of adding to discussion filters */
+    public function discussionsController_afterDiscussionTabs_handler($Sender, $Args) {
+        if (stringEndsWith(Gdn::request()->path(), '/unanswered', true)) {
+            $CssClass = ' class="Active"';
+        } else {
+            $CssClass = '';
+        }
+
+        $Count = Gdn::cache()->get('QnA-UnansweredCount');
+        if ($Count === Gdn_Cache::CACHEOP_FAILURE) {
+            $Count = ' <span class="Popin Count" rel="/discussions/unansweredcount">';
+        } else {
+            $Count = ' <span class="Count">'.$Count.'</span>';
+        }
+
+        echo '<li'.$CssClass.'><a class="TabLink QnA-UnansweredQuestions" href="'.url('/discussions/unanswered').'">'.t('Unanswered Questions', 'Unanswered').$Count.'</span></a></li>';
+    }
+
+    /**
+     * @param DiscussionsController $Sender
+     * @param array $Args
+     */
+    public function discussionsController_unanswered_create($Sender, $Args = array()) {
+        $Sender->View = 'Index';
+        $Sender->setData('_PagerUrl', 'discussions/unanswered/{Page}');
+        $Sender->index(val(0, $Args, 'p1'));
+        $this->InUnanswered = true;
+    }
+
+    public function discussionsController_beforeBuildPager_handler($Sender, &$Args = array()) {
+        if (Gdn::controller()->RequestMethod == 'unanswered') {
+            $Count = $this->getUnansweredCount();
+            $Sender->setData('CountDiscussions', $Count);
+        }
+    }
+
+    public function getUnansweredCount() {
+        $Count = Gdn::cache()->get('QnA-UnansweredCount');
+        if ($Count === Gdn_Cache::CACHEOP_FAILURE) {
+            Gdn::SQL()->whereIn('QnA', array('Unanswered', 'Rejected'));
+            $Count = Gdn::SQL()->getCount('Discussion', array('Type' => 'Question'));
+            Gdn::cache()->store('QnA-UnansweredCount', $Count, array(Gdn_Cache::FEATURE_EXPIRY => 15 * 60));
+        }
+        return $Count;
+    }
+
+    /**
+     *
+     * @param DiscussionsController $Sender
+     * @param type $Args
+     */
+    public function discussionsController_unanswered_render($Sender, $Args) {
+        $Sender->setData('CountDiscussions', false);
+
+        // Add 'Ask a Question' button if using BigButtons.
+        if (c('Plugins.QnA.UseBigButtons')) {
+            $QuestionModule = new NewQuestionModule($Sender, 'plugins/QnA');
+            $Sender->addModule($QuestionModule);
+        }
+
+        // Remove announcements that aren't questions...
+        if (is_a($Sender->data('Announcements'), 'Gdn_DataSet')) {
+            $Sender->data('Announcements')->result();
+            $Announcements = array();
+            foreach ($Sender->data('Announcements') as $i => $Row) {
+                if (val('Type', $Row) == 'Question') {
+                    $Announcements[] = $Row;
+                }
             }
-            break;
-         case 'Accepted':
-            $Text = 'Answered';
-            $Title = ' title="'.T("This question's answer has been accepted.").'"';
-            break;
-         default:
-            $QnA = FALSE;
-      }
-      if ($QnA) {
-         echo ' <span class="Tag QnA-Tag-'.$QnA.'"'.$Title.'>'.T("Q&A $QnA", $Text).'</span> ';
-      }
-   }
+            trace($Announcements);
+            $Sender->setData('Announcements', $Announcements);
+            $Sender->AnnounceData = $Announcements;
+        }
+    }
 
-   /**
-    * @param Gdn_Controller $Sender
-    * @param array $Args
-    */
-   public function NotificationsController_BeforeInformNotifications_Handler($Sender, $Args) {
-      $Path = trim($Sender->Request->GetValue('Path'), '/');
-      if (preg_match('`^(vanilla/)?discussion[^s]`i', $Path))
-         return;
+    /**
+     * @param DiscussionsController $Sender
+     * @param array $Args
+     */
+    public function discussionsController_unansweredCount_create($Sender, $Args = array()) {
+        $Count = $this->getUnansweredCount();
 
-      // Check to see if the user has answered questions.
-      $Count = Gdn::SQL()->GetCount('Discussion', array('Type' => 'Question', 'InsertUserID' => Gdn::Session()->UserID, 'QnA' => 'Answered'));
-      if ($Count > 0) {
-         $Sender->InformMessage(FormatString(T("You've asked questions that have now been answered", "<a href=\"{/discussions/mine?qna=Answered,url}\">You've asked questions that now have answers</a>. Make sure you accept/reject the answers.")), 'Dismissable');
-      }
-   }
+        $Sender->setData('UnansweredCount', $Count);
+        $Sender->setData('_Value', $Count);
+        $Sender->render('Value', 'Utility', 'Dashboard');
+    }
 
-   /**
-    * Add 'Ask a Question' button if using BigButtons.
-    */
-   public function CategoriesController_Render_Before($Sender) {
-      if (C('Plugins.QnA.UseBigButtons')) {
-         $QuestionModule = new NewQuestionModule($Sender, 'plugins/QnA');
-         $Sender->AddModule($QuestionModule);
-      }
-   }
+    public function base_beforeDiscussionMeta_handler($Sender, $Args) {
+        $Discussion = $Args['Discussion'];
 
-   /**
-    * Add 'Ask a Question' button if using BigButtons.
-    */
-   public function DiscussionController_Render_Before($Sender) {
-      if (C('Plugins.QnA.UseBigButtons')) {
-         $QuestionModule = new NewQuestionModule($Sender, 'plugins/QnA');
-         $Sender->AddModule($QuestionModule);
-      }
+        if (strtolower(val('Type', $Discussion)) != 'question') {
+            return;
+        }
 
-      if ($Sender->Data('Discussion.Type') == 'Question') {
-         $Sender->SetData('_CommentsHeader', T('Answers'));
-      }
-   }
+        $QnA = val('QnA', $Discussion);
+        $Title = '';
+        switch ($QnA) {
+            case '':
+            case 'Unanswered':
+            case 'Rejected':
+                $Text = 'Question';
+                $QnA = 'Question';
+                break;
+            case 'Answered':
+                $Text = 'Answered';
+                if (val('InsertUserID', $Discussion) == Gdn::session()->UserID) {
+                    $QnA = 'Answered';
+                    $Title = ' title="'.t("Someone's answered your question. You need to accept/reject the answer.").'"';
+                }
+                break;
+            case 'Accepted':
+                $Text = 'Answered';
+                $Title = ' title="'.t("This question's answer has been accepted.").'"';
+                break;
+            default:
+                $QnA = false;
+        }
+        if ($QnA) {
+            echo ' <span class="Tag QnA-Tag-'.$QnA.'"'.$Title.'>'.t("Q&A $QnA", $Text).'</span> ';
+        }
+    }
+
+    /**
+     * @param Gdn_Controller $Sender
+     * @param array $Args
+     */
+    public function notificationsController_beforeInformNotifications_handler($Sender, $Args) {
+        $Path = trim($Sender->Request->getValue('Path'), '/');
+        if (preg_match('`^(vanilla/)?discussion[^s]`i', $Path)) {
+            return;
+        }
+
+        // Check to see if the user has answered questions.
+        $Count = Gdn::SQL()->getCount('Discussion', array('Type' => 'Question', 'InsertUserID' => Gdn::session()->UserID, 'QnA' => 'Answered'));
+        if ($Count > 0) {
+            $Sender->informMessage(formatString(t("You've asked questions that have now been answered", "<a href=\"{/discussions/mine?qna=Answered,url}\">You've asked questions that now have answers</a>. Make sure you accept/reject the answers.")), 'Dismissable');
+        }
+    }
+
+    /**
+     * Add 'Ask a Question' button if using BigButtons.
+     */
+    public function categoriesController_render_before($Sender) {
+        if (c('Plugins.QnA.UseBigButtons')) {
+            $QuestionModule = new NewQuestionModule($Sender, 'plugins/QnA');
+            $Sender->addModule($QuestionModule);
+        }
+    }
+
+    /**
+     * Add 'Ask a Question' button if using BigButtons.
+     */
+    public function discussionController_render_before($Sender) {
+        if (c('Plugins.QnA.UseBigButtons')) {
+            $QuestionModule = new NewQuestionModule($Sender, 'plugins/QnA');
+            $Sender->addModule($QuestionModule);
+        }
+
+        if ($Sender->data('Discussion.Type') == 'Question') {
+            $Sender->setData('_CommentsHeader', t('Answers'));
+        }
+    }
 
 
-   /**
-    * Add the "new question" option to the new discussion button group dropdown.
-    */
+    /**
+     * Add the "new question" option to the new discussion button group dropdown.
+     */
 //   public function Base_BeforeNewDiscussionButton_Handler($Sender) {
 //      $NewDiscussionModule = &$Sender->EventArguments['NewDiscussionModule'];
 //
@@ -999,41 +1037,41 @@ class QnAPlugin extends Gdn_Plugin {
 //      $NewDiscussionModule->AddButton(T('Ask a Question'), 'post/question'.$Category);
 //   }
 
-   /**
-    * Add the question form to vanilla's post page.
-    */
-   public function PostController_AfterForms_Handler($Sender) {
-      $Forms = $Sender->Data('Forms');
-      $Forms[] = array('Name' => 'Question', 'Label' => Sprite('SpQuestion').T('Ask a Question'), 'Url' => 'post/question');
-		$Sender->SetData('Forms', $Forms);
-   }
+    /**
+     * Add the question form to vanilla's post page.
+     */
+    public function postController_afterForms_handler($Sender) {
+        $Forms = $Sender->data('Forms');
+        $Forms[] = array('Name' => 'Question', 'Label' => sprite('SpQuestion').t('Ask a Question'), 'Url' => 'post/question');
+        $Sender->setData('Forms', $Forms);
+    }
 
-   /**
-    * Create the new question method on post controller.
-    */
-   public function PostController_Question_Create($Sender, $CategoryUrlCode = '') {
-      // Create & call PostController->Discussion()
-      $Sender->View = PATH_PLUGINS.'/QnA/views/post.php';
-      $Sender->SetData('Type', 'Question');
-      $Sender->Discussion($CategoryUrlCode);
-   }
+    /**
+     * Create the new question method on post controller.
+     */
+    public function postController_question_create($Sender, $CategoryUrlCode = '') {
+        // Create & call PostController->Discussion()
+        $Sender->View = PATH_PLUGINS.'/QnA/views/post.php';
+        $Sender->setData('Type', 'Question');
+        $Sender->discussion($CategoryUrlCode);
+    }
 
-   /**
-    * Override the PostController->Discussion() method before render to use our view instead.
-    */
-   public function PostController_BeforeDiscussionRender_Handler($Sender) {
-      // Override if we are looking at the question url.
-      if ($Sender->RequestMethod == 'question') {
-         $Sender->Form->AddHidden('Type', 'Question');
-         $Sender->Title(T('Ask a Question'));
-         $Sender->SetData('Breadcrumbs', array(array('Name' => $Sender->Data('Title'), 'Url' => '/post/question')));
-      }
-   }
+    /**
+     * Override the PostController->Discussion() method before render to use our view instead.
+     */
+    public function postController_beforeDiscussionRender_handler($Sender) {
+        // Override if we are looking at the question url.
+        if ($Sender->RequestMethod == 'question') {
+            $Sender->Form->addHidden('Type', 'Question');
+            $Sender->title(t('Ask a Question'));
+            $Sender->setData('Breadcrumbs', array(array('Name' => $Sender->data('Title'), 'Url' => '/post/question')));
+        }
+    }
 
-   /**
-    * Add 'New Question Form' location to Messages.
-    */
-   public function MessageController_AfterGetLocationData_Handler($Sender, $Args) {
-      $Args['ControllerData']['Vanilla/Post/Question'] = T('New Question Form');
-   }
+    /**
+     * Add 'New Question Form' location to Messages.
+     */
+    public function messageController_afterGetLocationData_handler($Sender, $Args) {
+        $Args['ControllerData']['Vanilla/Post/Question'] = t('New Question Form');
+    }
 }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -45,9 +45,9 @@ class QnAPlugin extends Gdn_Plugin {
     public function setup() {
         $this->structure();
 
-        touchConfig('QnA.IsPointsAwardEnabled', false);
-        touchConfig('QnA.PointsPerAnswer', 1);
-        touchConfig('QnA.PointsPerAcceptedAnswer', 1);
+        touchConfig('QnA.Points.Enabled', false);
+        touchConfig('QnA.Points.Answer', 1);
+        touchConfig('QnA.Points.AcceptedAnswer', 1);
     }
 
     public function structure() {
@@ -236,9 +236,9 @@ class QnAPlugin extends Gdn_Plugin {
         $validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
         $configurationModel->setField(array(
-            'QnA.IsPointsAwardEnabled' => c('QnA.IsPointsAwardEnabled', false),
-            'QnA.PointsPerAnswer' => c('QnA.PointsPerAnswer', 1),
-            'QnA.PointsPerAcceptedAnswer' => c('QnA.PointsPerAcceptedAnswer', 1),
+            'QnA.Points.Enabled' => c('QnA.Points.Enabled', false),
+            'QnA.Points.Answer' => c('QnA.Points.Answer', 1),
+            'QnA.Points.AcceptedAnswer' => c('QnA.Points.AcceptedAnswer', 1),
         ));
         $sender->Form->setModel($configurationModel);
 
@@ -246,20 +246,20 @@ class QnAPlugin extends Gdn_Plugin {
         if ($sender->Form->authenticatedPostBack() === false) {
             $sender->Form->setData($configurationModel->Data);
         } else {
-            $configurationModel->Validation->applyRule('QnA.IsPointsAwardEnabled', 'Boolean');
+            $configurationModel->Validation->applyRule('QnA.Points.Enabled', 'Boolean');
 
-            if ($sender->Form->getFormValue('QnA.IsPointsAwardEnabled')) {
-                $configurationModel->Validation->applyRule('QnA.PointsPerAnswer', 'Required');
-                $configurationModel->Validation->applyRule('QnA.PointsPerAnswer', 'Integer');
+            if ($sender->Form->getFormValue('QnA.Points.Enabled')) {
+                $configurationModel->Validation->applyRule('QnA.Points.Answer', 'Required');
+                $configurationModel->Validation->applyRule('QnA.Points.Answer', 'Integer');
 
-                $configurationModel->Validation->applyRule('QnA.PointsPerAcceptedAnswer', 'Required');
-                $configurationModel->Validation->applyRule('QnA.PointsPerAcceptedAnswer', 'Integer');
+                $configurationModel->Validation->applyRule('QnA.Points.AcceptedAnswer', 'Required');
+                $configurationModel->Validation->applyRule('QnA.Points.AcceptedAnswer', 'Integer');
 
-                if ($sender->Form->getFormValue('QnA.PointsPerAnswer') < 0) {
-                    $sender->Form->setFormValue('QnA.PointsPerAnswer', 0);
+                if ($sender->Form->getFormValue('QnA.Points.Answer') < 0) {
+                    $sender->Form->setFormValue('QnA.Points.Answer', 0);
                 }
-                if ($sender->Form->getFormValue('QnA.PointsPerAcceptedAnswer') < 0) {
-                    $sender->Form->setFormValue('QnA.PointsPerAcceptedAnswer', 0);
+                if ($sender->Form->getFormValue('QnA.Points.AcceptedAnswer') < 0) {
+                    $sender->Form->setFormValue('QnA.Points.AcceptedAnswer', 0);
                 }
             }
 
@@ -670,8 +670,8 @@ class QnAPlugin extends Gdn_Plugin {
                     case 'Accepted':
                         $Change = 1;
 
-                        if (c('QnA.IsPointsAwardEnabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
-                            UserModel::givePoints($Comment['InsertUserID'], c('QnA.PointsPerAcceptedAnswer', 1), 'QnA');
+                        if (c('QnA.Points.Enabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
+                            UserModel::givePoints($Comment['InsertUserID'], c('QnA.Points.AcceptedAnswer', 1), 'QnA');
                         }
                         break;
 
@@ -1163,19 +1163,21 @@ class QnAPlugin extends Gdn_Plugin {
      * @param $args Event arguments.
      */
     public function commentModel_afterSaveComment_handler($sender, $args) {
-        if (!c('QnA.IsPointsAwardEnabled', false) || !$args['Insert']) {
+        if (!c('QnA.Points.Enabled', false) || !$args['Insert']) {
             return;
         }
 
-        $discussion = (new DiscussionModel())->getID($args['CommentData']['DiscussionID'], DATASET_TYPE_ARRAY);
-        // If the comment is not an answer to a question
-        // or if the question already have an accepted answer
-        // or if the original poster comments on its own question, abort.
-        if ($discussion['Type'] !== 'Question' || $discussion['QnA'] === 'Accepted' || $discussion['InsertUserID'] == GDN::session()->UserID) {
+        $discussionModel = new DiscussionModel();
+        $discussion = $discussionModel->getID($args['CommentData']['DiscussionID'], DATASET_TYPE_ARRAY);
+
+        $isCommentAnAnswer = $discussion['Type'] === 'Question';
+        $isQuestionResolved = $discussion['QnA'] === 'Accepted';
+        $isCurrentUserOriginalPoster = $discussion['InsertUserID'] == GDN::session()->UserID;
+        if (!$isCommentAnAnswer || $isQuestionResolved || $isCurrentUserOriginalPoster) {
             return;
         }
 
-        $userAnswersToQuestion = (new CommentModel())->getWhere(array(
+        $userAnswersToQuestion = $sender->getWhere(array(
             'DiscussionID' => $args['CommentData']['DiscussionID'],
             'InsertUserId' => GDN::session()->UserID,
         ));
@@ -1184,6 +1186,6 @@ class QnAPlugin extends Gdn_Plugin {
             return;
         }
 
-        UserModel::givePoints(GDN::session()->UserID, c('QnA.PointsPerAnswer', 1), 'QnA');
+        UserModel::givePoints(GDN::session()->UserID, c('QnA.Points.Answer', 1), 'QnA');
     }
 }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -281,7 +281,7 @@ class QnAPlugin extends Gdn_Plugin {
         $sender->title(sprintf(t('%s settings'), t('Q&A')));
         $sender->addSideMenu('settings/QnA');
         $sender->Form = new Gdn_Form();
-        $this->dispatch($sender, $sender->RequestArgs);
+        $this->controller_index($sender);
     }
 
     /**

--- a/plugins/QnA/js/QnA.js
+++ b/plugins/QnA/js/QnA.js
@@ -1,0 +1,11 @@
+(function($) {
+    $(function() {
+        $('#IsPointsAwardEnabled').change(function() {
+            if ($(this).prop('checked')) {
+                $('.PointAwardsInputs').show().find('input').prop('disabled', false);
+            } else {
+                $('.PointAwardsInputs').hide().find('input').prop('disabled', true);
+            }
+        });
+    });
+})(jQuery);

--- a/plugins/QnA/js/QnA.js
+++ b/plugins/QnA/js/QnA.js
@@ -6,6 +6,6 @@
             } else {
                 $('.PointAwardsInputs').hide().find('input').prop('disabled', true);
             }
-        });
+        }).change();
     });
 })(jQuery);

--- a/plugins/QnA/locale/en.php
+++ b/plugins/QnA/locale/en.php
@@ -1,4 +1,4 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php if (!defined('APPLICATION')) { exit(); }
 
 // Discussion / Question
 $Definition['Activity.QuestionAnswer.FullHeadline'] = '%1$s answered %4$s %8$s.';

--- a/plugins/QnA/modules/class.newquestionmodule.php
+++ b/plugins/QnA/modules/class.newquestionmodule.php
@@ -1,4 +1,4 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php if (!defined('APPLICATION')) { exit(); }
 
 /**
  * Garden.Modules
@@ -9,13 +9,14 @@
  */
 class NewQuestionModule extends Gdn_Module {
 
-   public function AssetTarget() {
-      return 'Panel';
-   }
-   
-   public function ToString() {
-      $HasPermission = Gdn::Session()->CheckPermission('Vanilla.Discussions.Add', TRUE, 'Category', 'any');
-      if ($HasPermission)
-         echo Anchor(T('Ask a Question'), '/post/discussion?Type=Question', 'Button BigButton NewQuestion');
-   }
+    public function assetTarget() {
+        return 'Panel';
+    }
+
+    public function toString() {
+        $HasPermission = Gdn::session()->checkPermission('Vanilla.Discussions.Add', true, 'Category', 'any');
+        if ($HasPermission) {
+            echo anchor(t('Ask a Question'), '/post/discussion?Type=Question', 'Button BigButton NewQuestion');
+        }
+    }
 }

--- a/plugins/QnA/views/answers.php
+++ b/plugins/QnA/views/answers.php
@@ -1,12 +1,12 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
+<?php if (!defined('APPLICATION')) { exit(); } ?>
 <div class="DataBox DataBox-AcceptedAnswers"><span id="accepted"></span>
-   <h2 class="CommentHeading"><?php echo Plural(count($Sender->Data('Answers')), 'Best Answer', 'Best Answers'); ?></h2>
-   <ul class="MessageList DataList AcceptedAnswers">
-      <?php
-      foreach($Sender->Data('Answers') as $Row) {
-         $Sender->EventArguments['Comment'] = $Row;
-         WriteComment($Row, $Sender, Gdn::Session(), 0);
-      }
-      ?>
-   </ul>
+    <h2 class="CommentHeading"><?php echo plural(count($Sender->data('Answers')), 'Best Answer', 'Best Answers'); ?></h2>
+    <ul class="MessageList DataList AcceptedAnswers">
+        <?php
+        foreach ($Sender->data('Answers') as $Row) {
+            $Sender->EventArguments['Comment'] = $Row;
+            writeComment($Row, $Sender, Gdn::session(), 0);
+        }
+        ?>
+    </ul>
 </div>

--- a/plugins/QnA/views/commentoptions.php
+++ b/plugins/QnA/views/commentoptions.php
@@ -1,24 +1,24 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
-<h1><?php echo $this->Data('Title') ?></h1>
+<?php if (!defined('APPLICATION')) { exit(); } ?>
+<h1><?php echo $this->data('Title') ?></h1>
 <div class="">
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 
 <div class="P">
-   <?php
-     echo '<i>'.T('Did this answer the question?').'</i>';
-     echo $this->Form->GetFormValue('QnA');
-     echo $this->Form->RadioList('QnA', $this->Data('_QnAs'), array('list' => TRUE));
-   ?>
+    <?php
+    echo '<i>'.t('Did this answer the question?').'</i>';
+    echo $this->Form->getFormValue('QnA');
+    echo $this->Form->radioList('QnA', $this->data('_QnAs'), array('list' => true));
+    ?>
 </div>
-   
+
 <?php
-echo '<div class="Buttons Buttons-Confirm">', 
-   $this->Form->Button(T('OK')), ' ',
-   $this->Form->Button(T('Cancel'), array('type' => 'button', 'class' => 'Button Close')),
-   '</div>';
-echo $this->Form->Close();
+echo '<div class="Buttons Buttons-Confirm">',
+    $this->Form->button(t('OK')), ' ',
+    $this->Form->button(t('Cancel'), array('type' => 'button', 'class' => 'Button Close')),
+    '</div>';
+echo $this->Form->close();
 ?>
 </div>

--- a/plugins/QnA/views/configuration.php
+++ b/plugins/QnA/views/configuration.php
@@ -23,7 +23,7 @@ echo $this->Form->errors();
         echo $this->Form->checkBox('QnA.IsPointsAwardEnabled', t('Enables points award. This will gives users points for answering questions.'), $checkBoxAttributes);
     ?></li>
     <li class="PointAwardsInputs"<?php echo $pointsAwardEnabled ? null : ' style="display:none;"'?>><?php
-        echo $this->Form->label(t('Point(s) per answer'), 'QnA.PointsPerAnswer');
+        echo $this->Form->label(t('Point(s) per answer (Only the first user\'s answer to a question will award points)'), 'QnA.PointsPerAnswer');
         echo $this->Form->textBox('QnA.PointsPerAnswer', $textBoxAttributes);
     ?></li>
     <li class="PointAwardsInputs"<?php echo $pointsAwardEnabled ? null : ' style="display:none;"'?>><?php

--- a/plugins/QnA/views/configuration.php
+++ b/plugins/QnA/views/configuration.php
@@ -8,7 +8,7 @@ echo $this->Form->errors();
 ?>
 <ul>
     <li><?php
-        $pointsAwardEnabled = c('QnA.IsPointsAwardEnabled');
+        $pointsAwardEnabled = c('QnA.Points.Enabled');
 
         $textBoxAttributes = array();
         $checkBoxAttributes = array(
@@ -20,15 +20,16 @@ echo $this->Form->errors();
         } else {
             $textBoxAttributes['disabled'] = true;
         }
-        echo $this->Form->checkBox('QnA.IsPointsAwardEnabled', t('Enables points award. This will gives users points for answering questions.'), $checkBoxAttributes);
+
+        echo $this->Form->checkBox('QnA.Points.Enabled', t('Enables points award. This will gives users points for answering questions.'), $checkBoxAttributes);
     ?></li>
     <li class="PointAwardsInputs"<?php echo $pointsAwardEnabled ? null : ' style="display:none;"'?>><?php
-        echo $this->Form->label(t('Point(s) per answer (Only the first user\'s answer to a question will award points)'), 'QnA.PointsPerAnswer');
-        echo $this->Form->textBox('QnA.PointsPerAnswer', $textBoxAttributes);
+        echo $this->Form->label(t('Point(s) per answer (Only the first user\'s answer to a question will award points)'), 'QnA.Points.Answer');
+        echo $this->Form->textBox('QnA.Points.Answer', $textBoxAttributes);
     ?></li>
     <li class="PointAwardsInputs"<?php echo $pointsAwardEnabled ? null : ' style="display:none;"'?>><?php
-        echo $this->Form->label(t('Points per accepted answer'), 'QnA.PointsPerAcceptedAnswer');
-        echo $this->Form->textBox('QnA.PointsPerAcceptedAnswer', $textBoxAttributes);
+        echo $this->Form->label(t('Points per accepted answer'), 'QnA.Points.AcceptedAnswer');
+        echo $this->Form->textBox('QnA.Points.AcceptedAnswer', $textBoxAttributes);
     ?></li>
 </ul>
 <?php echo $this->Form->close('Save');

--- a/plugins/QnA/views/configuration.php
+++ b/plugins/QnA/views/configuration.php
@@ -1,0 +1,34 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+
+<h1><?php echo t($this->Data['Title']); ?></h1>
+
+<?php
+echo $this->Form->open();
+echo $this->Form->errors();
+?>
+<ul>
+    <li><?php
+        $pointsAwardEnabled = c('QnA.IsPointsAwardEnabled');
+
+        $textBoxAttributes = array();
+        $checkBoxAttributes = array(
+            'id' => 'IsPointsAwardEnabled',
+        );
+
+        if ($pointsAwardEnabled) {
+            $checkBoxAttributes['checked'] = true;
+        } else {
+            $textBoxAttributes['disabled'] = true;
+        }
+        echo $this->Form->checkBox('QnA.IsPointsAwardEnabled', t('Enables points award. This will gives users points for answering questions.'), $checkBoxAttributes);
+    ?></li>
+    <li class="PointAwardsInputs"<?php echo $pointsAwardEnabled ? null : ' style="display:none;"'?>><?php
+        echo $this->Form->label(t('Point(s) per answer'), 'QnA.PointsPerAnswer');
+        echo $this->Form->textBox('QnA.PointsPerAnswer', $textBoxAttributes);
+    ?></li>
+    <li class="PointAwardsInputs"<?php echo $pointsAwardEnabled ? null : ' style="display:none;"'?>><?php
+        echo $this->Form->label(t('Points per accepted answer'), 'QnA.PointsPerAcceptedAnswer');
+        echo $this->Form->textBox('QnA.PointsPerAcceptedAnswer', $textBoxAttributes);
+    ?></li>
+</ul>
+<?php echo $this->Form->close('Save');

--- a/plugins/QnA/views/discussionoptions.php
+++ b/plugins/QnA/views/discussionoptions.php
@@ -1,23 +1,23 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
-<h1><?php echo $this->Data('Title') ?></h1>
+<?php if (!defined('APPLICATION')) { exit(); } ?>
+<h1><?php echo $this->data('Title') ?></h1>
 <div class="">
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 
 <div class="P">
-   <?php
+    <?php
 //   echo $this->Form->Label();
-     echo $this->Form->RadioList('Type', $this->Data('_Types'), array('list' => TRUE));
-   ?>
+    echo $this->Form->radioList('Type', $this->data('_Types'), array('list' => true));
+    ?>
 </div>
-   
+
 <?php
-echo '<div class="Buttons Buttons-Confirm">', 
-   $this->Form->Button(T('OK')), ' ',
-   $this->Form->Button(T('Cancel'), array('type' => 'button', 'class' => 'Button Close')),
-   '</div>';
-echo $this->Form->Close();
+echo '<div class="Buttons Buttons-Confirm">',
+    $this->Form->button(t('OK')), ' ',
+    $this->Form->button(t('Cancel'), array('type' => 'button', 'class' => 'Button Close')),
+    '</div>';
+echo $this->Form->close();
 ?>
 </div>

--- a/plugins/QnA/views/post.php
+++ b/plugins/QnA/views/post.php
@@ -1,53 +1,55 @@
-<?php if (!defined('APPLICATION')) exit();
-$Session = Gdn::Session();
+<?php if (!defined('APPLICATION')) { exit(); } ?>
+$Session = Gdn::session();
 $CancelUrl = '/discussions';
-if (C('Vanilla.Categories.Use') && is_object($this->Category))
-   $CancelUrl = '/categories/'.urlencode($this->Category->UrlCode);
+if (c('Vanilla.Categories.Use') && is_object($this->Category)) {
+    $CancelUrl = '/categories/'.urlencode($this->Category->UrlCode);
+}
 
 ?>
 <div id="DiscussionForm" class="FormTitleWrapper DiscussionForm">
    <?php
-		if ($this->DeliveryType() == DELIVERY_TYPE_ALL)
-			echo Wrap($this->Data('Title'), 'h1', array('class' => 'H'));
+		if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
+		    echo wrap($this->data('Title'), 'h1', array('class' => 'H'));
+		}
 
-      echo '<div class="FormWrapper">';
-      echo $this->Form->Open();
-      echo $this->Form->Errors();
-      $this->FireEvent('BeforeFormInputs');
+        echo '<div class="FormWrapper">';
+        echo $this->Form->open();
+        echo $this->Form->errors();
+        $this->fireEvent('BeforeFormInputs');
 
-      if ($this->ShowCategorySelector === TRUE) {
-			echo '<div class="P">';
-				echo '<div class="Category">';
-				echo $this->Form->Label('Category', 'CategoryID'), ' ';
-				echo $this->Form->CategoryDropDown('CategoryID', array('Value' => GetValue('CategoryID', $this->Category), 'PermFilter' => array('AllowedDiscussionTypes' => 'Question')));
-				echo '</div>';
-			echo '</div>';
-      }
+        if ($this->ShowCategorySelector === true) {
+            echo '<div class="P">';
+                echo '<div class="Category">';
+                echo $this->Form->label('Category', 'CategoryID'), ' ';
+                echo $this->Form->categoryDropDown('CategoryID', array('Value' => val('CategoryID', $this->Category), 'PermFilter' => array('AllowedDiscussionTypes' => 'Question')));
+                echo '</div>';
+            echo '</div>';
+        }
 
-      echo '<div class="P">';
-			echo $this->Form->Label('Question', 'Name');
-			echo Wrap($this->Form->TextBox('Name', array('maxlength' => 100, 'class' => 'InputBox BigInput')), 'div', array('class' => 'TextBoxWrapper'));
-		echo '</div>';
+        echo '<div class="P">';
+            echo $this->Form->label('Question', 'Name');
+            echo wrap($this->Form->textBox('Name', array('maxlength' => 100, 'class' => 'InputBox BigInput')), 'div', array('class' => 'TextBoxWrapper'));
+        echo '</div>';
 
-		$this->FireEvent('BeforeBodyInput');
-		echo '<div class="P">';
-         echo $this->Form->BodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true));
-		echo '</div>';
+        $this->fireEvent('BeforeBodyInput');
+        echo '<div class="P">';
+         echo $this->Form->bodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true));
+        echo '</div>';
 
-		$this->FireEvent('AfterDiscussionFormOptions');
+        $this->fireEvent('AfterDiscussionFormOptions');
 
-      echo '<div class="Buttons">';
-      $this->FireEvent('BeforeFormButtons');
-      echo $this->Form->Button((property_exists($this, 'Discussion')) ? 'Save' : 'Ask Question', array('class' => 'Button Primary DiscussionButton'));
-      if (!property_exists($this, 'Discussion') || !is_object($this->Discussion) || (property_exists($this, 'Draft') && is_object($this->Draft))) {
-         echo ' '.$this->Form->Button('Save Draft', array('class' => 'Button Warning DraftButton'));
-      }
-      echo ' '.$this->Form->Button('Preview', array('class' => 'Button Warning PreviewButton'));
-      echo ' '.anchor(t('Edit'), '#', 'Button WriteButton Hidden')."\n";
-      $this->FireEvent('AfterFormButtons');
-      echo ' '.Anchor(T('Cancel'), $CancelUrl, 'Button Cancel');
-      echo '</div>';
-      echo $this->Form->Close();
-      echo '</div>';
+        echo '<div class="Buttons">';
+        $this->fireEvent('BeforeFormButtons');
+        echo $this->Form->button((property_exists($this, 'Discussion')) ? 'Save' : 'Ask Question', array('class' => 'Button Primary DiscussionButton'));
+        if (!property_exists($this, 'Discussion') || !is_object($this->Discussion) || (property_exists($this, 'Draft') && is_object($this->Draft))) {
+            echo ' '.$this->Form->button('Save Draft', array('class' => 'Button Warning DraftButton'));
+        }
+        echo ' '.$this->Form->button('Preview', array('class' => 'Button Warning PreviewButton'));
+        echo ' '.anchor(t('Edit'), '#', 'Button WriteButton Hidden')."\n";
+        $this->fireEvent('AfterFormButtons');
+        echo ' '.anchor(t('Cancel'), $CancelUrl, 'Button Cancel');
+        echo '</div>';
+        echo $this->Form->close();
+        echo '</div>';
    ?>
 </div>

--- a/plugins/QnA/views/post.php
+++ b/plugins/QnA/views/post.php
@@ -1,4 +1,4 @@
-<?php if (!defined('APPLICATION')) { exit(); } ?>
+<?php if (!defined('APPLICATION')) { exit(); } 
 $Session = Gdn::session();
 $CancelUrl = '/discussions';
 if (c('Vanilla.Categories.Use') && is_object($this->Category)) {

--- a/plugins/QnA/views/qnapost.php
+++ b/plugins/QnA/views/qnapost.php
@@ -1,19 +1,19 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
+<?php if (!defined('APPLICATION')) { exit(); } ?>
 <div class="P">
-   <?php echo T('You can either ask a question or start a discussion.', 'You can either ask a question or start a discussion. Choose what you want to do below.'); ?>
+    <?php echo t('You can either ask a question or start a discussion.', 'You can either ask a question or start a discussion. Choose what you want to do below.'); ?>
 </div>
 <style>.NoScript { display: none; }</style>
 <noscript>
-   <style>.NoScript { display: block; } .YesScript { display: none; }</style>
+    <style>.NoScript { display: block; } .YesScript { display: none; }</style>
 </noscript>
 <div class="P NoScript">
-   <?php echo $Form->RadioList('Type', array('Question' => T('Ask a Question'), 'Discussion' => T('Start a New Discussion'))); ?>
+    <?php echo $Form->radioList('Type', array('Question' => t('Ask a Question'), 'Discussion' => t('Start a New Discussion'))); ?>
 </div>
 <div class="YesScript">
-   <div class="Tabs">
-      <ul>
-         <li class="<?php echo $Form->GetValue('Type') == 'Question' ? 'Active' : '' ?>"><a id="QnA_Question" class="QnAButton TabLink" rel="Question" href="#"><?php echo T('Ask a Question'); ?></a></li>
-         <li class="<?php echo $Form->GetValue('Type') == 'Discussion' ? 'Active' : '' ?>"><a id="QnA_Discussion" class="QnAButton TabLink" rel="Discussion" href="#"><?php echo T('Start a New Discussion'); ?></a></li>
-      </ul>
-   </div>
+    <div class="Tabs">
+        <ul>
+            <li class="<?php echo $Form->getValue('Type') == 'Question' ? 'Active' : '' ?>"><a id="QnA_Question" class="QnAButton TabLink" rel="Question" href="#"><?php echo t('Ask a Question'); ?></a></li>
+            <li class="<?php echo $Form->getValue('Type') == 'Discussion' ? 'Active' : '' ?>"><a id="QnA_Discussion" class="QnAButton TabLink" rel="Discussion" href="#"><?php echo t('Start a New Discussion'); ?></a></li>
+        </ul>
+    </div>
 </div>

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -512,7 +512,7 @@ class JsConnectPlugin extends Gdn_Plugin {
 
             // Grab the user's roles.
             $Roles = Gdn::UserModel()->GetRoles(Gdn::Session()->UserID);
-            $Roles = ConsolidateArrayValuesByKey($Roles, 'Name');
+            $Roles = array_column($Roles, 'Name');
             $User['Roles'] = '';
             if (is_array($Roles) && sizeof($Roles))
                 $User['Roles'] = implode(',', $Roles);
@@ -683,8 +683,6 @@ class JsConnectPlugin extends Gdn_Plugin {
     public function settings_delete($Sender, $Args) {
         $client_id = $Sender->Request->Get('client_id');
         $Provider = self::getProvider($client_id);
-
-        $Sender->Form->InputPrefix = FALSE;
 
         if ($Sender->Form->AuthenticatedPostBack()) {
             if ($Sender->Form->GetFormValue('Yes')) {


### PR DESCRIPTION
Depends on https://github.com/vanilla/addons/pull/297

Adds configuration options to the QnA plugin.

* Award user points -> On/Off
* Points per answers (only for users' first answer to that question) -> uint
* Points per accepted answers -> uint