### PR TITLE
Fix Q&A point-awarding interactions with Reactions

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -526,8 +526,10 @@ class QnAPlugin extends Gdn_Plugin {
                     include_once(Gdn::controller()->fetchViewLocation('reaction_functions', '', 'plugins/Reactions'));
                     $Rm = new ReactionModel();
 
+                    // Assume that the reaction is done by the question's owner
+                    $questionOwner = $Discussion['InsertUserID'];
                     // If there's change, reactions will take care of it
-                    $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer', null, true);
+                    $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer', $questionOwner, true);
                 }
             }
 
@@ -698,8 +700,10 @@ class QnAPlugin extends Gdn_Plugin {
                         include_once(Gdn::controller()->fetchViewLocation('reaction_functions', '', 'plugins/Reactions'));
                         $Rm = new ReactionModel();
 
+                        // Assume that the reaction is done by the question's owner
+                        $questionOwner = $Discussion['InsertUserID'];
                         // If there's change, reactions will take care of it
-                        $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer');
+                        $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer', $questionOwner, true);
                     }
                 }
             }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1089,7 +1089,7 @@ class QnAPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Give point(s) to users for their first answer on an answered question!
+     * Give point(s) to users for their first answer on an unanswered question!
      *
      * @param CommentModel $sender Sending controller instance.
      * @param array $args Event arguments.

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -508,15 +508,10 @@ class QnAPlugin extends Gdn_Plugin {
                         }
                         break;
                 }
-
-                $nbsPoint = $Change * (int)c('QnA.Points.AcceptedAnswer', 1);
-                if ($nbsPoint && !$this->Reactions && c('QnA.Points.Enabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
-                    UserModel::givePoints($Comment['InsertUserID'], $nbsPoint, 'QnA');
-                }
             }
 
             // Apply change effects
-            if ($Change) {
+            if ($Change && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
                 // Update the user
                 $UserID = val('InsertUserID', $Comment);
                 $this->recalculateUserQnA($UserID);
@@ -530,6 +525,11 @@ class QnAPlugin extends Gdn_Plugin {
                     $questionOwner = $Discussion['InsertUserID'];
                     // If there's change, reactions will take care of it
                     $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer', $questionOwner, true);
+                } else {
+                    $nbsPoint = $Change * (int)c('QnA.Points.AcceptedAnswer', 1);
+                    if ($nbsPoint && c('QnA.Points.Enabled', false)) {
+                        UserModel::givePoints($Comment['InsertUserID'], $nbsPoint, 'QnA');
+                    }
                 }
             }
 
@@ -681,16 +681,10 @@ class QnAPlugin extends Gdn_Plugin {
                             }
                             break;
                     }
-
-                    $nbsPoint = $Change * (int)c('QnA.Points.AcceptedAnswer', 1);
-                    if ($nbsPoint && !$this->Reactions && c('QnA.Points.Enabled', false) && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
-                        UserModel::givePoints($Comment['InsertUserID'], $nbsPoint, 'QnA');
-                    }
                 }
 
                 // Apply change effects
-                if ($Change) {
-
+                if ($Change && $Discussion['InsertUserID'] != $Comment['InsertUserID']) {
                     // Update the user
                     $UserID = val('InsertUserID', $Comment);
                     $this->recalculateUserQnA($UserID);
@@ -704,6 +698,11 @@ class QnAPlugin extends Gdn_Plugin {
                         $questionOwner = $Discussion['InsertUserID'];
                         // If there's change, reactions will take care of it
                         $Rm->react('Comment', $Comment['CommentID'], 'AcceptAnswer', $questionOwner, true);
+                    } else {
+                        $nbsPoint = $Change * (int)c('QnA.Points.AcceptedAnswer', 1);
+                        if ($nbsPoint && c('QnA.Points.Enabled', false)) {
+                            UserModel::givePoints($Comment['InsertUserID'], $nbsPoint, 'QnA');
+                        }
                     }
                 }
             }

--- a/plugins/QnA/structure.php
+++ b/plugins/QnA/structure.php
@@ -157,18 +157,26 @@ if ($this->Reactions && class_exists('ReactionModel')) {
         }
 
         // AcceptAnswer
-        $Rm->defineReactionType([
-            'UrlCode' => 'AcceptAnswer',
-            'Name' => 'Accept Answer',
-            'Sort' => 0,
-            'Class' => 'Positive',
-            'IncrementColumn' => 'Score',
-            'IncrementValue' => 5,
-            'Points' => $points,
-            'Permission' => 'Garden.Curation.Manage',
-            'Hidden' => 1,
-            'Description' => "When someone correctly answers a question, they are rewarded with this reaction."
-        ]);
+        $record = $Rm->getWhere(['UrlCode' => 'AcceptAnswer']);
+        if (!$record) {
+            $result = $Rm->defineReactionType([
+                'UrlCode' => 'AcceptAnswer',
+                'Name' => 'Accept Answer',
+                'Sort' => 0,
+                'Class' => 'Positive',
+                'IncrementColumn' => 'Score',
+                'IncrementValue' => 5,
+                'Points' => $points,
+                'Permission' => 'Garden.Curation.Manage',
+                'Hidden' => 1,
+                'Description' => "When someone correctly answers a question, they are rewarded with this reaction."
+            ]);
+        } else {
+            $Rm->save([
+                'UrlCode' => 'AcceptAnswer',
+                'Points' => $points,
+            ]);
+        }
     }
 
     Gdn::structure()->reset();


### PR DESCRIPTION
Fix https://github.com/vanilla/addons/issues/428

- [x] Change points properly using the QnAOptions (admin tool)
  - [x] With Reaction turned ON
  - [x] With Reaction turned OFF
- [x] Update Accepted Answer reaction points properly
  - [x] First setup with the Reaction plugin ON
  - [x] Subsequent setup with the Reaction plugin ON (Turn the QnA plugin on and configure the point feature then turn the plugin off, turn reaction ON, turn the QnA plugin back ON)

Check the UserPoint table.
If Reaction is OFF the only source should be QnA.
If Reaction is ON there should be both QnA (for first answer on a question) and Reaction (for accepted answer).

Using the QnAOptions tool should remove/add points properly.