### PR TITLE
Make tables render better according to their content

### DIFF
--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -8,7 +8,6 @@ Gdn_Theme::assetEnd();
 <?php echo wrap($this->data('Title'), 'h1');
 echo anchor(sprintf(t('Add %s'), t('Pocket')), 'settings/pockets/add', 'btn btn-primary js-modal'); ?>
 </div>
-<div class="table-wrap">
     <table>
         <tr>
             <td width="200"><?php
@@ -21,14 +20,13 @@ echo anchor(sprintf(t('Add %s'), t('Pocket')), 'settings/pockets/add', 'btn btn-
             <td><?php echo t('This option shows/hides the locations where pockets can go.', 'This option shows/hides the locations where pockets can go, but only for users that have permission to add/edit pockets. Try showing the locations and then visit your site.'); ?></td>
         </tr>
     </table>
-</div>
 <div class="table-wrap">
-    <table id="Pockets" class="AltColumns">
+    <table id="Pockets" class="table-data">
         <thead>
             <tr>
-                <th><?php echo t('Pocket'); ?></th>
-                <th><?php echo t('Body'); ?></th>
-                <th class="options"><?php echo t('Options'); ?></th>
+                <th class="column-md"><?php echo t('Pocket'); ?></th>
+                <th class="column-xl"><?php echo t('Body'); ?></th>
+                <th class="column-sm"><?php echo t('Options'); ?></th>
             </tr>
         </thead>
         <tbody>

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -46,14 +46,14 @@
     echo $this->Form->close();
 ?>
 <div class="table-wrap padded">
-    <table class="AltRows">
+    <table class="table-data">
         <thead>
         <tr>
-            <th><?php echo T('Client ID'); ?></th>
-            <th><?php echo T('Site Name'); ?></th>
-            <th><?php echo T('Authentication URL'); ?></th>
-            <th><?php echo T('Test') ?></th>
-            <th>&#160;</th>
+            <th><?php echo t('Client ID'); ?></th>
+            <th><?php echo t('Site Name'); ?></th>
+            <th class="column-md"><?php echo t('Authentication URL'); ?></th>
+            <th><?php echo t('Test') ?></th>
+            <th class="column-sm"><?php echo t('Options') ?></th>
         </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Allowing the table layout to choose the column widths resulted in some unpleasant-looking tables. Recent updates to the dashboard css allow us to hint at a column width. The column will never shrink below the specified width. This, combined with jquery.tablejengo.js give us perfectly responsive tables without squishing or trying to push the table beyond the width of its container.