### PR TITLE
Fix Signature images count message

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -289,7 +289,7 @@ class SignaturesPlugin extends Gdn_Plugin {
 
         if ($maxNumberImages !== 'Unlimited') {
 
-            if (is_int($maxNumberImages) && $maxNumberImages > 0) {]
+            if (is_int($maxNumberImages) && $maxNumberImages > 0) {
                 $rulesParams['maxImages'] = $maxNumberImages;
                 $rules[] = FormatString(T('Use up to {maxImages,plural,%s image, %s images}.'), $rulesParams);
             } else {

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -284,15 +284,17 @@ class SignaturesPlugin extends Gdn_Plugin {
         $rules = array();
         $rulesParams = array();
         $imagesAllowed = true;
+        $maxNumberImages = c('Plugins.Signatures.MaxNumberImages', 'Unlimited');
 
 
-        if (C('Plugins.Signatures.MaxNumberImages', 'Unlimited') !== 'Unlimited') {
-            if (C('Plugins.Signatures.MaxNumberImages') === 'None') {
+        if ($maxNumberImages !== 'Unlimited') {
+
+            if (is_int($maxNumberImages) && $maxNumberImages > 0) {]
+                $rulesParams['maxImages'] = $maxNumberImages;
+                $rules[] = FormatString(T('Use up to {maxImages,plural,%s image, %s images}.'), $rulesParams);
+            } else {
                 $rules[] = T('Images not allowed.');
                 $imagesAllowed = false;
-            } else {
-                $rulesParams['maxImages'] = C('Plugins.Signatures.MaxNumberImages');
-                $rules[] = FormatString(T('Use up to {maxImages,plural,%s image, %s images}.'), $rulesParams);
             }
         }
         if ($imagesAllowed && C('Plugins.Signatures.MaxImageHeight') && C('Plugins.Signatures.MaxImageHeight') > 0) {


### PR DESCRIPTION
The signature image count message is often broken. The config values are too varied and cause bugs. The setSignatureRules function has been rewritten to be more robust.

The following config options have been changed:
`Plugins.Signatures.MaxNumberImages` to `Signatures.Images.MaxNumber`
`Plugins.Signatures.MaxImageHeight` to `Signatures.Images.MaxHeight`
`Plugins.Signatures.MaxLength` to `Plugins.Signatures.MaxLength`