### PR TITLE
QnA: Add `AfterAccepted` event

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -684,6 +684,9 @@ class QnAPlugin extends Gdn_Plugin {
 
                 $ActivityModel = new ActivityModel();
                 $ActivityModel->save($Activity);
+
+                $this->EventArguments['Activity'] =& $Activity;
+                $this->fireEvent('AfterAccepted');
             }
         }
         redirect("/discussion/comment/{$Comment['CommentID']}#Comment_{$Comment['CommentID']}");


### PR DESCRIPTION
I'm currently working on a plug-in to integrate Vanilla with Algolia search and I'd like to include QnA accepted answers as a flag in Algolia to improve a comments ranking. For this I need to know when a comment is marked as accepted. This change adds a `AfterAccepted` event which passes the activity array as an event argument.

It might be possible to use the `BeforeSave` event from `ActivityModel`, but the `ActivityModel` has a check to make sure that users are notified of changes they make to their own data. that means the `BeforeSave` event doesn't get triggered bending on who marks the thread as accepted. This event resolves this.

I've signed the CLA should you wish to pull this in :-)