### PR TITLE
Sitemap Plugin - Added event to filter categories

### DIFF
--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -124,8 +124,8 @@ class SitemapsPlugin extends Gdn_Plugin {
     }
 
     /**
-     * @param Gdn_Controller $Sender
-     * @param type $args
+     * @param UtilityController $Sender Sending controller instance
+     * @param array $args Event's arguments
      */
     public function utilityController_siteMapIndex_create($Sender, $args) {
         // Clear the session to mimic a crawler.
@@ -160,7 +160,11 @@ class SitemapsPlugin extends Gdn_Plugin {
         $Sender->render('SiteMapIndex', '', 'plugins/Sitemaps');
     }
 
-    public function utilityController_siteMap_create($Sender, $Args = []) {
+    /**
+     * @param UtilityController $Sender Sending controller instance
+     * @param array $args Event's arguments
+     */
+    public function utilityController_siteMap_create($Sender, $Args) {
         Gdn::session()->start(0, false, false);
         $Sender->deliveryMethod(DELIVERY_METHOD_XHTML);
         $Sender->deliveryType(DELIVERY_TYPE_VIEW);

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -125,9 +125,9 @@ class SitemapsPlugin extends Gdn_Plugin {
 
     /**
      * @param Gdn_Controller $Sender
-     * @param type $Args
+     * @param type $args
      */
-    public function utilityController_siteMapIndex_create($Sender, $args = []) {
+    public function utilityController_siteMapIndex_create($Sender, $args) {
         // Clear the session to mimic a crawler.
         Gdn::session()->start(0, false, false);
         $Sender->deliveryMethod(DELIVERY_METHOD_XHTML);

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -127,7 +127,7 @@ class SitemapsPlugin extends Gdn_Plugin {
      * @param Gdn_Controller $Sender
      * @param type $Args
      */
-    public function utilityController_siteMapIndex_create($Sender) {
+    public function utilityController_siteMapIndex_create($Sender, $args = []) {
         // Clear the session to mimic a crawler.
         Gdn::session()->start(0, false, false);
         $Sender->deliveryMethod(DELIVERY_METHOD_XHTML);
@@ -138,6 +138,10 @@ class SitemapsPlugin extends Gdn_Plugin {
 
         if (class_exists('CategoryModel')) {
             $Categories = CategoryModel::categories();
+
+            $this->EventArguments['Categories'] = &$categories;
+            $this->fireEvent('siteMapCategories');
+
             foreach ($Categories as $Category) {
                 if (!$Category['PermsDiscussionsView'] || $Category['CategoryID'] < 0 || $Category['CountDiscussions'] == 0) {
                     continue;

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -170,7 +170,7 @@ class SitemapsPlugin extends Gdn_Plugin {
         $Sender->deliveryType(DELIVERY_TYPE_VIEW);
         $Sender->setHeader('Content-Type', 'text/xml');
 
-        $Arg = stringEndsWith(GetValue(0, $Args), '.xml', true, true);
+        $Arg = stringEndsWith(val(0, $Args), '.xml', true, true);
         $Parts = explode('-', $Arg, 2);
         $Type = strtolower($Parts[0]);
         $Arg = val(1, $Parts, '');

--- a/plugins/Sitemaps/views/settings.php
+++ b/plugins/Sitemaps/views/settings.php
@@ -1,22 +1,21 @@
-<?php if (!defined('APPLICATION')) { exit; } ?>
+<?php if (!defined('APPLICATION')) exit; ?>
 
 <h1><?php echo $this->data('Title'); ?></h1>
 <div class="padded">
-    A site map is an <a href="http://en.wikipedia.org/wiki/XML">xml</a> file that search engines can use to help index
-    your site.
+    <p>
+        A site map is an <a href="http://en.wikipedia.org/wiki/XML" target="_blank">xml</a> file that search engines can use to help index your site.
+    </p>
+    <p>
     <ul>
-        <li>Your main site map is located here: <?php echo Gdn_Format::links(Url('/sitemapindex.xml', true)); ?>.</li>
-        <li>Your <?php echo anchor('robots.txt', url('/robots.txt', true)) ?> file contains the location of this site
-            map so that search engines that are aware of your site will know where to look.
-        </li>
+        <li>Your main site map is located here: <?php echo Gdn_Format::links(url('/sitemapindex.xml', true)); ?>.</li>
+        <li>Your <?php echo anchor('robots.txt', url('/robots.txt', true)) ?> file contains the location of this site map so that search engines that are aware of your site will know where to look.</li>
     </ul>
-</div>
-<div class="alert alert-info">
+    </p>
     <?php
     echo '<p>', sprintf(t('Learm more about %s from the following sites:'), t('sitemaps')), '</p>';
     echo '<ul>';
-    echo '<li>', anchor('sitemaps.org', 'http://www.sitemaps.org/'), '</li>';
-    echo '<li>', anchor('Google webmaster center', 'http://www.google.com/webmasters/'), '</li>';
+    echo '<li>', anchor('sitemaps.org', 'http://www.sitemaps.org/', '', ['target' => '_blank']), '</li>';
+    echo '<li>', anchor('Google webmaster center', 'http://www.google.com/webmasters/',  '', ['target' => '_blank']), '</li>';
     echo '</ul>';
     ?>
 </div>


### PR DESCRIPTION
This plugin didn't work properly with plugins that changed the url structure of Vanilla. I've added an event that allows to filter the categories sent to the plugin.