### PR TITLE
Don't pass sender by reference

### DIFF
--- a/plugins/CssThemes/class.cssthemes.plugin.php
+++ b/plugins/CssThemes/class.cssthemes.plugin.php
@@ -198,7 +198,7 @@ class CssThemes extends Gdn_Plugin {
 		return $Result;
 	}
 	
-	public function Base_GetAppSettingsMenuItems_Handler(&$Sender) {
+	public function Base_GetAppSettingsMenuItems_Handler($Sender) {
       $Menu = $Sender->EventArguments['SideMenu'];
 		$Menu->AddLink('Add-ons', 'Colors', 'plugin/cssthemes', 'Garden.Themes.Manage');
 	}

--- a/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
+++ b/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
@@ -42,7 +42,7 @@ class FeedDiscussionsPlugin extends Gdn_Plugin {
    /**
     * Set up appmenu link
     */
-   public function Base_GetAppSettingsMenuItems_Handler(&$Sender) {
+   public function Base_GetAppSettingsMenuItems_Handler($Sender) {
       $Menu = &$Sender->EventArguments['SideMenu'];
       $Menu->AddItem('Forum', T('Forum'));
       $Menu->AddLink('Forum', T('Feed Discussions'), 'plugin/feeddiscussions', 'Garden.Settings.Manage');

--- a/plugins/Liked/class.liked.plugin.php
+++ b/plugins/Liked/class.liked.plugin.php
@@ -12,7 +12,7 @@ $PluginInfo['Liked'] = array(
 
 class LikedPlugin extends Gdn_Plugin {
 	
-	public function DiscussionController_Render_Before(&$Sender) {
+	public function DiscussionController_Render_Before($Sender) {
       $FB_SDK = <<<EOD
 <div id="fb-root"></div>
 <script>(function(d, s, id) {
@@ -26,7 +26,7 @@ EOD;
       $Sender->AddAsset('Panel', $FB_SDK);
 	}
 	
-	public function DiscussionController_AfterDiscussionBody_Handler(&$Sender) {
+	public function DiscussionController_AfterDiscussionBody_Handler($Sender) {
       echo '<div class="fb-like" data-href="';
       echo Gdn_Url::Request(true, true, true);
       echo '" data-send="false" data-width="450" data-show-faces="false" data-font="lucida grande"></div>';

--- a/plugins/MathJax/class.mathjax.plugin.php
+++ b/plugins/MathJax/class.mathjax.plugin.php
@@ -37,7 +37,7 @@ class MathJaxPlugin extends Gdn_Plugin {
      *
      * @param DiscussionController $sender
      */
-    public function DiscussionController_Render_Before(&$sender) {
+    public function DiscussionController_Render_Before($sender) {
 
         // Add basic MathJax configuration
         $mathJaxConfig = <<<MATHJAX

--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -88,7 +88,7 @@ class PocketsPlugin extends Gdn_Plugin {
      *
      * @param $Sender
      */
-    public function base_GetAppSettingsMenuItems_Handler(&$Sender) {
+    public function base_GetAppSettingsMenuItems_Handler($Sender) {
         $Menu = $Sender->EventArguments['SideMenu'];
         $Menu->addItem('Appearance', t('Appearance'));
         $Menu->addLink('Appearance', t('Pockets'), 'settings/pockets', 'Plugins.Pockets.Manage');

--- a/plugins/PostCount/class.postcount.plugin.php
+++ b/plugins/PostCount/class.postcount.plugin.php
@@ -26,7 +26,7 @@ $PluginInfo['PostCount'] = array(
 
 class PostCountPlugin extends Gdn_Plugin {
    
-   public function UserInfoModule_OnBasicInfo_Handler(&$Sender) {
+   public function UserInfoModule_OnBasicInfo_Handler($Sender) {
       $User = Gdn::UserModel()->GetID($Sender->User->UserID);
       if ($User) {
          $PostCount = GetValue('CountComments', $User, 0) + GetValue('CountDiscussions', $User, 0);
@@ -35,15 +35,15 @@ class PostCountPlugin extends Gdn_Plugin {
       }
    }
    
-   public function DiscussionController_AuthorInfo_Handler(&$Sender) {
+   public function DiscussionController_AuthorInfo_Handler($Sender) {
       $this->_AttachPostCount($Sender);
    }
    
-   public function PostController_AuthorInfo_Handler(&$Sender) {
+   public function PostController_AuthorInfo_Handler($Sender) {
       $this->_AttachPostCount($Sender);
    }
    
-   protected function _AttachPostCount(&$Sender) {
+   protected function _AttachPostCount($Sender) {
       $User = Gdn::UserModel()->GetID($Sender->EventArguments['Author']->UserID);
       if ($User) {
          $Posts = GetValue('CountComments', $User, 0) + GetValue('CountDiscussions', $User, 0);

--- a/plugins/RightToLeft/class.righttoleft.plugin.php
+++ b/plugins/RightToLeft/class.righttoleft.plugin.php
@@ -35,7 +35,7 @@ class RightToLeftPlugin extends Gdn_Plugin {
     *
     * @param Gdn_Controller $Sender
     */
-    public function Base_Render_Before(&$Sender) {
+    public function Base_Render_Before($Sender) {
         $currentLocale = substr(Gdn::Locale()->Current(), 0, 2);
 
         if (in_array($currentLocale, $this->rtlLocales)) {

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -280,7 +280,7 @@ class SignaturesPlugin extends Gdn_Plugin {
         }
     }
 
-    public function setSignatureRules(&$Sender) {
+    public function setSignatureRules($Sender) {
         $rules = array();
         $rulesParams = array();
         $imagesAllowed = true;

--- a/plugins/Voting/class.voting.plugin.php
+++ b/plugins/Voting/class.voting.plugin.php
@@ -25,7 +25,7 @@ class VotingPlugin extends Gdn_Plugin {
 	/**
 	 * Admin Toggle to turn Voting on/off
 	 */
-   public function Base_GetAppSettingsMenuItems_Handler(&$Sender) {
+   public function Base_GetAppSettingsMenuItems_Handler($Sender) {
       $Menu = &$Sender->EventArguments['SideMenu'];
       $Menu->AddItem('Forum', T('Forum'));
       $Menu->AddLink('Forum', T('Voting'), 'settings/voting', 'Garden.Settings.Manage');
@@ -519,7 +519,7 @@ class VotingPlugin extends Gdn_Plugin {
 
    /**
    * Don't let the users access the category management screens.
-   public function SettingsController_Render_Before(&$Sender) {
+   public function SettingsController_Render_Before($Sender) {
       if (strpos(strtolower($Sender->RequestMethod), 'categor') > 0)
          Redirect($Sender->Routes['DefaultPermission']);
    }

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -390,7 +390,7 @@ class JsConnectPlugin extends Gdn_Plugin {
         $Sender->SetData('SSOUser', $JsData);
     }
 
-    public function base_getAppSettingsMenuItems_handler(&$Sender) {
+    public function base_getAppSettingsMenuItems_handler($Sender) {
         $Menu = $Sender->EventArguments['SideMenu'];
         $Menu->AddItem('Users', T('Users'));
         $Menu->AddLink('Users', 'jsConnect', 'settings/jsconnect', 'Garden.Settings.Manage', array('class' => 'nav-jsconnect'));


### PR DESCRIPTION
Fixes a bunch of notices and issues where nav items don't appear in the panel. We've started using call_user_func in the plugin manager https://github.com/vanilla/vanilla/commit/b9f91ee66b8e54f63239f291b42b9172dfb800a3, which doesn't allow references. 