### PR TITLE
Fix repetition logic for "Begin At" in Pockets

### DIFF
--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -134,7 +134,7 @@ class Pocket {
                     if ($Every < 1)
                         $Every = 1;
                     $Begin = val(1, $Frequency, 1);
-                    if (($Count % $Every) != ($Begin % $Every))
+                    if (($Count % $Every) > 0 || ($Count < $Begin))
                         return false;
                     break;
                 case Pocket::REPEAT_INDEX:


### PR DESCRIPTION
If a pocket is set to repeat with a "Begin At" value, it is not currently respecting that value.  This seems to be due to some bad logic.

This update revises the logic for when to begin a pocket's repetition, making it respect the "Begin At" value.