### PR TITLE
Fix failure to unignore user if their ignore privileges have been revoked

### DIFF
--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -397,7 +397,7 @@ class IgnorePlugin extends Gdn_Plugin {
       $UserID = GetValue('UserID', $User);
 
       // Set title and mode
-      $IgnoreRestricted = $this->IgnoreIsRestricted($UserID);
+      $IgnoreRestricted = $this->IgnoreIsRestricted();
       $UserIgnored = $this->Ignored($UserID);
       $Mode = $UserIgnored ? 'unset' : 'set';
       $ActionText = T($Mode == 'set' ? 'Ignore' : 'Unignore');
@@ -646,19 +646,29 @@ class IgnorePlugin extends Gdn_Plugin {
 
    /**
     * Is this user forbidden from using ignore?
+    *
+    * @param int|null $userID ID for the user to verify ignore permissions for. Current user if none specified.
+    * @return bool|string IgnorePlugin::IGNORE_RESTRICTED if user cannot ignore, otherwise false.
     */
-   public function IgnoreIsRestricted($UserID = NULL) {
+   public function ignoreIsRestricted($userID = NULL) {
       // Guests cant ignore
-      if (!Gdn::Session()->IsValid()) return TRUE;
+      if (!Gdn::session()->isValid()) {
+         return self::IGNORE_RESTRICTED;
+      }
 
-      if (is_null($UserID))
-         $UserID = Gdn::Session()->UserID;
+      if (is_null($userID)) {
+         $userID = Gdn::session()->UserID;
+      }
 
-      if (is_null($UserID)) return TRUE;
+      if (is_null($userID)) {
+         return self::IGNORE_RESTRICTED;
+      }
 
-      $IgnoreRestricted = $this->GetUserMeta($UserID, 'Plugin.Ignore.Forbidden');
-      $IgnoreRestricted = GetValue('Plugin.Ignore.Forbidden', $IgnoreRestricted, FALSE);
-      if ($IgnoreRestricted) return TRUE;
+      $isRestricted = $this->getUserMeta($userID, 'Plugin.Ignore.Forbidden');
+      $isRestricted = val('Plugin.Ignore.Forbidden', $isRestricted, FALSE);
+      if ($isRestricted) {
+         return self::IGNORE_RESTRICTED;
+      }
 
       return FALSE;
    }


### PR DESCRIPTION
When ignoring a user, the Ignore plug-in currently [checks the ignore permissions of the target user](https://github.com/vanilla/addons/blob/30546963e6f7f1d9e3bcf72606f386cf930bdbe8/plugins/Ignore/class.ignore.plugin.php#L400), not the current user.  If you're attempting to unignore a user who has had their ignore permissions revoked, you're met with a "You can't ignore that person" error.  You can *ignore* those kinds of users, because when setting up a new ignore, `IgnorePlugin::ignoreRestricted` overwrites the value being checked with a result verifying the target user isn't an administrator or something.  When you're *unignoring* a user, the value is being set to `true` and matches the first case in the switch statement that follows.

This update removes the `$UserID` parameter being passed to `IgnorePlugin::ignoreIsRestricted`, so the permissions of the current user, not the target user, are used to determine availability of ignore capabilities.  In addition, `IgnorePlugin::ignoreIsRestricted`now returns `false` or `self::IGNORE_RESTRICTED`, instead of `true`, so it can work properly with the switch statement.  Existing checks for a truthy value returned from this function should still work.  Lastly, coding standards have been updated in the function.

Closes #413 