### PR TITLE
Update Settings Views

### DIFF
--- a/plugins/CivilTongueEx/views/index.php
+++ b/plugins/CivilTongueEx/views/index.php
@@ -1,38 +1,30 @@
 <?php if (!defined('APPLICATION')) exit();
 echo Wrap($this->Data('Title'), 'h1');
+
+$desc =  T('Civil Tongue lets you make a list of words that are not allowed on the forum and replace them. This plugins also helps to make your forum suitable for younger audiences.');
+echo wrap($desc, 'div', ['class' => 'alert alert-info padded']);
+
 echo $this->Form->Open();
 echo $this->Form->Errors();
-
-Gdn_Theme::assetBegin('Help');
-echo '<h2>'.sprintf(t('About %s'), $this->Data('Title')).'</h2>';
 ?>
-<p>
-    <?php echo T('Civil Tongue lets you make a list of words that are not allowed on the forum and replace them. This plugins also helps to make your forum suitable for younger audiences.'); ?>
-</p>
-<?php
-Gdn_Theme::assetEnd();
-?>
-    <ul>
-        <li class="form-group">
-            <div class="label-wrap">
-                <?php echo $this->Form->label('Forbidden words', 'Plugins.CivilTongue.Words');
-                echo wrap(t('Separate each word with a semi-colon ";"'), 'div', ['class' => 'info']); ?>
-            </div>
-            <div class="input-wrap">
-                <?php echo $this->Form->TextBox('Plugins.CivilTongue.Words', array('MultiLine' => TRUE)); ?>
-            </div>
-        </li>
-        <li class="form-group">
-            <div class="label-wrap">
-                <?php echo $this->Form->label('Replacement word', 'Plugins.CivilTongue.Replacement');
-                echo wrap(t('Enter the word you wish to replace the banned word with.'), 'div', ['class' => 'info']); ?>
-            </div>
-            <div class="input-wrap">
-                <?php echo $this->Form->TextBox('Plugins.CivilTongue.Replacement'); ?>
-            </div>
-        </li>
-    </ul>
-
-<div class="form-footer js-modal-footer">
-    <?php echo $this->Form->Close('Save'); ?>
-</div>
+<ul>
+    <li class="form-group">
+        <div class="label-wrap">
+            <?php echo $this->Form->label('Forbidden words', 'Plugins.CivilTongue.Words');
+            echo wrap(t('Separate each word with a semi-colon ";"'), 'div', ['class' => 'info']); ?>
+        </div>
+        <div class="input-wrap">
+            <?php echo $this->Form->TextBox('Plugins.CivilTongue.Words', array('MultiLine' => TRUE)); ?>
+        </div>
+    </li>
+    <li class="form-group">
+        <div class="label-wrap">
+            <?php echo $this->Form->label('Replacement word', 'Plugins.CivilTongue.Replacement');
+            echo wrap(t('Enter the word you wish to replace the banned word with.'), 'div', ['class' => 'info']); ?>
+        </div>
+        <div class="input-wrap">
+            <?php echo $this->Form->TextBox('Plugins.CivilTongue.Replacement'); ?>
+        </div>
+    </li>
+</ul>
+<?php echo $this->Form->Close('Save'); ?>

--- a/plugins/CustomizeText/views/customizetext.php
+++ b/plugins/CustomizeText/views/customizetext.php
@@ -69,8 +69,5 @@ if ($this->Form->GetValue('Keywords', '') != '') {
         echo '</li>';
     }
     echo '</ul>';
-    echo '<div class="form-footer">';
-    echo $this->Form->Button('Save All');
-    echo '</div>';
 }
-echo $this->Form->Close();
+echo $this->Form->Close('Save All');

--- a/plugins/Disqus/views/settings.php
+++ b/plugins/Disqus/views/settings.php
@@ -17,9 +17,6 @@ echo $form->errors();
 echo $form->simple(array(
     'AuthenticationKey' => array('LabelCode' => 'Consumer Key'),
     'AssociationSecret' => array('LabelCode' => 'Consumer Secret')
-)); ?>
+));
 
-<div class="form-footer js-modal-footer">
-<?php echo $form->button('Save');
-echo $form->close(); ?>
-</div>
+echo $form->close('Save'); ?>

--- a/plugins/FeedDiscussions/views/feeddiscussions.php
+++ b/plugins/FeedDiscussions/views/feeddiscussions.php
@@ -38,7 +38,7 @@
     );
 
     ?>
-    <ul>
+    <ul class="padded-bottom">
         <li class="form-group">
             <?php echo $this->Form->labelWrap('Feed URL', 'FeedURL'); ?>
             <?php echo $this->Form->textBoxWrap('FeedURL', array('class' => 'InputBox')); ?>
@@ -62,9 +62,7 @@
             </div>
         </li>
     </ul>
-    <div class="form-footer padded-bottom">
-        <?php echo $this->Form->Close("Add Feed"); ?>
-    </div>
+    <?php echo $this->Form->Close("Add Feed"); ?>
 </div>
 
 <h2><?php echo T('Active Feeds'); ?></h2>

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -87,19 +87,10 @@ echo $Form->errors();
         <div class="input-wrap">
             <?php
             echo $Form->checkbox("MobileOnly", t("Only display on mobile browsers."));
-            echo '<div class="info">', t('Limit the display of this pocket to "mobile only".'), '</div>';
-
             echo $Form->checkbox("MobileNever", t("Never display on mobile browsers."));
-            echo '<div class="info">', t('Limit the display of this pocket for mobile devices.'), '</div>';
-
             echo $Form->checkbox("EmbeddedNever", t("Don't display for embedded comments."));
-            echo '<div class="info">', t('Limit the display of this pocket for embedded comments.'), '</div>';
-
             echo $Form->checkbox("ShowInDashboard", t("Display in dashboard. (not recommended)"));
-            echo '<div class="info">', t("Most pockets shouldn't be displayed in the dashboard."), '</div>';
-
-            echo $Form->checkbox("Ad", t("This pocket is an ad."));
-            echo '<div class="info">', t("Users with the no ads permission will not see this pocket."), '</div>';
+            echo $Form->checkbox("Ad", t("This pocket is an ad.").' '.t("Users with the no ads permission will not see this pocket."));
             ?>
         </div>
     </li>
@@ -117,8 +108,5 @@ echo $Form->errors();
         </div>
     </li>
 </ul>
-<div class="js-modal-footer form-footer">
-<?php echo $Form->button('Save'); ?>
-</div>
-<?php $Form->close();
+<?php $Form->close('Save');
 

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -1,8 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
-Gdn_Theme::assetBegin('Help');
-echo '<h2>'.sprintf(t('About %s'), t('Pockets')).'</h2>';
-echo '<div>'.t('Pockets allow you to add free-form HTML to various places around the application.').'</div>';
-Gdn_Theme::assetEnd();
+helpAsset(sprintf(t('About %s'), t('Pockets')), t('Pockets allow you to add free-form HTML to various places around the application.'));
 ?>
 <div class="header-block">
 <?php echo wrap($this->data('Title'), 'h1');

--- a/plugins/QnA/views/configuration.php
+++ b/plugins/QnA/views/configuration.php
@@ -29,6 +29,4 @@ if ($pointsAwardEnabled) {
         echo $this->Form->textBoxWrap('QnA.Points.AcceptedAnswer', $textBoxAttributes);
     ?></li>
 </ul>
-<div class="form-footer js-modal-footer">
-    <?php echo $this->Form->close('Save'); ?>
-</div>
+<?php echo $this->Form->close('Save'); ?>

--- a/plugins/ShareThis/views/sharethis.php
+++ b/plugins/ShareThis/views/sharethis.php
@@ -30,9 +30,6 @@ echo $this->Form->Errors();
             </div>
         </li>
     </ul>
-    <div class="form-footer js-modal-footer">
-        <?php echo $this->Form->Button('Save'); ?>
-    </div>
-<?php echo $this->Form->Close();
+<?php echo $this->Form->Close('Save');
 
 

--- a/plugins/Spoof/views/spoof.php
+++ b/plugins/Spoof/views/spoof.php
@@ -25,6 +25,4 @@ echo $this->Form->Errors();
       </div>
    </li>
 </ul>
-<div class="form-footer js-modal-footer">
-   <?php echo $this->Form->Close('Go'); ?>
-</div>
+<?php echo $this->Form->Close('Go'); ?>

--- a/plugins/TouchIcon/views/touchicon.php
+++ b/plugins/TouchIcon/views/touchicon.php
@@ -18,6 +18,4 @@ echo wrap(img(val('Path', $this->Data)), 'div'); ?>
    </div>
    <?php echo $this->Form->fileUploadWrap('TouchIcon'); ?>
 </div>
-<div class="js-modal-footer form-footer">
-   <?php echo $this->Form->close('Save'); ?>
-</div>
+<?php echo $this->Form->close('Save'); ?>

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -1,50 +1,41 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
+<?php if (!defined('APPLICATION')) exit();
 
-<?php Gdn_Theme::assetBegin('Help'); ?>
-<div class="Help Aside">
-    <?php
-    echo '<h2>'.sprintf(t('About %s'), 'jsConnect').'</h2>';
-    echo t('You can connect to multiple sites that support jsConnect.');
-    echo '<h2>'.t('Need More Help?').'</h2>';
-    echo '<ul>';
-    echo '<li>'.anchor(t('jsConnect Documentation'), 'http://docs.vanillaforums.com/features/sso/jsconnect/').'</li>';
-    echo '<li>'.anchor(t('jsConnect Client Libraries'), 'http://docs.vanillaforums.com/features/sso/jsconnect/overview/#your-endpoint').'</li>';
-    echo '</ul>';
-    ?>
-</div>
-<?php Gdn_Theme::assetEnd(); ?>
+$links = '<ul>';
+$links .= '<li>'.anchor(t('jsConnect Documentation'), 'http://docs.vanillaforums.com/features/sso/jsconnect/').'</li>';
+$links .= '<li>'.anchor(t('jsConnect Client Libraries'), 'http://docs.vanillaforums.com/features/sso/jsconnect/overview/#your-endpoint').'</li>';
+$links .= '</ul>';
+
+helpAsset(sprintf(t('About %s'), 'jsConnect'), t('You can connect to multiple sites that support jsConnect.'));
+helpAsset(t('Need More Help?'), $links);
+
+?>
 <div class="header-block">
     <h1><?php echo sprintf(t('%s Settings'), 'jsConnect'); ?></h1>
     <?php echo anchor(t('Add Connection'), '/settings/jsconnect/addedit', 'btn btn-primary js-modal'); ?>
 </div>
 <h2 class="subheading-border">Signing In</h2>
 <?php
-    echo $this->Form->open();
-    echo $this->Form->errors(); ?>
-    <div class="form-group">
-        <div class="label-wrap-wide">
-            <?php echo t('Auto Connect'); ?>
-            <?php echo '<div class="info">'.t('Automatically connect to an existing user account if it has the same email address.').'</div>' ?>
-        </div>
-        <div class="input-wrap-right">
-            <?php echo $this->Form->toggle('Garden.Registration.AutoConnect'); ?>
-        </div>
+echo $this->Form->open();
+echo $this->Form->errors(); ?>
+<div class="form-group">
+    <div class="label-wrap-wide">
+        <?php echo t('Auto Connect'); ?>
+        <?php echo '<div class="info">'.t('Automatically connect to an existing user account if it has the same email address.').'</div>' ?>
     </div>
-    <div class="form-group">
-        <div class="label-wrap-wide">
-            <?php echo t('Use Popup Sign In Pages'); ?>
-            <?php echo '<div class="info">'.t('Use popups for sign in pages (not recommended while using SSO).').'</div>'; ?>
-        </div>
-        <div class="input-wrap-right">
-            <?php echo $this->Form->toggle('Garden.SignIn.Popup'); ?>
-        </div>
+    <div class="input-wrap-right">
+        <?php echo $this->Form->toggle('Garden.Registration.AutoConnect'); ?>
     </div>
-    <?php
-    echo '<div class="form-footer">';
-    echo $this->Form->button('Save');
-    echo '</div>';
-    echo $this->Form->close();
-?>
+</div>
+<div class="form-group">
+    <div class="label-wrap-wide">
+        <?php echo t('Use Popup Sign In Pages'); ?>
+        <?php echo '<div class="info">'.t('Use popups for sign in pages (not recommended while using SSO).').'</div>'; ?>
+    </div>
+    <div class="input-wrap-right">
+        <?php echo $this->Form->toggle('Garden.SignIn.Popup'); ?>
+    </div>
+</div>
+<?php echo $this->Form->close('Save'); ?>
 <div class="table-wrap">
     <table class="table-data js-tj">
         <thead>

--- a/plugins/jsconnect/views/settings_addedit.php
+++ b/plugins/jsconnect/views/settings_addedit.php
@@ -1,17 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-
-<?php Gdn_Theme::assetBegin('Help'); ?>
-    <div class="Help Aside">
-        <?php
-        echo '<h2>', t('Need More Help?'), '</h2>';
-        echo '<ul>';
-        echo '<li>'.anchor(t('jsConnect Documentation'), 'http://docs.vanillaforums.com/features/sso/jsconnect/').'</li>';
-        echo '<li>'.anchor(t('jsConnect Client Libraries'), 'http://docs.vanillaforums.com/features/sso/jsconnect/overview/#your-endpoint').'</li>';
-        echo '</ul>';
-        ?>
-    </div>
-<?php Gdn_Theme::assetEnd() ?>
-    <h1><?php echo $this->data('Title'); ?></h1>
+<h1><?php echo $this->data('Title'); ?></h1>
 <?php
 echo $this->Form->open(), $this->Form->errors();
 echo $this->Form->simple($this->data('_Controls'));


### PR DESCRIPTION
Does three things:

1. Uses new helpAsset() function to add info to the help asset and render it properly
2. Removes the wrapper for form footer and adds it to the form class instead.
3. Uses data-title, data-body, data-css-class, etc. for modal content overriding instead of passing data-modal-content as an object.

Help Asset styling and modal overrides rely on https://github.com/vanilla/vanilla/pull/4631
Help Asset rendering relies on https://github.com/vanilla/vanilla/pull/4632