### PR TITLE
Update Pockets plugin enable/disable state

### DIFF
--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -74,6 +74,17 @@ class Pocket {
     }
 
     /**
+     * The Disabled field used to have 3 states: enabled, disabled, or testing. Testing has since branched out
+     * into its own field: TestMode. We need to check both places to see if a pocket is in test mode.
+     *
+     * @param $pocket
+     * @return bool
+     */
+    public static function inTestMode($pocket) {
+        return (val('Disabled', $pocket) === Pocket::TESTING) || (val('TestMode', $pocket) === 1);
+    }
+
+    /**
      * Whether or not this pocket should be processed based on its state.
      *
      * @param array $Data Data specific to the request.
@@ -101,7 +112,7 @@ class Pocket {
         switch ($this->Disabled) {
             case Pocket::DISABLED:
                 return false;
-            case Pocket::TESTING:
+            case self::inTestMode($this):
                 if (!checkPermission('Plugins.Pockets.Manage'))
                     return false;
                 break;

--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -55,6 +55,9 @@ class Pocket {
     /** $var string Pocket type */
     public $Type;
 
+    /** $var string Whether the pocket is in test mode. */
+    public $TestMode = false;
+
     /** $var bool Whether to disable the pocket for embedded comments. * */
     public $EmbeddedNever = false;
 
@@ -108,14 +111,12 @@ class Pocket {
             return false;
         }
 
-        // Check to see if the pocket is enabled.
-        switch ($this->Disabled) {
-            case Pocket::DISABLED:
-                return false;
-            case self::inTestMode($this):
-                if (!checkPermission('Plugins.Pockets.Manage'))
-                    return false;
-                break;
+        if ($this->Disabled === Pocket::DISABLED) {
+            return false;
+        }
+
+        if (self::inTestMode($this) && !checkPermission('Plugins.Pockets.Manage')) {
+            return false;
         }
 
         // Check to see if the page matches.
@@ -176,6 +177,7 @@ class Pocket {
         $this->Type = val('Type', $Data, Pocket::TYPE_DEFAULT);
         $this->EmbeddedNever = val('EmbeddedNever', $Data);
         $this->ShowInDashboard = val('ShowInDashboard', $Data);
+        $this->TestMode = val('TestMode', $Data);
 
         // parse the frequency.
         $Repeat = $Data['Repeat'];

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -2,11 +2,21 @@
 
 echo '<h1>', $this->data('Title'), '</h1>';
 
+/** @var Gdn_Form $Form */
 $Form = $this->Form; //new Gdn_Form();
 echo $Form->open();
 echo $Form->errors();
 ?>
 <ul>
+    <li class="form-group">
+        <div class="label-wrap-wide">
+            <?php echo $Form->label('Enable Pocket', 'Enabled'); ?>
+            <div class="info"><?php echo t('Disabled pockets will not be displayed.'); ?></div>
+        </div>
+        <div class="input-wrap-right">
+            <?php echo $Form->toggle('Enabled'); ?>
+        </div>
+    </li>
     <li class="form-group">
         <div class="label-wrap">
         <?php
@@ -21,7 +31,7 @@ echo $Form->errors();
             echo $Form->label('Body', 'Body');
             echo '<div class="info">', t('The text of the pocket.', 'Enter the text of the pocket. This will be output exactly as you type it so make sure that you enter valid HTML.'), '</div>'; ?>
         </div>
-        <?php echo $Form->textBoxWrap('Body', array('Multiline' => true));
+        <?php echo $Form->textBoxWrap('Body', ['Multiline' => true, 'class' => 'js-pocket-body']);
         ?>
     </li>
     <li class="form-group">
@@ -95,16 +105,12 @@ echo $Form->errors();
         </div>
     </li>
     <li class="form-group">
-        <?php
-            echo $Form->labelWrap('Enable/Disable', 'Disabled'); ?>
-        <div class="input-wrap">
-        <?php
-            echo '<div>', $Form->radio('Disabled', t('Enabled', 'Enabled: The pocket will be displayed.'), array('Value' => Pocket::ENABLED)), '</div>';
-
-            echo '<div>', $Form->radio('Disabled', t('Disabled', 'Disabled: The pocket will <b>not</b> be displayed.'), array('Value' => Pocket::DISABLED)), '</div>';
-
-            echo '<div>', $Form->radio('Disabled', t('Test Mode', 'Test Mode: The pocket will only be displayed for pocket administrators.'), array('Value' => Pocket::TESTING)), '</div>';
-        ?>
+        <div class="label-wrap-wide">
+            <?php echo $Form->label('Test Mode', 'Testing'); ?>
+            <?php echo wrap(t('The pocket will only be displayed for pocket administrators.'), 'div', ['class' => 'info']) ?>
+        </div>
+        <div class="input-wrap-right">
+            <?php echo $Form->toggle('TestMode'); ?>
         </div>
     </li>
 </ul>

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -27,46 +27,32 @@ echo heading($this->data('Title'), sprintf(t('Add %s'), t('Pocket')), 'settings/
             <tr>
                 <th class="column-md"><?php echo t('Name'); ?></th>
                 <th class="column-xl"><?php echo t('Pocket'); ?></th>
-                <th class="column-sm"></th>
+                <th class="column-md"></th>
             </tr>
         </thead>
         <tbody>
             <?php
             foreach ($this->data('PocketData') as $PocketRow) {
-                 $MobileOnly = $PocketRow['MobileOnly'];
-                 $MobileNever = $PocketRow['MobileNever'];
-                 $NoAds = $PocketRow['Type'] == Pocket::TYPE_AD;
-
                 echo '<tr'.($PocketRow['Disabled'] != Pocket::DISABLED ? '' : ' class="Disabled"').'>';
 
                 echo '<td>',
                     '<strong>', htmlspecialchars($PocketRow['Name']), '</strong>';
-                    if ($notes = $PocketRow['Notes']) {
-                        echo '<div class="info pocket-notes">'.sprintf(t('%s: %s'), t('Notes'), $notes).'</div>';
-                    }
-                    if ($page = htmlspecialchars($PocketRow['Page'])) {
-                        echo '<div class="info pocket-page">'.sprintf(t('%s: %s'), t('Page'), $page).'</div>';
-                    }
-                    if ($location = htmlspecialchars($PocketRow['Location'])) {
-                        echo '<div class="info pocket-location">'.sprintf(t('%s: %s'), t('Location'), $location).'</div>';
-                    }
-                    if ($MobileOnly) {
-                        echo '<div class="info">(', t('Shown only on mobile'), ')</div>';
-                    }
-                    if ($MobileNever) {
-                        echo '<div class="info">(', t('Hidden for mobile'), ')</div>';
-                    }
-                    if ($MobileNever && $MobileOnly) {
-                        echo '<div class="info">(', t('Hidden for everything!'), ')</div>';
-                    }
-                    if ($NoAds) {
-                        echo '<div class="info">(', t('Users with the no ads permission will not see this pocket.'), ')</div>';
-                    }
-                    '</td>';
+
+                $meta = $PocketRow['Meta'];
+                echo '<div class="table-meta">';
+                foreach ($meta as $metaItem) {
+                    $label = wrap(sprintf(t('%s: %s'), val('label', $metaItem), ''), 'span', ['class' => 'table-meta-item-label']);
+                    $value = wrap(val('value', $metaItem), 'span', ['class' => 'table-meta-item-data']);
+                    echo '<div class="table-meta-item">'.$label.$value.'</div>';
+                }
+
+                echo '</div>';
+                echo '</td>';
                 echo '<td><pre style="white-space: pre-wrap;">', nl2br(htmlspecialchars(substr($PocketRow['Body'], 0, 200))), '</pre></td>';
                 echo '<td class="options"><div class="btn-group">';
                 echo anchor(dashboardSymbol('edit'), "/settings/pockets/edit/{$PocketRow['PocketID']}", 'js-modal btn btn-icon', ['aria-label' => t('Edit'), 'title' => t('Edit'), 'data-content' => ['cssClass' => 'pockets']]);
                 echo anchor(dashboardSymbol('delete'), "/settings/pockets/delete/{$PocketRow['PocketID']}", 'Popup btn btn-icon', ['aria-label' => t('Delete'), 'title' => t('Delete')]);
+                echo renderPocketToggle($PocketRow);
                 echo '</div></td>';
                 echo "</tr>\n";
             }


### PR DESCRIPTION
This update will require a utility/update for the Test Mode enabling to work properly.

* Refactor the test mode out of the Disabled field in the Pockets table
* Add a TestMode column to the Pockets table
* Add a toggle to enable/disable a pocket from the Pockets index
* Add enable and disable endpoints to the plugin

Relies on https://github.com/vanilla/vanilla/pull/5216 for styling tweaks
Closes https://github.com/vanilla/vanilla/issues/5098