### PR TITLE
Correct SteamConnect class and file name

### DIFF
--- a/plugins/SteamConnect/class.steamconnect.plugin.php
+++ b/plugins/SteamConnect/class.steamconnect.plugin.php
@@ -21,7 +21,7 @@ $PluginInfo['SteamConnect'] = array(
  * @package   Steam Connect
  * @since     1.0.0
  */
-class SteamPlugin extends Gdn_Plugin {
+class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * This will run when you "Enable" the plugin
      *


### PR DESCRIPTION
Plugin SteamConnect has a mixture of "Steam" and "SteamConnect" in folder name, file name, plugin info and class name.