### PR TITLE
Update CivilTongueEx to work on Groups and Events + bugfix on categories

### DIFF
--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -491,6 +491,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
     /**
      * Replace bad words in the group list
      *
+     * Vanilla's proprietary group plugin hook.
+     *
      * @param SettingsController $sender Sending controller instance
      * @param array $args Event's arguments
      */
@@ -512,6 +514,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
     /**
      * Replace bad words in the group browsing list
      *
+     * Vanilla's proprietary group plugin hook.
+     *
      * @param SettingsController $sender Sending controller instance
      * @param array $args Event's arguments
      */
@@ -529,6 +533,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
     /**
      * Replace bad words in the group view and the events list
      *
+     * Vanilla's proprietary group plugin hook.
+     *
      * @param SettingsController $sender Sending controller instance
      * @param array $args Event's arguments
      */
@@ -539,6 +545,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
 
     /**
      * Replace bad words in the event list of a group
+     *
+     * Vanilla's proprietary group plugin hook.
      *
      * @param SettingsController $sender Sending controller instance
      * @param array $args Event's arguments
@@ -554,6 +562,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
 
     /**
      * Replace bad words in the events list
+     *
+     * Vanilla's proprietary group plugin hook.
      *
      * @param SettingsController $sender Sending controller instance
      * @param array $args Event's arguments
@@ -574,6 +584,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
 
     /**
      * Replace bad words in the event view
+     *
+     * Vanilla's proprietary group plugin hook.
      *
      * @param SettingsController $sender Sending controller instance
      * @param array $args Event's arguments

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -482,4 +482,105 @@ class CivilTonguePlugin extends Gdn_Plugin {
             $args['Poll']->Name = $this->replace($name);
         }
     }
+
+    /**
+     * Replace bad words in the group list
+     *
+     * @param SettingsController $sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function groupsController_beforeGroupLists_handler($sender, $args) {
+        $sections = ['MyGroups', 'NewGroups', 'Groups'];
+
+        foreach($sections as $section) {
+            $groups = $sender->data($section);
+            if ($groups) {
+                foreach($groups as &$group) {
+                    $group['Name'] = $this->replace($group['Name']);
+                    $group['Description'] = $this->replace($group['Description']);
+                }
+                $sender->setData($section, $groups);
+            }
+        }
+    }
+
+    /**
+     * Replace bad words in the group browsing list
+     *
+     * @param SettingsController $sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function groupsController_beforeBrowseGroupList_handler($sender, $args) {
+        $groups = $sender->data('Groups');
+        if ($groups) {
+            foreach($groups as &$group) {
+                $group['Name'] = $this->replace($group['Name']);
+                $group['Description'] = $this->replace($group['Description']);
+            }
+            $sender->setData('Groups', $groups);
+        }
+    }
+
+    /**
+     * Replace bad words in the group view and the events list
+     *
+     * @param SettingsController $sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function base_groupLoaded_handler($sender, $args) {
+        $args['Group']['Name'] = $this->replace($args['Group']['Name']);
+        $args['Group']['Description'] = $this->replace($args['Group']['Description']);
+    }
+
+    /**
+     * Replace bad words in the event list of a group
+     *
+     * @param SettingsController $sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function groupController_groupEventsLoaded_handler($sender, $args) {
+        $events = &$args['Events'];
+        foreach($events as &$event) {
+            $event['Name'] = $this->replace($event['Name']);
+            $event['Body'] = $this->replace($event['Body']);
+            $event['Location'] = $this->replace($event['Location']);
+        }
+    }
+
+    /**
+     * Replace bad words in the events list
+     *
+     * @param SettingsController $sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function eventsController_eventsLoaded_handler($sender, $args) {
+        $sections = ['UpcomingEvents', 'RecentEvents'];
+
+        foreach($sections as $section) {
+            $events = &$args[$section];
+            foreach($events as &$event) {
+                $event['Name'] = $this->replace($event['Name']);
+                $event['Body'] = $this->replace($event['Body']);
+                $event['Location'] = $this->replace($event['Location']);
+            }
+            unset($events, $event);
+        }
+    }
+
+    /**
+     * Replace bad words in the event view
+     *
+     * @param SettingsController $sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function eventController_eventLoaded_handler($sender, $args) {
+        $args['Event']['Name'] = $this->replace($args['Event']['Name']);
+        $args['Event']['Body'] = $this->replace($args['Event']['Body']);
+        $args['Event']['Location'] = $this->replace($args['Event']['Location']);
+
+        if (isset($args['Group'])) {
+            $args['Group']['Name'] = $this->replace($args['Group']['Name']);
+            $args['Group']['Description'] = $this->replace($args['Group']['Description']);
+        }
+    }
 }

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -185,6 +185,11 @@ class CivilTonguePlugin extends Gdn_Plugin {
         }
     }
 
+    /**
+     * Recursively replace the LastTitle field in a category tree.
+     *
+     * @param array $categories
+     */
     protected function sanitizeCategories(array &$categories) {
         foreach ($categories as &$row) {
             if (isset($row['LastTitle'])) {
@@ -492,10 +497,10 @@ class CivilTonguePlugin extends Gdn_Plugin {
     public function groupsController_beforeGroupLists_handler($sender, $args) {
         $sections = ['MyGroups', 'NewGroups', 'Groups'];
 
-        foreach($sections as $section) {
+        foreach ($sections as $section) {
             $groups = $sender->data($section);
             if ($groups) {
-                foreach($groups as &$group) {
+                foreach ($groups as &$group) {
                     $group['Name'] = $this->replace($group['Name']);
                     $group['Description'] = $this->replace($group['Description']);
                 }
@@ -513,7 +518,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
     public function groupsController_beforeBrowseGroupList_handler($sender, $args) {
         $groups = $sender->data('Groups');
         if ($groups) {
-            foreach($groups as &$group) {
+            foreach ($groups as &$group) {
                 $group['Name'] = $this->replace($group['Name']);
                 $group['Description'] = $this->replace($group['Description']);
             }
@@ -540,7 +545,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
      */
     public function groupController_groupEventsLoaded_handler($sender, $args) {
         $events = &$args['Events'];
-        foreach($events as &$event) {
+        foreach ($events as &$event) {
             $event['Name'] = $this->replace($event['Name']);
             $event['Body'] = $this->replace($event['Body']);
             $event['Location'] = $this->replace($event['Location']);
@@ -556,9 +561,9 @@ class CivilTonguePlugin extends Gdn_Plugin {
     public function eventsController_eventsLoaded_handler($sender, $args) {
         $sections = ['UpcomingEvents', 'RecentEvents'];
 
-        foreach($sections as $section) {
+        foreach ($sections as $section) {
             $events = &$args[$section];
-            foreach($events as &$event) {
+            foreach ($events as &$event) {
                 $event['Name'] = $this->replace($event['Name']);
                 $event['Body'] = $this->replace($event['Body']);
                 $event['Location'] = $this->replace($event['Location']);

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -169,18 +169,10 @@ class CivilTonguePlugin extends Gdn_Plugin {
      * @param CategoriesController $Sender
      */
     public function categoriesController_render_before($Sender) {
-        if (isset($Sender->Data['Categories'])) {
-            foreach ($Sender->Data['Categories'] as &$Row) {
-                if (is_array($Row)) {
-                    if (isset($Row['LastTitle'])) {
-                        $Row['LastTitle'] = $this->replace($Row['LastTitle']);
-                    }
-                } elseif (is_object($Row)) {
-                    if (isset($Row->LastTitle)) {
-                        $Row->LastTitle = $this->replace($Row->LastTitle);
-                    }
-                }
-            }
+        $categoryTree = $Sender->data('CategoryTree');
+        if ($categoryTree) {
+            $this->sanitizeCategories($categoryTree);
+            $Sender->setData('CategoryTree', $categoryTree);
         }
 
         // When category layout is table.
@@ -191,7 +183,17 @@ class CivilTonguePlugin extends Gdn_Plugin {
                 $Discussion->Body = $this->replace($Discussion->Body);
             }
         }
+    }
 
+    protected function sanitizeCategories(array &$categories) {
+        foreach ($categories as &$row) {
+            if (isset($row['LastTitle'])) {
+                $row['LastTitle'] = $this->replace($row['LastTitle']);
+            }
+            if (!empty($row['Children'])) {
+                $this->sanitizeCategories($row['Children']);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Depends on https://github.com/vanilla/internal/pull/737
Fixes https://github.com/vanilla/addons/issues/408

Fix filtering on the categories view.
Filter out groups and events fields.

P.S. Yeah I know it is a 2 in one.. don't crucify me.