### PR TITLE
QnA: Don't display "Ask a question" in the drop down if BigButtons is enabled

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -329,12 +329,14 @@ class QnAPlugin extends Gdn_Plugin {
      * @param array $args Event arguments.
      */
     public function base_discussionTypes_handler($sender, $args) {
-        $args['Types']['Question'] = array(
-            'Singular' => 'Question',
-            'Plural' => 'Questions',
-            'AddUrl' => '/post/question',
-            'AddText' => 'Ask a Question'
-        );
+        if (!C('Plugins.QnA.UseBigButtons')) {
+            $args['Types']['Question'] = array(
+                'Singular' => 'Question',
+                'Plural' => 'Questions',
+                'AddUrl' => '/post/question',
+                'AddText' => 'Ask a Question'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
When I enabled the UseBigButtons options I was initially really confused as to why the New Discussion button was still a dropdown. It seems redundant to have two different buttons for "Ask a question" on the page, so I've added a _not_ condition to the addition of asking a question if `UseBigButtons` is enabled.