### PR TITLE
Fix invalid call to Gdn_Upload::copyLocal

### DIFF
--- a/plugins/FileUpload/class.fileupload.plugin.php
+++ b/plugins/FileUpload/class.fileupload.plugin.php
@@ -568,7 +568,8 @@ class FileUploadPlugin extends Gdn_Plugin {
       $Parsed = Gdn_Upload::Parse($Name);
 
       // Get actual path to the file.
-      $Path = Gdn_Upload::CopyLocal($SubPath);
+      $upload = new Gdn_UploadImage();
+      $Path = $upload->copyLocal($SubPath);
       if (!file_exists($Path))
          throw NotFoundException('File');
 


### PR DESCRIPTION
`Gdn_Upload::copyLocal ` is not a static function and should not be called in a static context.

This update replaces the `copyLocal` call with one made to an instance of `Gdn_UploadImage`.

Closes #337 