### PR TITLE
Optimize discussion polling in Participated plug-in

### DIFF
--- a/plugins/Participated/class.participated.plugin.php
+++ b/plugins/Participated/class.participated.plugin.php
@@ -67,8 +67,10 @@ class ParticipatedPlugin extends Gdn_Plugin {
         $sender->SQL->select('d.*')
             ->from('UserDiscussion ud')
             ->join('Discussion d', 'ud.DiscussionID = d.DiscussionID')
+            ->join('Comment c', 'ud.DiscussionID = c.DiscussionID and c.InsertUserID = ud.UserID')
             ->where('ud.UserID', $userID)
             ->where('ud.Participated', 1)
+            ->groupBy('d.DiscussionID')
             ->orderBy('d.DateLastComment', 'desc')
             ->limit($limit, $offset);
 

--- a/plugins/Participated/class.participated.plugin.php
+++ b/plugins/Participated/class.participated.plugin.php
@@ -64,21 +64,23 @@ class ParticipatedPlugin extends Gdn_Plugin {
         }
 
         $sender->SQL->reset();
-        $sender->discussionSummaryQuery();
-
-        $data = $sender->SQL->select('d.*')
-            ->select('w.UserID', '', 'WatchUserID')
-            ->select('w.DateLastViewed, w.Dismissed, w.Bookmarked')
-            ->select('w.CountComments', '', 'CountCommentWatch')
-            ->join('UserDiscussion w', "d.DiscussionID = w.DiscussionID and w.UserID = {$userID}", 'left')
-            ->join('Comment c','d.DiscussionID = c.DiscussionID')
-            ->where('c.InsertUserID', $userID)
-            ->groupBy('c.DiscussionID')
+        $sender->SQL->select('d.*')
+            ->from('UserDiscussion ud')
+            ->join('Discussion d', 'ud.DiscussionID = d.DiscussionID')
+            ->where('ud.UserID', $userID)
+            ->where('ud.Participated', 1)
             ->orderBy('d.DateLastComment', 'desc')
-            ->limit($limit, $offset)
-            ->get();
+            ->limit($limit, $offset);
 
+        $permissions = DiscussionModel::categoryPermissions();
+        if ($permissions !== true) {
+            $sender->SQL->where('d.CategoryID', $permissions);
+        }
+
+        $data = $sender->SQL->get();
         $sender->addDiscussionColumns($data);
+        Gdn::userModel()->joinUsers($data, ['FirstUserID', 'LastUserID']);
+        CategoryModel::joinCategories($data);
 
         return $data;
     }


### PR DESCRIPTION
This update attempts to optimize how a user's "participated" discussions are queried. The UserDiscussion table is queried based on the value of the `Participated` field and the Discussion table is joined in.

The methods of joining in additional user and category data seemed outdated, so I've updated them to match what's currently used in `DiscussionModel::getWhere`.

Closes #462 