### PR TITLE
Fix redirector plugin for vBulletin case showthread.php?=p

### DIFF
--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -249,27 +249,32 @@ class RedirectorPlugin extends Gdn_Plugin {
             if ($Value !== null)
                 $Vars[$Opts[0]] = $Value;
         }
-
         trace($Vars, 'Translated Arguments');
         // Now let's see what kind of record we have.
         // We'll check the various primary keys in order of importance.
         $Result = false;
+
         if (isset($Vars['CommentID'])) {
             trace("Looking up comment {$Vars['CommentID']}.");
-
             $CommentModel = new CommentModel();
             // If a legacy slug is provided (assigned during a merge), attempt to lookup the comment using it
             if (isset($Get['legacy']) && Gdn::Structure()->Table('Comment')->ColumnExists('ForeignID')) {
-                $Comment = $CommentModel->GetWhere(['ForeignID' => $Get['legacy'] . '-' . $Vars['CommentID']])->FirstRow();
+                $Comment = $CommentModel->GetWhere(['ForeignID' => $Vars['CommentID']])->FirstRow();
+
             } else {
                 $Comment = $CommentModel->GetID($Vars['CommentID']);
             }
             if ($Comment) {
                 $Result = CommentUrl($Comment, '//');
+            } else {
+                // vBulletin, defaulting to discussions (foreign ID) when showthread.php?p=xxxx returns no comment
+                $Vars['DiscussionID'] = $Vars['CommentID'];
+                unset($Vars['CommentID']);
             }
-        } elseif (isset($Vars['DiscussionID'])) {
+        }
+        // Splitting the if statement to default to discussions (foreign ID) when showthread.php?p=xxxx returns no comment
+        if (isset($Vars['DiscussionID'])) {
             trace("Looking up discussion {$Vars['DiscussionID']}.");
-
             $DiscussionModel = new DiscussionModel();
             $DiscussionID = $Vars['DiscussionID'];
             $Discussion = false;
@@ -277,7 +282,7 @@ class RedirectorPlugin extends Gdn_Plugin {
             if (is_numeric($DiscussionID)) {
                 // If a legacy slug is provided (assigned during a merge), attempt to lookup the discussion using it
                 if (isset($Get['legacy']) && Gdn::Structure()->Table('Discussion')->ColumnExists('ForeignID')) {
-                    $Discussion = $DiscussionModel->GetWhere(['ForeignID' => $Get['legacy'] . '-' . $DiscussionID])->FirstRow();
+                    $Discussion = $DiscussionModel->GetWhere(['ForeignID' => $DiscussionID])->FirstRow();
                 } else {
                     $Discussion = $DiscussionModel->GetID($Vars['DiscussionID']);
                 }
@@ -519,7 +524,6 @@ class RedirectorPlugin extends Gdn_Plugin {
      * @return array Mapping of vB parameters
      */
     public static function showthreadFilter(&$Get) {
-
         $data = array(
             'p' => 'CommentID',
             'page' => 'Page',
@@ -540,12 +544,11 @@ class RedirectorPlugin extends Gdn_Plugin {
             ];
             self::vbFriendlyUrlID($Get, 't');
         } elseif (isset($Get['p'])) {
-            $data['p'] = 'DiscussionID';
+            $data['p'] = 'CommentID';
             $Get['legacy'] = true;
         }
-
-
         return $data;
+
     }
 
     /**

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -270,6 +270,7 @@ class RedirectorPlugin extends Gdn_Plugin {
                 // vBulletin, defaulting to discussions (foreign ID) when showthread.php?p=xxxx returns no comment
                 $Vars['DiscussionID'] = $Vars['CommentID'];
                 unset($Vars['CommentID']);
+                $Get['legacy'] = true;
             }
         }
         // Splitting the if statement to default to discussions (foreign ID) when showthread.php?p=xxxx returns no comment
@@ -543,9 +544,6 @@ class RedirectorPlugin extends Gdn_Plugin {
                 'Filter' => [__CLASS__, 'removeID']
             ];
             self::vbFriendlyUrlID($Get, 't');
-        } elseif (isset($Get['p'])) {
-            $data['p'] = 'CommentID';
-            $Get['legacy'] = true;
         }
         return $data;
 


### PR DESCRIPTION
Modified behaviour of redirector plugin for the vBulletin case"showthread.php?=p".

First the plugin will try to match the URL to a comment. If no comment is returned, the plugin will try to match if to a discussion using the foreign ID column.

Fixes https://github.com/vanilla/addons/issues/460