### PR TITLE
Add auto-connect and sign-in popup settings to jsConnect

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -697,8 +697,23 @@ class JsConnectPlugin extends Gdn_Plugin {
     }
 
     protected function settings_index($Sender, $Args) {
+        $validation = new Gdn_Validation();
+        $configurationModel = new Gdn_ConfigurationModel($validation);
+        $configurationModel->setField([
+            'Garden.Registration.AutoConnect',
+            'Garden.SignIn.Popup'
+        ]);
+        $Sender->Form->setModel($configurationModel);
+        if ($Sender->Form->authenticatedPostback()) {
+            if ($Sender->Form->save() !== false) {
+                $Sender->informMessage(t('Your settings have been saved.'));
+            }
+        } else {
+            $Sender->Form->setData($configurationModel->Data);
+        }
+
         $Providers = self::getProvider();
-        $Sender->SetData('Providers', $Providers);
-        $Sender->Render('Settings', '', 'plugins/jsconnect');
+        $Sender->setData('Providers', $Providers);
+        $Sender->render('Settings', '', 'plugins/jsconnect');
     }
 }

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -15,28 +15,28 @@
 <div class="FilterMenu"><?php
     echo Anchor(T('Add Connection'), '/settings/jsconnect/addedit', 'SmallButton');
 ?></div>
-<h1><?php echo t('Settings'); ?></h1>
-<?php
-    echo '<div class="Info">';
-    echo $this->Form->open();
-    echo $this->Form->errors();
+<div class="Info">
+    <h2>Signing In</h2>
+    <?php
+        echo $this->Form->open();
+        echo $this->Form->errors();
 
-    echo wrap($this->Form->checkBox(
-        'Garden.Registration.AutoConnect',
-        'Automatically connect users based on e-mail address.'
-    ), 'p');
-    echo wrap($this->Form->checkBox(
-        'Garden.SignIn.Popup',
-        'Use popups for sign in pages <small>(not recommended while using SSO)</small>.'
-    ), 'p');
+        echo wrap($this->Form->checkBox(
+            'Garden.Registration.AutoConnect',
+            'Automatically connect users based on e-mail address.'
+        ), 'p');
+        echo wrap($this->Form->checkBox(
+            'Garden.SignIn.Popup',
+            'Use popups for sign in pages <small>(not recommended while using SSO)</small>.'
+        ), 'p');
 
-    echo '<div class="Buttons">';
-    echo $this->Form->button('Save');
-    echo '</div>';
+        echo '<div class="Buttons">';
+        echo $this->Form->button('Save');
+        echo '</div>';
 
-    echo $this->Form->close();
-    echo '</div>';
-?>
+        echo $this->Form->close();
+    ?>
+</div>
 <table class="AltRows">
     <thead>
     <tr>

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -14,7 +14,29 @@
 </div>
 <div class="FilterMenu"><?php
     echo Anchor(T('Add Connection'), '/settings/jsconnect/addedit', 'SmallButton');
-    ?></div>
+?></div>
+<h1><?php echo t('Settings'); ?></h1>
+<?php
+    echo '<div class="Info">';
+    echo $this->Form->open();
+    echo $this->Form->errors();
+
+    echo wrap($this->Form->checkBox(
+        'Garden.Registration.AutoConnect',
+        'Automatically connect users based on e-mail address.'
+    ), 'p');
+    echo wrap($this->Form->checkBox(
+        'Garden.SignIn.Popup',
+        'Use popups for sign in pages <small>(not recommended while using SSO)</small>.'
+    ), 'p');
+
+    echo '<div class="Buttons">';
+    echo $this->Form->button('Save');
+    echo '</div>';
+
+    echo $this->Form->close();
+    echo '</div>';
+?>
 <table class="AltRows">
     <thead>
     <tr>

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -23,7 +23,7 @@
 
         echo wrap($this->Form->checkBox(
             'Garden.Registration.AutoConnect',
-            'Automatically connect users based on e-mail address.'
+            'Automatically connect to an existing user account if it has the same email address.'
         ), 'p');
         echo wrap($this->Form->checkBox(
             'Garden.SignIn.Popup',


### PR DESCRIPTION
"Sign in popups" and "Autoconnect" are two core settings of Vanilla that have an impact on jsConnect's functionality, but locating them in the dashboard may not be intuitive.  This update adds these two configuration options to a new "Settings" area on the primary jsConnect configuration page.

Closes https://github.com/vanilla/vanilla/issues/3083
Closes https://github.com/vanilla/vanilla/issues/3084