### PR TITLE
Fix case sensitivity of translation function names in the locale developer

### DIFF
--- a/plugins/LocaleDeveloper/class.developerlocale.php
+++ b/plugins/LocaleDeveloper/class.developerlocale.php
@@ -1,98 +1,99 @@
 <?php
-/* 
+
+/*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
 
 class DeveloperLocale extends Gdn_Locale {
-   public $_CapturedDefinitions = array();
+    public $_CapturedDefinitions = array();
 
-   /**
-    * Gets all of the definitions in the current locale.
-    *
-    * return array
-    */
-   public function AllDefinitions() {
-      $Result = array_merge($this->_Definition, $this->_CapturedDefinitions);
-      return $Result;
-   }
+    /**
+     * Gets all of the definitions in the current locale.
+     *
+     * return array
+     */
+    public function AllDefinitions() {
+        $Result = array_merge($this->_Definition, $this->_CapturedDefinitions);
+        return $Result;
+    }
 
-   public function CapturedDefinitions() {
-      return $this->_CapturedDefinitions;
-   }
-   
-   public static function GuessPrefix() {
-      $Trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-      
-      foreach ($Trace as $i => $Row) {
-         if ($Row['function'] == 'T') {
-            if ($Trace[$i + 1]['function'] == 'Plural')
-               return self::PrefixFromPath($Trace[$i + 1]['file']);
-            else
-               return self::PrefixFromPath($Row['file']);
-         }
-         if ($Row['function'] == 'Translate') {
-            if (!in_array(basename($Row['file']), array('functions.general.php', 'class.gdn.php'))) {
-               return self::PrefixFromPath($Row['file']);
+    public function CapturedDefinitions() {
+        return $this->_CapturedDefinitions;
+    }
+
+    public static function GuessPrefix() {
+        $Trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        foreach ($Trace as $i => $Row) {
+            if (strcasecmp($Row['function'], 't') === 0) {
+                if ($Trace[$i + 1]['function'] == 'Plural')
+                    return self::PrefixFromPath($Trace[$i + 1]['file']);
+                else
+                    return self::PrefixFromPath($Row['file']);
             }
-         }
-      }
-      
-      return FALSE;
-   }
-   
-   public static function PrefixFromPath($Path) {
-      $Result = '';
-      
-      if (preg_match('`/plugins/([^/]+)`i', $Path, $Matches)) {
-         $Plugin = strtolower($Matches[1]);
-         
-         if (in_array($Plugin, array('buttonbar', 'fileupload', 'facebook', 'twitter', 'quotes', 'signatures', 'splitmerge', 'tagging', 'nbbc'))) {
-            $Result .= 'core';
-         } else
-            $Result .= $Plugin.'_plugin';
-      } elseif (preg_match('`/library/`i', $Path, $Matches)) {
-         $Result .= 'core';
-      } elseif (preg_match('`/applications/([^/]+)`i', $Path, $Matches)) {
-         $App = strtolower($Matches[1]);
-         
-         if (in_array($App, array('conversations', 'vanilla', 'dashboard'))) {
-            // This is a core app.
-            $Result .= 'core';
-         } else {
-            $Result .= $App.'_application';
-         }
-      } elseif (preg_match('`/themes/([^/]+)`i', $Path, $Matches)) {
-         $Result = FALSE;
-      }
-      return $Result;
-   }
+            if (strcasecmp($Row['function'], 'Translate') === 0) {
+                if (!in_array(basename($Row['file']), array('functions.general.php', 'class.gdn.php'))) {
+                    return self::PrefixFromPath($Row['file']);
+                }
+            }
+        }
 
-   public function Translate($Code, $Default = FALSE) {
-      $Result = parent::Translate($Code, $Default);
-      
-      if (!$Code || substr($Code, 0, 1) == '@')
-         return $Result;
-         
-      $Prefix = self::GuessPrefix();
-      
-      if (!$Prefix) {
-         return $Result;
-      }
-      
-      if ($Prefix == 'unknown') {
-         decho($Code);
-         decho(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
-         die();
-      }
-      
-      if (Gdn_Theme::InSection('Dashboard'))
-         $Prefix = 'dash_'.$Prefix;
-      else
-         $Prefix = 'site_'.$Prefix;
-      
-      $this->_CapturedDefinitions[$Prefix][$Code] = $Result;
+        return FALSE;
+    }
 
-      return $Result;
-   }
+    public static function PrefixFromPath($Path) {
+        $Result = '';
+
+        if (preg_match('`/plugins/([^/]+)`i', $Path, $Matches)) {
+            $Plugin = strtolower($Matches[1]);
+
+            if (in_array($Plugin, array('buttonbar', 'fileupload', 'facebook', 'twitter', 'quotes', 'signatures', 'splitmerge', 'tagging', 'nbbc'))) {
+                $Result .= 'core';
+            } else
+                $Result .= $Plugin.'_plugin';
+        } elseif (preg_match('`/library/`i', $Path, $Matches)) {
+            $Result .= 'core';
+        } elseif (preg_match('`/applications/([^/]+)`i', $Path, $Matches)) {
+            $App = strtolower($Matches[1]);
+
+            if (in_array($App, array('conversations', 'vanilla', 'dashboard'))) {
+                // This is a core app.
+                $Result .= 'core';
+            } else {
+                $Result .= $App.'_application';
+            }
+        } elseif (preg_match('`/themes/([^/]+)`i', $Path, $Matches)) {
+            $Result = FALSE;
+        }
+        return $Result;
+    }
+
+    public function Translate($Code, $Default = FALSE) {
+        $Result = parent::Translate($Code, $Default);
+
+        if (!$Code || substr($Code, 0, 1) == '@')
+            return $Result;
+
+        $Prefix = self::GuessPrefix();
+
+        if (!$Prefix) {
+            return $Result;
+        }
+
+        if ($Prefix == 'unknown') {
+            decho($Code);
+            decho(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
+            die();
+        }
+
+        if (Gdn_Theme::InSection('Dashboard'))
+            $Prefix = 'dash_'.$Prefix;
+        else
+            $Prefix = 'site_'.$Prefix;
+
+        $this->_CapturedDefinitions[$Prefix][$Code] = $Result;
+
+        return $Result;
+    }
 }

--- a/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
+++ b/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
@@ -105,6 +105,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
             $fp = fopen($Path, 'wb');
             if (!is_resource($fp)) {
                 Logger::error("Could not open {path}.", ['path' => $Path]);
+                continue;
             }
             fwrite($fp, $this->GetFileHeader());
             LocaleModel::WriteDefinitions($fp, $Definition);

--- a/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
+++ b/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
@@ -10,271 +10,274 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 
 // Define the plugin:
 $PluginInfo['LocaleDeveloper'] = array(
-   'Name' => 'Locale Developer',
-   'Description' => 'Contains useful functions for locale developers. When you enable this plugin go to its settings page to change your options. This plugin is maintained at http://github.com/vanillaforums/Addons',
-   'Version' => '1.1.1',
-   'Author' => "Todd Burry",
-   'AuthorEmail' => 'todd@vanillaforums.com',
-   'AuthorUrl' => 'http://vanillaforums.org/profile/todd',
-   'RequiredApplications' => array('Vanilla' => '2.0.11'),
-   'SettingsUrl' => '/settings/localedeveloper',
-   'SettingsPermission' => 'Garden.Site.Manage',
+    'Name' => 'Locale Developer',
+    'Description' => 'Contains useful functions for locale developers. When you enable this plugin go to its settings page to change your options. This plugin is maintained at http://github.com/vanillaforums/Addons',
+    'Version' => '1.1.1',
+    'Author' => "Todd Burry",
+    'AuthorEmail' => 'todd@vanillaforums.com',
+    'AuthorUrl' => 'http://vanillaforums.org/profile/todd',
+    'RequiredApplications' => array('Vanilla' => '2.0.11'),
+    'SettingsUrl' => '/settings/localedeveloper',
+    'SettingsPermission' => 'Garden.Site.Manage',
 );
 
 class LocaleDeveloperPlugin extends Gdn_Plugin {
-   public $LocalePath;
+    public $LocalePath;
 
-   /**
-    * @var Gdn_Form Form
-    */
-   protected $Form;
+    /**
+     * @var Gdn_Form Form
+     */
+    protected $Form;
 
-   public function  __construct() {
-      $this->LocalePath = PATH_UPLOADS.'/LocaleDeveloper';
-      $this->Form = new Gdn_Form();
-      parent::__construct();
-   }
+    public function __construct() {
+        $this->LocalePath = PATH_UPLOADS.'/LocaleDeveloper';
+        $this->Form = new Gdn_Form();
+        parent::__construct();
+    }
 
-   /**
-    * Save the captured definitions.
-    *
-    * @param Gdn_Controller $Sender
-    * @param array $Args
-    */
-   public function Base_Render_After($Sender, $Args) {
-      $Locale = Gdn::Locale();
-      if (!is_a($Locale, 'DeveloperLocale'))
-         return;
+    /**
+     * Save the captured definitions.
+     *
+     * @param Gdn_Controller $Sender
+     * @param array $Args
+     */
+    public function Base_Render_After($Sender, $Args) {
+        $Locale = Gdn::Locale();
+        if (!is_a($Locale, 'DeveloperLocale'))
+            return;
 
-      $Path = $this->LocalePath.'/tmp_'.RandomString(10);
-      if (!file_exists(dirname($Path)))
-         mkdir(dirname($Path), 0777, TRUE);
-      elseif (file_exists($Path)) {
-         // Load the existing definitions.
-         $Locale->Load($Path);
-      }
-      
-      // Load the core definitions.
-      if (file_exists($this->LocalePath.'/captured_site_core.php')) {
-         $Definition = array();
-         include $this->LocalePath.'/captured_site_core.php';
-         $Core = $Definition;
-      } else {
-         $Core = array();
-      }
-      
-      // Load the admin definitions.
-      if (file_exists($this->LocalePath.'/captured_dash_core.php')) {
-         $Definition = array();
-         include $this->LocalePath.'/captured_dash_core.php';
-         $Admin = $Definition;
-      } else {
-         $Admin = array();
-      }
+        $Path = $this->LocalePath.'/tmp_'.RandomString(10);
+        if (!file_exists(dirname($Path)))
+            mkdir(dirname($Path), 0777, TRUE);
+        elseif (file_exists($Path)) {
+            // Load the existing definitions.
+            $Locale->Load($Path);
+        }
 
-      // Load the ignore file.
-      $Definition = array();
-      include dirname(__FILE__).'/ignore.php';
-      $Ignore = $Definition;
-      $Definition = array();
-      
-      $CapturedDefinitions = $Locale->CapturedDefinitions();
-      
+        // Load the core definitions.
+        if (file_exists($this->LocalePath.'/captured_site_core.php')) {
+            $Definition = array();
+            include $this->LocalePath.'/captured_site_core.php';
+            $Core = $Definition;
+        } else {
+            $Core = array();
+        }
+
+        // Load the admin definitions.
+        if (file_exists($this->LocalePath.'/captured_dash_core.php')) {
+            $Definition = array();
+            include $this->LocalePath.'/captured_dash_core.php';
+            $Admin = $Definition;
+        } else {
+            $Admin = array();
+        }
+
+        // Load the ignore file.
+        $Definition = array();
+        include dirname(__FILE__).'/ignore.php';
+        $Ignore = $Definition;
+        $Definition = array();
+
+        $CapturedDefinitions = $Locale->CapturedDefinitions();
+
 //      decho ($CapturedDefinitions);
 //      die();
-      
-      foreach ($CapturedDefinitions as $Prefix => $Definition) {
-         $FinalPath = $this->LocalePath."/captured_$Prefix.php";
 
-         // Load the definitions that have already been captured.
-         if (file_exists($FinalPath)) {
-            include $FinalPath;
-         }
-         $Definition = array_diff_key($Definition, $Ignore);
-         
-         // Strip core definitions from the file.
-         if ($Prefix != 'site_core') {
-            $Definition = array_diff_key($Definition, $Core);
-            
-            if ($Prefix != 'dash_core') {
-               $Definition = array_diff_key($Definition, $Admin);
+        foreach ($CapturedDefinitions as $Prefix => $Definition) {
+            $FinalPath = $this->LocalePath."/captured_$Prefix.php";
+
+            // Load the definitions that have already been captured.
+            if (file_exists($FinalPath)) {
+                include $FinalPath;
             }
-         }
+            $Definition = array_diff_key($Definition, $Ignore);
 
-         // Save the current definitions.
-         $fp = fopen($Path, 'wb');
-         fwrite($fp, $this->GetFileHeader());
-         LocaleModel::WriteDefinitions($fp, $Definition);
-         fclose($fp);
+            // Strip core definitions from the file.
+            if ($Prefix != 'site_core') {
+                $Definition = array_diff_key($Definition, $Core);
 
-         // Copy the file over the existing one.
-         $Result = rename($Path, $FinalPath);
-      }
-   }
-   
-   public function Gdn_Dispatcher_BeforeDispatch_Handler($Sender) {
-      if (C('Plugins.LocaleDeveloper.CaptureDefinitions')) {
-         // Install the developer locale.
-         $_Locale = new DeveloperLocale(Gdn::Locale()->Current(), C('EnabledApplications'), C('EnabledPlugins'));
+                if ($Prefix != 'dash_core') {
+                    $Definition = array_diff_key($Definition, $Admin);
+                }
+            }
 
-         $tmp = Gdn::FactoryOverwrite(TRUE);
-         Gdn::FactoryInstall(Gdn::AliasLocale, 'Gdn_Locale', NULL, Gdn::FactorySingleton, $_Locale);
-         Gdn::FactoryOverwrite($tmp);
-         unset($tmp);
-      }
-   }
+            // Save the current definitions.
+            $fp = fopen($Path, 'wb');
+            if (!is_resource($fp)) {
+                Logger::error("Could not open {path}.", ['path' => $Path]);
+            }
+            fwrite($fp, $this->GetFileHeader());
+            LocaleModel::WriteDefinitions($fp, $Definition);
+            fclose($fp);
 
-   /**
-    *
-    * @param Gdn_Controller $Sender
-    * @param array $Args
-    */
-   public function SettingsController_Render_Before($Sender, $Args) {
-      if (strcasecmp($Sender->RequestMethod, 'locales') != 0)
-         return;
+            // Copy the file over the existing one.
+            $Result = rename($Path, $FinalPath);
+        }
+    }
 
-      // Add a little pointer to the settings.
-      $Text = '<div class="Info">'.
-         sprintf(T('Locale Developer Settings %s.'), Anchor(T('here'), '/settings/localedeveloper')).
-         '</div>';
-      $Sender->AddAsset('Content', $Text, 'LocaleDeveloperLink');
-   }
+    public function Gdn_Dispatcher_BeforeDispatch_Handler($Sender) {
+        if (C('Plugins.LocaleDeveloper.CaptureDefinitions')) {
+            // Install the developer locale.
+            $_Locale = new DeveloperLocale(Gdn::Locale()->Current(), C('EnabledApplications'), C('EnabledPlugins'));
 
-   /**
-    *
-    * @var SettingsController $Sender
-    */
-   public function SettingsController_LocaleDeveloper_Create($Sender, $Args = array()) {
-      $Sender->Permission('Garden.Settings.Manage');
+            $tmp = Gdn::FactoryOverwrite(TRUE);
+            Gdn::FactoryInstall(Gdn::AliasLocale, 'Gdn_Locale', NULL, Gdn::FactorySingleton, $_Locale);
+            Gdn::FactoryOverwrite($tmp);
+            unset($tmp);
+        }
+    }
 
-      $Sender->AddSideMenu();
-      $Sender->SetData('Title', T('Locale Developer'));
+    /**
+     *
+     * @param Gdn_Controller $Sender
+     * @param array $Args
+     */
+    public function SettingsController_Render_Before($Sender, $Args) {
+        if (strcasecmp($Sender->RequestMethod, 'locales') != 0)
+            return;
 
-      switch (strtolower(GetValue(0, $Args, ''))) {
-         case '':
+        // Add a little pointer to the settings.
+        $Text = '<div class="Info">'.
+            sprintf(T('Locale Developer Settings %s.'), Anchor(T('here'), '/settings/localedeveloper')).
+            '</div>';
+        $Sender->AddAsset('Content', $Text, 'LocaleDeveloperLink');
+    }
+
+    /**
+     *
+     * @var SettingsController $Sender
+     */
+    public function SettingsController_LocaleDeveloper_Create($Sender, $Args = array()) {
+        $Sender->Permission('Garden.Settings.Manage');
+
+        $Sender->AddSideMenu();
+        $Sender->SetData('Title', T('Locale Developer'));
+
+        switch (strtolower(GetValue(0, $Args, ''))) {
+            case '':
+                $this->_Settings($Sender, $Args);
+                break;
+            case 'download':
+                $this->_Download($Sender, $Args);
+                break;
+            case 'googletranslate':
+                $this->_GoogleTranslate($Sender, $Args);
+                break;
+        }
+    }
+
+    public function _Download($Sender, $Args) {
+        try {
+            // Create the zip file.
+            $Path = $this->CreateZip();
+
+            // Serve the zip file.
+            Gdn_FileSystem::ServeFile($Path, basename($Path), 'application/zip');
+        } catch (Exception $Ex) {
+            $this->Form->AddError($Ex);
             $this->_Settings($Sender, $Args);
-            break;
-         case 'download':
-            $this->_Download($Sender, $Args);
-            break;
-         case 'googletranslate':
-            $this->_GoogleTranslate($Sender, $Args);
-            break;
-      }
-   }
+        }
+    }
 
-   public function _Download($Sender, $Args) {
-      try {
-      // Create the zip file.
-      $Path = $this->CreateZip();
+    public function EnsureDefinitionFile() {
+        $Path = $this->LocalePath.'/definitions.php';
+        if (file_exists($Path))
+            unlink($Path);
+        $Contents = $this->GetFileHeader().self::FormatInfoArray('$LocaleInfo', $this->GetInfoArray());
+        Gdn_FileSystem::SaveFile($Path, $Contents);
+    }
 
-      // Serve the zip file.
-      Gdn_FileSystem::ServeFile($Path, basename($Path), 'application/zip');
-      } catch (Exception $Ex) {
-         $this->Form->AddError($Ex);
-         $this->_Settings($Sender, $Args);
-      }
-   }
+    public static function FormatInfoArray($VariableName, $Array) {
+        $VariableName = '$'.trim($VariableName, '$');
 
-   public function EnsureDefinitionFile() {
-      $Path = $this->LocalePath.'/definitions.php';
-      if (file_exists($Path))
-         unlink($Path);
-      $Contents = $this->GetFileHeader().self::FormatInfoArray('$LocaleInfo', $this->GetInfoArray());
-      Gdn_FileSystem::SaveFile($Path, $Contents);
-   }
+        $Result = '';
+        foreach ($Array as $Key => $Value) {
+            $Result .= $VariableName."['".addcslashes($Key, "'")."'] = ";
+            $Result .= var_export($Value, TRUE);
+            $Result .= ";\n\n";
+        }
 
-   public static function FormatInfoArray($VariableName, $Array) {
-      $VariableName = '$'.trim($VariableName, '$');
+        return $Result;
+    }
 
-      $Result = '';
-      foreach ($Array as $Key => $Value) {
-         $Result .= $VariableName."['".addcslashes($Key, "'")."'] = ";
-         $Result .= var_export($Value, TRUE);
-         $Result .= ";\n\n";
-      }
+    public static function FormatValue($Value, $SingleLine = TRUE) {
+        if (is_bool($Value)) {
+            return $Value ? 'TRUE' : 'FALSE';
+        } elseif (is_numeric($Value)) {
+            return (string)$Value;
+        } elseif (is_string($Value)) {
+            if ($SingleLine)
+                return var_export($Value, TRUE);
+            else
+                return "'".addcslashes($Value, "'")."'";
+        } elseif (is_array($Value)) {
+            $Result = '';
+            $ArraySep = $SingleLine ? ', ' : ",\n   ";
 
-      return $Result;
-   }
+            foreach ($Value as $Key => $ArrayValue) {
+                if (strlen($Result) > 0)
+                    $Result .= $ArraySep;
 
-   public static function FormatValue($Value, $SingleLine = TRUE) {
-      if (is_bool($Value)) {
-         return $Value ? 'TRUE' : 'FALSE';
-      } elseif (is_numeric($Value)) {
-         return (string)$Value;
-      } elseif (is_string($Value)) {
-         if ($SingleLine)
-            return var_export($Value, TRUE);
-         else
-            return "'".addcslashes($Value, "'")."'";
-      } elseif (is_array($Value)) {
-         $Result = '';
-         $ArraySep = $SingleLine ? ', ' : ",\n   ";
+                if ($SingleLine == 'TRUEFALSE')
+                    $SingleLine = FALSE;
 
-         foreach ($Value as $Key => $ArrayValue) {
-            if (strlen($Result) > 0)
-               $Result .= $ArraySep;
+                $Result .= "'".addcslashes($Key, "'")."' => ".self::FormatValue($ArrayValue, $SingleLine);
+            }
 
-            if ($SingleLine == 'TRUEFALSE')
-               $SingleLine = FALSE;
+            $Result = 'array('.$Result.')';
+            return $Result;
+        } else {
+            $Error = print_r($Value);
+            $Error = str_replace('*/', '', $Error);
 
-            $Result .= "'".addcslashes($Key, "'")."' => ".self::FormatValue($ArrayValue, $SingleLine);
-         }
+            return "/* Could not format the following value:\n{$Error}\n*/";
+        }
+    }
 
-         $Result = 'array('.$Result.')';
-         return $Result;
-      } else {
-         $Error = print_r($Value);
-         $Error = str_replace('*/', '', $Error);
+    public function GetFileHeader() {
+        $Now = Gdn_Format::ToDateTime();
 
-         return "/* Could not format the following value:\n{$Error}\n*/";
-      }
-   }
-
-   public function GetFileHeader() {
-      $Now = Gdn_Format::ToDateTime();
-
-      $Result = "<?php if (!defined('APPLICATION')) exit();
+        $Result = "<?php if (!defined('APPLICATION')) exit();
 /** This file was generated by the Locale Developer plugin on $Now **/\n\n";
 
-      return $Result;
-   }
+        return $Result;
+    }
 
-   public function GetInfoArray() {
-      $Info = C('Plugins.LocaleDeveloper');
-      foreach ($Info as $Key => $Value) {
-         if (!$Value)
-            unset($Info[$Key]);
-      }
+    public function GetInfoArray() {
+        $Info = C('Plugins.LocaleDeveloper');
+        foreach ($Info as $Key => $Value) {
+            if (!$Value)
+                unset($Info[$Key]);
+        }
 
-      $InfoArray = array(GetValue('Key', $Info, 'LocaleDeveloper') => array(
-          'Locale' => GetValue('Locale', $Info, Gdn::Locale()->Current()),
-          'Name' => GetValue('Name', $Info, 'Locale Developer'),
-          'Description' => 'Automatically gernerated by the Locale Developer plugin.',
-          'Version' => '0.1a',
-          'Author' => "Your Name",
-          'AuthorEmail' => 'Your Email',
-          'AuthorUrl' => 'http://your.domain.com',
-          'License' => 'Your choice of license'
-      ));
+        $InfoArray = array(GetValue('Key', $Info, 'LocaleDeveloper') => array(
+            'Locale' => GetValue('Locale', $Info, Gdn::Locale()->Current()),
+            'Name' => GetValue('Name', $Info, 'Locale Developer'),
+            'Description' => 'Automatically gernerated by the Locale Developer plugin.',
+            'Version' => '0.1a',
+            'Author' => "Your Name",
+            'AuthorEmail' => 'Your Email',
+            'AuthorUrl' => 'http://your.domain.com',
+            'License' => 'Your choice of license'
+        ));
 
-      return $InfoArray;
-   }
+        return $InfoArray;
+    }
 
-   public function _GoogleTranslate($Sender, $Args) {
-      $Sender->Form = $this->Form;
+    public function _GoogleTranslate($Sender, $Args) {
+        $Sender->Form = $this->Form;
 
-      if ($this->Form->IsPostBack()) {
-         exit('Foo');
+        if ($this->Form->IsPostBack()) {
+            exit('Foo');
 
-      } else {
-         // Load all of the definitions.
-         //$Definitions = $this->LoadDefinitions();
-         //$Sender->SetData('Definitions', $Definitions);
-      }
+        } else {
+            // Load all of the definitions.
+            //$Definitions = $this->LoadDefinitions();
+            //$Sender->SetData('Definitions', $Definitions);
+        }
 
-      $Sender->Render('googletranslate', '', 'plugins/LocaleDeveloper');
-   }
+        $Sender->Render('googletranslate', '', 'plugins/LocaleDeveloper');
+    }
 
 //   public function LoadDefinitions($Path = NULL) {
 //      if ($Path === NULL)
@@ -291,123 +294,123 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
 //      return $Definition;
 //   }
 
-   public function _Settings($Sender, $Args) {
-      $Sender->Form = $this->Form;
+    public function _Settings($Sender, $Args) {
+        $Sender->Form = $this->Form;
 
-      // Grab the existing locale packs.
-      $LocaleModel = new LocaleModel();
-      $LocalePacks = $LocaleModel->AvailableLocalePacks();
-      $LocalArray = array();
-      foreach ($LocalePacks as $Key => $Info) {
-         $LocaleArray[$Key] = GetValue('Name', $Info, $Key);
-      }
-      $Sender->SetData('LocalePacks', $LocaleArray);
+        // Grab the existing locale packs.
+        $LocaleModel = new LocaleModel();
+        $LocalePacks = $LocaleModel->AvailableLocalePacks();
+        $LocalArray = array();
+        foreach ($LocalePacks as $Key => $Info) {
+            $LocaleArray[$Key] = GetValue('Name', $Info, $Key);
+        }
+        $Sender->SetData('LocalePacks', $LocaleArray);
 
-      if ($this->Form->IsPostBack()) {
-         if ($this->Form->GetFormValue('Save')) {
-            $Values = ArrayTranslate($this->Form->FormValues(), array('Key', 'Name', 'Locale', 'CaptureDefinitions'));
-            $SaveValues = array();
+        if ($this->Form->IsPostBack()) {
+            if ($this->Form->GetFormValue('Save')) {
+                $Values = ArrayTranslate($this->Form->FormValues(), array('Key', 'Name', 'Locale', 'CaptureDefinitions'));
+                $SaveValues = array();
+                foreach ($Values as $Key => $Value) {
+                    $SaveValues['Plugins.LocaleDeveloper.'.$Key] = $Value;
+                }
+
+                // Save the settings.
+                SaveToConfig($SaveValues, '', array('RemoveEmpty' => TRUE));
+
+                $Sender->StatusMessage = T('Your changes have been saved.');
+            } elseif ($this->Form->GetFormValue('GenerateChanges')) {
+                $Key = $this->Form->GetFormValue('LocalePackForChanges');
+                if (!$Key)
+                    $this->Form->AddError('ValidateRequired', 'Locale Pack');
+                $Path = PATH_ROOT.'/locales/'.$Key;
+                if (!file_exists($Path))
+                    $this->Form->AddError('Could not find the selected locale pack.');
+
+                if ($this->Form->ErrorCount() == 0) {
+                    try {
+                        $LocaleModel->GenerateChanges($Path, $this->LocalePath);
+                        $Sender->StatusMessage = T('Your changes have been saved.');
+                    } catch (Exception $Ex) {
+                        $this->Form->AddError($Ex);
+                    }
+                }
+            } elseif ($this->Form->GetFormValue('Copy')) {
+                $Key = $this->Form->GetFormValue('LocalePackForCopy');
+                if (!$Key)
+                    $this->Form->AddError('ValidateRequired', 'Locale Pack');
+                $Path = PATH_ROOT.'/locales/'.$Key;
+                if (!file_exists($Path))
+                    $this->Form->AddError('Could not find the selected locale pack.');
+
+                if ($this->Form->ErrorCount() == 0) {
+                    try {
+                        $LocaleModel->CopyDefinitions($Path, $this->LocalePath.'/copied.php');
+                        $Sender->StatusMessage = T('Your changes have been saved.');
+                    } catch (Exception $Ex) {
+                        $this->Form->AddError($Ex);
+                    }
+                }
+            } elseif ($this->Form->GetFormValue('Remove')) {
+                $Files = SafeGlob($this->LocalePath.'/*');
+                foreach ($Files as $File) {
+                    $Result = unlink($File);
+                    if (!$Result) {
+                        $this->Form->AddError('@'.sprintf(T('Could not remove %s.'), $File));
+                    }
+                }
+                if ($this->Form->ErrorCount() == 0)
+                    $Sender->StatusMessage = T('Your changes have been saved.');
+            }
+        } else {
+            $Values = C('Plugins.LocaleDeveloper');
             foreach ($Values as $Key => $Value) {
-               $SaveValues['Plugins.LocaleDeveloper.'.$Key] = $Value;
+                $this->Form->SetFormValue($Key, $Value);
             }
+        }
 
-            // Save the settings.
-            SaveToConfig($SaveValues, '', array('RemoveEmpty' => TRUE));
+        $Sender->SetData('LocalePath', $this->LocalePath);
 
-            $Sender->StatusMessage = T('Your changes have been saved.');
-         } elseif ($this->Form->GetFormValue('GenerateChanges')) {
-            $Key = $this->Form->GetFormValue('LocalePackForChanges');
-            if (!$Key)
-               $this->Form->AddError('ValidateRequired', 'Locale Pack');
-            $Path = PATH_ROOT.'/locales/'.$Key;
-            if (!file_exists($Path))
-               $this->Form->AddError('Could not find the selected locale pack.');
+        $Sender->Render('', '', 'plugins/LocaleDeveloper');
+    }
 
-            if ($this->Form->ErrorCount() == 0) {
-               try {
-                  $LocaleModel->GenerateChanges($Path, $this->LocalePath);
-                  $Sender->StatusMessage = T('Your changes have been saved.');
-               } catch (Exception $Ex) {
-                  $this->Form->AddError($Ex);
-               }
-            }
-         } elseif ($this->Form->GetFormValue('Copy')) {
-            $Key = $this->Form->GetFormValue('LocalePackForCopy');
-            if (!$Key)
-               $this->Form->AddError('ValidateRequired', 'Locale Pack');
-            $Path = PATH_ROOT.'/locales/'.$Key;
-            if (!file_exists($Path))
-               $this->Form->AddError('Could not find the selected locale pack.');
+    public function WriteInfoArray($fp) {
+        $Info = C('Plugins.LocaleDeveloper');
 
-            if ($this->Form->ErrorCount() == 0) {
-               try {
-                  $LocaleModel->CopyDefinitions($Path, $this->LocalePath.'/copied.php');
-                  $Sender->StatusMessage = T('Your changes have been saved.');
-               } catch (Exception $Ex) {
-                  $this->Form->AddError($Ex);
-               }
-            }
-         } elseif ($this->Form->GetFormValue('Remove')) {
-            $Files = SafeGlob($this->LocalePath.'/*');
-            foreach ($Files as $File) {
-               $Result = unlink($File);
-               if (!$Result) {
-                  $this->Form->AddError('@'.sprintf(T('Could not remove %s.'), $File));
-               }
-            }
-            if ($this->Form->ErrorCount() == 0)
-               $Sender->StatusMessage = T('Your changes have been saved.');
-         }
-      } else {
-         $Values = C('Plugins.LocaleDeveloper');
-         foreach ($Values as $Key => $Value) {
-            $this->Form->SetFormValue($Key, $Value);
-         }
-      }
+        // Write the info array.
+        $InfoArray = $this->GetInfoArray();
 
-      $Sender->SetData('LocalePath', $this->LocalePath);
+        $InfoString = self::FormatInfoArray('$LocaleInfo', $InfoArray);
+        fwrite($fp, $InfoString);
+    }
 
-      $Sender->Render('', '', 'plugins/LocaleDeveloper');
-   }
+    public function CreateZip() {
+        if (!class_exists('ZipArchive')) {
+            throw new Exception('Your server does not support zipping files.', 400);
+        }
 
-   public function WriteInfoArray($fp) {
-      $Info = C('Plugins.LocaleDeveloper');
+        $Info = $this->GetInfoArray();
+        $this->EnsureDefinitionFile();
 
-      // Write the info array.
-      $InfoArray = $this->GetInfoArray();
+        // Get the basename of the locale.
+        $Key = key($Info);
 
-      $InfoString = self::FormatInfoArray('$LocaleInfo', $InfoArray);
-      fwrite($fp, $InfoString);
-   }
+        $ZipPath = PATH_UPLOADS."/$Key.zip";
+        $TmpPath = PATH_UPLOADS."/tmp_".RandomString(10);
 
-   public function CreateZip() {
-      if (!class_exists('ZipArchive')) {
-         throw new Exception('Your server does not support zipping files.', 400);
-      }
+        $Zip = new ZipArchive();
+        $Zip->open($TmpPath, ZIPARCHIVE::CREATE);
 
-      $Info = $this->GetInfoArray();
-      $this->EnsureDefinitionFile();
+        // Add all of the files in the locale to the zip.
+        $Files = SafeGlob(rtrim($this->LocalePath, '/').'/*.*', array('php', 'txt'));
+        foreach ($Files as $File) {
+            $LocalPath = $Key.'/'.basename($File);
+            $Zip->addFile($File, $LocalPath);
+        }
 
-      // Get the basename of the locale.
-      $Key = key($Info);
+        $Zip->close();
 
-      $ZipPath = PATH_UPLOADS."/$Key.zip";
-      $TmpPath = PATH_UPLOADS."/tmp_".RandomString(10);
+        rename($TmpPath, $ZipPath);
 
-      $Zip = new ZipArchive();
-      $Zip->open($TmpPath, ZIPARCHIVE::CREATE);
-      
-      // Add all of the files in the locale to the zip.
-      $Files = SafeGlob(rtrim($this->LocalePath, '/').'/*.*', array('php', 'txt'));
-      foreach ($Files as $File) {
-         $LocalPath = $Key.'/'.basename($File);
-         $Zip->addFile($File, $LocalPath);
-      }
-
-      $Zip->close();
-
-      rename($TmpPath, $ZipPath);
-
-      return $ZipPath;
-   }
+        return $ZipPath;
+    }
 }


### PR DESCRIPTION
Fixes an issue where translations were not captured when the translation functions used a different casing. Also includes formatting changes (use w=1 to review).