### PR TITLE
Fix bug with bump link for forums located in subfolders.

### DIFF
--- a/plugins/Bump/class.bump.plugin.php
+++ b/plugins/Bump/class.bump.plugin.php
@@ -19,7 +19,7 @@ class BumpPlugin extends Gdn_Plugin {
       $Discussion = $Args['Discussion'];
       if (CheckPermission('Garden.Moderation.Manage')) {
          $Label = T('Bump');
-         $Url = "/discussion/bump?discussionid={$Discussion->DiscussionID}";
+         $Url = Url("discussion/bump?discussionid={$Discussion->DiscussionID}");
          // Deal with inconsistencies in how options are passed
          if (isset($Sender->Options)) {
             $Sender->Options .= Wrap(Anchor($Label, $Url, 'Bump'), 'li');


### PR DESCRIPTION
Please see here for reference: https://open.vanillaforums.com/discussion/comment/246983/#Comment_246983

Forums located in subfolders show a wrong link for bumping.