### PR TITLE
RoleTitle Plugin: Fix case of array indexes.

### DIFF
--- a/plugins/RoleTitle/class.roletitle.plugin.php
+++ b/plugins/RoleTitle/class.roletitle.plugin.php
@@ -66,7 +66,7 @@ class RoleTitlePlugin extends Gdn_Plugin {
      * @param array $args Event arguments.
      */
     public function discussionController_beforeCommentDisplay_handler($sender, $args) {
-        $this->injectCssClass($args[$args['type']], $args['cssClass']);
+        $this->injectCssClass($args[$args['Type']], $args['CssClass']);
     }
 
     /**
@@ -76,7 +76,7 @@ class RoleTitlePlugin extends Gdn_Plugin {
      * @param array $args Event arguments.
      */
     public function postController_beforeCommentDisplay_handler($sender, $args) {
-        $this->injectCssClass($args[$args['type']], $args['cssClass']);
+        $this->injectCssClass($args[$args['Type']], $args['CssClass']);
     }
 
     /**


### PR DESCRIPTION
In two function some values were being called from an array but the indexes were in the wrong letter casing so they were returning nothing.