### PR TITLE
Add hook to watermark images after saving discussion.

### DIFF
--- a/plugins/FileUpload/class.fileupload.plugin.php
+++ b/plugins/FileUpload/class.fileupload.plugin.php
@@ -471,7 +471,9 @@ class FileUploadPlugin extends Gdn_Plugin {
 
       $AttachedFilesData = Gdn::Request()->GetValue('AttachedUploads');
       $AllFilesData = Gdn::Request()->GetValue('AllUploads');
-
+      $this->EventArguments['AllFilesData'] = $AllFilesData;
+      $this->EventArguments['CategoryID'] = $Args['Discussion']->CategoryID;
+      $this->fireEvent("InsertDiscussionMedia");
       $this->AttachAllFiles($AttachedFilesData, $AllFilesData, $DiscussionID, 'discussion');
    }
 


### PR DESCRIPTION
Fire an event to allow uploaded images to be manipulated after a discussion has been saved.