### PR TITLE
Points per accepted answer give the wrong value.

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -636,6 +636,11 @@ class QnAPlugin extends Gdn_Plugin {
 
                     case 'Accepted':
                         $Change = 1;
+
+                        if (!$this->Reactions && c('QnA.Points.Enabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
+                            UserModel::givePoints($Comment['InsertUserID'], c('QnA.Points.AcceptedAnswer', 1), 'QnA');
+                        }
+
                         break;
 
                     default:

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -640,7 +640,6 @@ class QnAPlugin extends Gdn_Plugin {
                         if (!$this->Reactions && c('QnA.Points.Enabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
                             UserModel::givePoints($Comment['InsertUserID'], c('QnA.Points.AcceptedAnswer', 1), 'QnA');
                         }
-
                         break;
 
                     default:

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -215,7 +215,7 @@ class QnAPlugin extends Gdn_Plugin {
 
             $points = 3;
             if (c('QnA.Points.Enabled', false)) {
-                $points = c('QnA.Points.AcceptedAnswer', $points);
+                $points = c('QnA.Points.AcceptedAnswer', 1);
             }
 
             // AcceptAnswer


### PR DESCRIPTION
Fix the number of points awarded from the QnA plugin when the Reaction plugin is also enabled.