### PR TITLE
Update NBBC spoiler markup

### DIFF
--- a/plugins/NBBC/class.nbbc.plugin.php
+++ b/plugins/NBBC/class.nbbc.plugin.php
@@ -293,11 +293,8 @@ EOT;
          ));
 
          $BBCode->AddRule('spoiler', Array(
-             'simple_start' => "\n" . '<div class="UserSpoiler">
-   <div class="SpoilerTitle">' . T('Spoiler') . ': </div>
-   <div class="SpoilerReveal"></div>
-   <div class="SpoilerText" style="display: none;">',
-             'simple_end' => "</div></div>\n",
+             'simple_start' => "\n<div class=\"Spoiler\">",
+             'simple_end' => "</div>\n",
              'allow_in' => Array('listitem', 'block', 'columns'),
              'before_tag' => "sns",
              'after_tag' => "sns",


### PR DESCRIPTION
This update changes the way spoiler content markup is generated from spoiler tags.  The simplified wrapper is compatible with the spoiler style rules in the Advanced Editor plug-in's [wysiwyg.css](https://github.com/vanilla/vanilla/blob/7b2d94a8a17646947106f107c836edb31567d7d1/plugins/editor/design/wysiwyg.css#L218).