### PR TITLE
Link to root of forum when opting out of Welcome Post

### DIFF
--- a/plugins/welcomepost/class.welcomepost.plugin.php
+++ b/plugins/welcomepost/class.welcomepost.plugin.php
@@ -108,7 +108,8 @@ class WelcomePostPlugin extends Gdn_Plugin {
      */
     public function entryController_registrationSuccessful_handler($sender, $args) {
         if (!c('Garden.Registration.ConfirmEmail')) {
-            redirect('/post/discussion?welcomepost=true');
+            $target = (Gdn::request()->post('Target')) ? '&Target='.Gdn::request()->post('Target') : null;
+            redirect('/post/discussion?welcomepost=true'.$target);
         }
     }
 
@@ -119,7 +120,7 @@ class WelcomePostPlugin extends Gdn_Plugin {
      * @param UserModel $args
      */
     public function userModel_afterSignIn_handler($sender, $args) {
-        $target = (Gdn::request()->get('Target')) ? '&Target='.Gdn::request()->get('Target') : null;
+        $target = (Gdn::request()->post('Target')) ? '&Target='.Gdn::request()->post('Target') : null;
         // AfterSignIn event is fired in several places, the InsertUserID
         // argument is only passed in the connect script.
         if (val('InsertUserID', $args)) {
@@ -170,7 +171,7 @@ class WelcomePostPlugin extends Gdn_Plugin {
         Gdn::locale()->setTranslation('Cancel', t('Skip'));
 
         //Skipping will bring you to where you were going
-        $cancelURL = ($sender->Request->get('Target')) ? $sender->Request->get('Target') : '/';
+        $cancelURL = (Gdn::request()->get('Target')) ? Gdn::request()->get('Target') : '/';
         $sender->setData('_CancelUrl', $cancelURL);
 
         $username = val('Name', Gdn::session()->User, 'Unknown');

--- a/plugins/welcomepost/class.welcomepost.plugin.php
+++ b/plugins/welcomepost/class.welcomepost.plugin.php
@@ -170,7 +170,7 @@ class WelcomePostPlugin extends Gdn_Plugin {
         Gdn::locale()->setTranslation('Cancel', t('Skip'));
 
         //Skipping will bring you to where you were going
-        $cancelURL = ($sender->Request->get('Target')) ? $sender->Request->get('Target') : c('Routes.DefaultController', '/');
+        $cancelURL = ($sender->Request->get('Target')) ? $sender->Request->get('Target') : '/';
         $sender->setData('_CancelUrl', $cancelURL);
 
         $username = val('Name', Gdn::session()->User, 'Unknown');

--- a/plugins/welcomepost/class.welcomepost.plugin.php
+++ b/plugins/welcomepost/class.welcomepost.plugin.php
@@ -172,6 +172,7 @@ class WelcomePostPlugin extends Gdn_Plugin {
 
         //Skipping will bring you to where you were going
         $cancelURL = (Gdn::request()->get('Target')) ? Gdn::request()->get('Target') : '/';
+        $cancelURL = (isSafeUrl($cancelURL)) ? $cancelURL : null;
         $sender->setData('_CancelUrl', $cancelURL);
 
         $username = val('Name', Gdn::session()->User, 'Unknown');


### PR DESCRIPTION
The Welcome Post gives the user the option to not post a "Welcome" post by clicking cancel which would send you to the default controller. This could have some unwanted consequences. This PR sends the user to / and assumes routing will make sure the user is going to the default page. 