### PR TITLE
Fix discussion array indexation after troll posts are removed from it.

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -184,6 +184,10 @@ class TrollManagementPlugin extends Gdn_Plugin {
             }
          }
       }
+      if (!empty($Result)) {
+         // Be sure the the array is properly indexed after unset. (important for json_encode)
+         $Result = array_values($Result);
+      }
    }
 
    /**


### PR DESCRIPTION
Reindex the array so that json_encode does not treat the array as an object due the the index being non sequencial

Fix https://github.com/vanilla/vanilla/issues/4310