### PR TITLE
Share This - Fix for button heights

### DIFF
--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -104,4 +104,8 @@ SHARETHIS;
       $Sender->Render('sharethis', '', 'plugins/ShareThis');
    }
 
+    public function discussionController_render_before($sender) {
+        $sender->addCssFile('ShareThis.css', 'plugins/ShareThis');
+    }
 }
+

--- a/plugins/ShareThis/design/ShareThis.css
+++ b/plugins/ShareThis/design/ShareThis.css
@@ -1,0 +1,3 @@
+.ShareThisButtonWrapper span {
+    box-sizing: content-box;
+}


### PR DESCRIPTION
On several themes, the buttons are cut off. The plugin assumes box-sizing is set to "content-box". I explicitly gave content-box sizing to the plugin to avoid issues.

Closes #403 
