### PR TITLE
Fix Cyrillic character recognition in CivilTongueEx

### DIFF
--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -350,7 +350,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
                 $ExplodedWords = explode(';', $Words);
                 foreach ($ExplodedWords as $Word) {
                     if (trim($Word)) {
-                        $Patterns[] = '`\b'.preg_quote(trim($Word), '`').'\b`is';
+                        $Patterns[] = '`\b'.preg_quote(trim($Word), '`').'\b`isu';
                     }
                 }
             }


### PR DESCRIPTION
This update adds the`PCRE_UTF8` flag to pattern matching in the CivilTongueEx plug-in.  Prior to this update, Cyrillic characters were not properly recognized and offending words containing them were not censored.

Closes #338