### PR TITLE
Fix signature plugin translate tags

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -108,7 +108,7 @@ class SignaturesPlugin extends Gdn_Plugin {
      */
     public function profileController_signature_create($Sender) {
         $Sender->permission('Garden.SignIn.Allow');
-        $Sender->title('Signature Settings');
+        $Sender->title(t('Signature Settings'));
 
         $this->dispatch($Sender);
     }

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -278,7 +278,7 @@ class SignaturesPlugin extends Gdn_Plugin {
             $Sig = Gdn_Format::to(val('Plugin.Signatures.Sig', $Values), val('Plugin.Signatures.Format', $Values, c('Garden.InputFormatter')));
             $numMatches = preg_match_all('/<img/i', $Sig);
             if (c('Plugins.Signatures.MaxNumberImages') === 'None' && $numMatches > 0) {
-                $Sender->Form->addError(t('Images not allowed'));
+                $Sender->Form->addError('Images not allowed');
             } else {
                 if ($numMatches > $max) {
                     $Sender->Form->addError('@'.formatString('You are only allowed {maxImages,plural,%s image,%s images}.',

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -278,7 +278,7 @@ class SignaturesPlugin extends Gdn_Plugin {
             $Sig = Gdn_Format::to(val('Plugin.Signatures.Sig', $Values), val('Plugin.Signatures.Format', $Values, c('Garden.InputFormatter')));
             $numMatches = preg_match_all('/<img/i', $Sig);
             if (c('Plugins.Signatures.MaxNumberImages') === 'None' && $numMatches > 0) {
-                $Sender->Form->addError('Images not allowed');
+                $Sender->Form->addError(t('Images not allowed'));
             } else {
                 if ($numMatches > $max) {
                     $Sender->Form->addError('@'.formatString('You are only allowed {maxImages,plural,%s image,%s images}.',
@@ -296,7 +296,7 @@ class SignaturesPlugin extends Gdn_Plugin {
 
         if (c('Plugins.Signatures.MaxNumberImages', 'Unlimited') !== 'Unlimited') {
             if (c('Plugins.Signatures.MaxNumberImages') === 'None') {
-                $rules[] = t('Images not allowed.');
+                $rules[] = t('Images not allowed').'.';
                 $imagesAllowed = false;
             } else {
                 $rulesParams['maxImages'] = c('Plugins.Signatures.MaxNumberImages');


### PR DESCRIPTION
One of the `t()` tags was missing and another was incorrect. Both of these already exist in vanilla/locales.