### PR TITLE
Fix Q&A interactions with other plugins

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -976,6 +976,11 @@ class QnAPlugin extends Gdn_Plugin {
     public function discussionsController_unanswered_create($sender, $args) {
         $sender->View = 'Index';
         $sender->setData('_PagerUrl', 'discussions/unanswered/{Page}');
+
+        // Be sure to display every unanswered question (ie from groups)
+        $categories = CategoryModel::categories();
+        $sender->setCategoryIDs(array_keys($categories));
+
         $sender->index(val(0, $args, 'p1'));
         $this->InUnanswered = true;
     }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -979,6 +979,10 @@ class QnAPlugin extends Gdn_Plugin {
 
         // Be sure to display every unanswered question (ie from groups)
         $categories = CategoryModel::categories();
+
+        $this->EventArguments['Categories'] = &$categories;
+        $this->fireEvent('UnansweredBeforeSetCategories');
+
         $sender->setCategoryIDs(array_keys($categories));
 
         $sender->index(val(0, $args, 'p1'));

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1001,24 +1001,22 @@ class QnAPlugin extends Gdn_Plugin {
         // TODO: Dekludge this when category permissions are refactored (tburry).
         $cacheKey = Gdn::request()->webRoot().'/QnA-UnansweredCount';
         $questionCount = Gdn::cache()->get($cacheKey);
+
         if ($questionCount === Gdn_Cache::CACHEOP_FAILURE) {
-            $questionCount = null;
-
-            // Check to see if another plugin can handle this.
-            $this->EventArguments['questionCount'] = &$questionCount;
-            $this->fireEvent('unansweredCount');
-
-            if ($questionCount === null) {
-                $questionCount = Gdn::sql()
-                    ->beginWhereGroup()
-                    ->where('QnA', null)
-                    ->orWhereIn('QnA', array('Unanswered', 'Rejected'))
-                    ->endWhereGroup()
-                    ->getCount('Discussion', array('Type' => 'Question'));
-            }
+            $questionCount = Gdn::sql()
+                ->beginWhereGroup()
+                ->where('QnA', null)
+                ->orWhereIn('QnA', array('Unanswered', 'Rejected'))
+                ->endWhereGroup()
+                ->getCount('Discussion', array('Type' => 'Question'));
 
             Gdn::cache()->store($cacheKey, $questionCount, array(Gdn_Cache::FEATURE_EXPIRY => 15 * 60));
         }
+
+        // Check to see if another plugin can handle this.
+        $this->EventArguments['questionCount'] = &$questionCount;
+        $this->fireEvent('unansweredCount');
+
         return $questionCount;
     }
 


### PR DESCRIPTION
- Move the `questionCount` hook so that it works when caching is enabled.
- Show unanswered questions from groups. 
  - *The group category has the `HideAllDiscussions` flag set to true. This means that the category won't be returned by `CategoryModel::categoryWatch();`. To circumvent that we explicitly set all categories on the discussion controller. That way we will get the unanswered questions from everywhere.*
- Add a hook to allow the categories from previous point to be modified. Needed by Subcommunities for example.

