### PR TITLE
Escape clientid in jsConnect errors

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -337,7 +337,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             throw new Gdn_UserException(sprintf(T('ValidateRequired'), 'client_id'), 400);
         $Provider = self::getProvider($client_id);
         if (!$Provider)
-            throw new Gdn_UserException(sprintf(T('Unknown client: %s.'), $client_id), 400);
+            throw new Gdn_UserException(sprintf(T('Unknown client: %s.'), htmlspecialchars($client_id)), 400);
 
         if (!GetValue('TestMode', $Provider)) {
             if (!$Signature)

--- a/plugins/jsconnect/functions.jsconnect.php
+++ b/plugins/jsconnect/functions.jsconnect.php
@@ -31,7 +31,7 @@ function writeJsConnect($User, $Request, $ClientID, $Secret, $Secure = TRUE) {
         if (!isset($Request['client_id'])) {
             $Error = array('error' => 'invalid_request', 'message' => 'The client_id parameter is missing.');
         } elseif ($Request['client_id'] != $ClientID) {
-            $Error = array('error' => 'invalid_client', 'message' => "Unknown client {$Request['client_id']}.");
+            $Error = array('error' => 'invalid_client', 'message' => "Unknown client ".htmlspecialchars($Request['client_id']).".");
         } elseif (!isset($Request['timestamp']) && !isset($Request['signature'])) {
             if (is_array($User) && count($User) > 0) {
                 // This isn't really an error, but we are just going to return public information when no signature is sent.

--- a/plugins/jsconnect/functions.jsconnect.php
+++ b/plugins/jsconnect/functions.jsconnect.php
@@ -31,7 +31,7 @@ function writeJsConnect($User, $Request, $ClientID, $Secret, $Secure = TRUE) {
         if (!isset($Request['client_id'])) {
             $Error = array('error' => 'invalid_request', 'message' => 'The client_id parameter is missing.');
         } elseif ($Request['client_id'] != $ClientID) {
-            $Error = array('error' => 'invalid_client', 'message' => "Unknown client ".htmlspecialchars($Request['client_id']).".");
+            $Error = array('error' => 'invalid_client', 'message' => "Unknown client {$Request['client_id']}.");
         } elseif (!isset($Request['timestamp']) && !isset($Request['signature'])) {
             if (is_array($User) && count($User) > 0) {
                 // This isn't really an error, but we are just going to return public information when no signature is sent.


### PR DESCRIPTION
The `client_id` property should be plain text so don't let it mis-render in error messages.