### PR TITLE
[Troll] Fix the toggle option not being avalaible in the profile when there are no trolls

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -379,9 +379,6 @@ class TrollManagementPlugin extends Gdn_Plugin {
             $userID = $sender->User->UserID;
 
             $trolls = self::getTrolls();
-            if (!count($trolls)) {
-                return;
-            }
 
             $troll = in_array($userID, $trolls) ? 1 : 0;
 

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -370,7 +370,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Add option to remove troll status from users
+     * Add toggle option to add/remove troll status from users
      *
      * @param ProfileController $sender
      */


### PR DESCRIPTION
If there were no trolls, the option to mark an user as one would never appear.