### PR TITLE
Add license information to PluginInfo array

### DIFF
--- a/plugins/Bump/class.bump.plugin.php
+++ b/plugins/Bump/class.bump.plugin.php
@@ -8,7 +8,8 @@ $PluginInfo['Bump'] = [
     'MobileFriendly' => true,
     'Author' => "Lincoln Russell",
     'AuthorEmail' => 'lincolnwebs@gmail.com',
-    'AuthorUrl' => 'http://lincolnwebs.com'
+    'AuthorUrl' => 'http://lincolnwebs.com',
+    'License' => 'GNU GPLv2'
 ];
 
 class BumpPlugin extends Gdn_Plugin {

--- a/plugins/Buttons/class.buttons.plugin.php
+++ b/plugins/Buttons/class.buttons.plugin.php
@@ -18,7 +18,8 @@ $PluginInfo['Buttons'] = array(
    'RequiredPlugins' => FALSE,
    'Author' => "Mark O'Sullivan",
    'AuthorEmail' => 'mark@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.com'
+   'AuthorUrl' => 'http://www.vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 class ButtonsPlugin extends Gdn_Plugin {

--- a/plugins/CategoryCollapser/class.categorycollapser.plugin.php
+++ b/plugins/CategoryCollapser/class.categorycollapser.plugin.php
@@ -9,7 +9,8 @@ $PluginInfo['CategoryCollapser'] = array(
    'AuthorUrl' => 'http://vanillaforums.com',
    'Icon' => 'collapse_categories.png',
    'RequiredApplications' => array('Vanilla' => '2.1'),
-   'MobileFriendly' => TRUE
+   'MobileFriendly' => TRUE,
+   'License' => 'GNU GPLv2'
 );
 
 class CategoryCollapserPlugin extends Gdn_Plugin {

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -16,7 +16,8 @@ $PluginInfo['CivilTongueEx'] = array(
     'AuthorUrl' => 'http://vanillaforums.org/profile/todd',
     'SettingsUrl' => '/plugin/tongue',
     'SettingsPermission' => 'Garden.Settings.Manage',
-    'Icon' => 'civil-tongue.png'
+    'Icon' => 'civil-tongue.png',
+    'License' => 'GNU GPLv2'
 );
 
 // 1.0 - Fix empty pattern when list ends in semi-colon, use non-custom permission (2012-03-12 Lincoln)

--- a/plugins/CloudflareSupport/class.cloudflaresupport.plugin.php
+++ b/plugins/CloudflareSupport/class.cloudflaresupport.plugin.php
@@ -17,7 +17,8 @@ $PluginInfo['CloudflareSupport'] = array(
    'SettingsPermission' => 'Garden.Settings.Manage',
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.com'
+   'AuthorUrl' => 'http://www.vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/CssThemes/class.cssthemes.plugin.php
+++ b/plugins/CssThemes/class.cssthemes.plugin.php
@@ -22,7 +22,8 @@ $PluginInfo['CssThemes'] = array(
    'SettingsPermission' => 'Garden.Themes.Manage', // The permission required to view the SettingsUrl.
    'Author' => "Todd Burry",
    'AuthorEmail' => 'todd@vanillaforums.com',
-   'AuthorUrl' => 'http://toddburry.com'
+   'AuthorUrl' => 'http://toddburry.com',
+   'License' => 'GNU GPLv2'
 );
 
 $tmp = Gdn::FactoryOverwrite(TRUE);

--- a/plugins/CustomizeText/class.customizetext.plugin.php
+++ b/plugins/CustomizeText/class.customizetext.plugin.php
@@ -25,7 +25,8 @@ $PluginInfo['CustomizeText'] = array(
    'AuthorUrl' => 'http://vanillaforums.com',
    'Icon' => 'custom_text.png',
    'SettingsUrl' => 'settings/customizetext',
-   'UsePopupSettings' => false
+   'UsePopupSettings' => false,
+   'License' => 'GNU GPLv2'
 );
 
 class CustomizeTextPlugin extends Gdn_Plugin {

--- a/plugins/Disqus/class.disqus.plugin.php
+++ b/plugins/Disqus/class.disqus.plugin.php
@@ -16,7 +16,8 @@ $PluginInfo['Disqus'] = array(
     'Author' => "Todd Burry",
     'AuthorEmail' => 'todd@vanillaforums.com',
     'SocialConnect'   => true,
-    'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd'
+    'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/EmailPasswordSync/class.emailpasswordsync.plugin.php
+++ b/plugins/EmailPasswordSync/class.emailpasswordsync.plugin.php
@@ -12,7 +12,8 @@ $PluginInfo['EmailPasswordSync'] = array(
    'RequiredApplications' => array('Vanilla' => '2.0.17'),
    'Author' => 'Todd Burry',
    'AuthorEmail' => 'todd@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd'
+   'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd',
+   'License' => 'GNU GPLv2'
 );
 
 class MultipleEmailsPlugin extends Gdn_Plugin {

--- a/plugins/FacebookID/class.facebookid.plugin.php
+++ b/plugins/FacebookID/class.facebookid.plugin.php
@@ -9,6 +9,7 @@ $PluginInfo['FacebookID'] = array(
    'AuthorEmail' => 'todd@vanillaforums.com',
    'AuthorUrl' => 'http://vanillaforums.com/profile/todd',
    'RegisterPermissions' => array('Plugins.FacebookID.View'),
+   'License' => 'GNU GPLv2'
 );
 
 class FacebookIDPlugin extends Gdn_Plugin {

--- a/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
+++ b/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
@@ -32,7 +32,8 @@ $PluginInfo['FeedDiscussions'] = [
     'Icon' => 'feed_discussions.png',
     'Author' => "Tim Gunter",
     'AuthorEmail' => 'tim@vanillaforums.com',
-    'AuthorUrl' => 'http://www.vanillaforums.com'
+    'AuthorUrl' => 'http://www.vanillaforums.com',
+    'License' => 'GNU GPLv2'
 ];
 
 class FeedDiscussionsPlugin extends Gdn_Plugin {

--- a/plugins/FileUpload/class.fileupload.plugin.php
+++ b/plugins/FileUpload/class.fileupload.plugin.php
@@ -33,7 +33,8 @@ $PluginInfo['FileUpload'] = [
     'Author' => "Tim Gunter",
     'AuthorEmail' => 'tim@vanillaforums.com',
     'AuthorUrl' => 'http://www.vanillaforums.com',
-    'Icon' => 'file-upload.png'
+    'Icon' => 'file-upload.png',
+    'License' => 'GNU GPLv2'
 ];
 
 /**

--- a/plugins/ForumMerge/class.forummerge.plugin.php
+++ b/plugins/ForumMerge/class.forummerge.plugin.php
@@ -8,7 +8,8 @@ $PluginInfo['ForumMerge'] = array(
    'Description' => 'Merge another Vanilla 2 forum into this one.',
    'Version' => '1.1',
    'Author' => "Lincoln Russell",
-   'AuthorEmail' => 'lincoln@vanillaforums.com'
+   'AuthorEmail' => 'lincoln@vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -38,7 +38,8 @@ $PluginInfo['Ignore'] = array(
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
    'AuthorUrl' => 'http://www.vanillaforums.com',
-   'Icon' => 'ignore.png'
+   'Icon' => 'ignore.png',
+   'License' => 'GNU GPLv2'
 );
 
 class IgnorePlugin extends Gdn_Plugin {

--- a/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
+++ b/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
@@ -9,7 +9,8 @@ $PluginInfo['InvisibilityCloak'] = array(
     'Version' => '1.0',
     'RequiredApplications' => ['Vanilla' => '2.1'],
     'Author' => "Lincoln Russell",
-    'AuthorEmail' => 'lincoln@vanillaforums.com'
+    'AuthorEmail' => 'lincoln@vanillaforums.com',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/LastEdited/class.lastedited.plugin.php
+++ b/plugins/LastEdited/class.lastedited.plugin.php
@@ -15,7 +15,8 @@ $PluginInfo['LastEdited'] = [
     'Author' => "Tim Gunter",
     'AuthorEmail' => 'tim@vanillaforums.com',
     'AuthorUrl' => 'http://www.vanillaforums.com',
-    'Icon' => 'last-edited.png'
+    'Icon' => 'last-edited.png',
+    'License' => 'GNU GPLv2'
 ];
 
 /**

--- a/plugins/Liked/class.liked.plugin.php
+++ b/plugins/Liked/class.liked.plugin.php
@@ -8,7 +8,8 @@ $PluginInfo['Liked'] = array(
    'Author' => "Gary Mardell",
    'Icon' => 'liked.png',
    'AuthorEmail' => 'gary@vanillaplugins.com',
-   'AuthorUrl' => 'http://garymardell.co.uk'
+   'AuthorUrl' => 'http://garymardell.co.uk',
+   'License' => 'GNU GPLv2'
 );
 
 class LikedPlugin extends Gdn_Plugin {

--- a/plugins/LinkTypes/class.linktypes.plugin.php
+++ b/plugins/LinkTypes/class.linktypes.plugin.php
@@ -12,7 +12,8 @@ $PluginInfo['LinkTypes'] = array(
    'Version' => '1.0',
    'RequiredApplications' => array('Vanilla' => '2.1'),
    'Author' => "Lincoln Russell",
-   'AuthorEmail' => 'lincoln@vanillaforums.com'
+   'AuthorEmail' => 'lincoln@vanillaforums.com',
+    'License' => 'GNU GPLv2'
 );
 
 class LinkTypesPlugin extends Gdn_Plugin {

--- a/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
+++ b/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
@@ -19,6 +19,7 @@ $PluginInfo['LocaleDeveloper'] = array(
     'RequiredApplications' => array('Vanilla' => '2.0.11'),
     'SettingsUrl' => '/settings/localedeveloper',
     'SettingsPermission' => 'Garden.Site.Manage',
+    'License' => 'GNU GPLv2'
 );
 
 class LocaleDeveloperPlugin extends Gdn_Plugin {

--- a/plugins/MathJax/class.mathjax.plugin.php
+++ b/plugins/MathJax/class.mathjax.plugin.php
@@ -12,7 +12,8 @@ $PluginInfo['MathJax'] = array(
     'MobileFriendly' => TRUE,
     'Author' => "Tim Gunter",
     'AuthorEmail' => 'tim@vanillaforums.com',
-    'AuthorUrl' => 'http://www.vanillaforums.com'
+    'AuthorUrl' => 'http://www.vanillaforums.com',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/MeAction/class.meaction.plugin.php
+++ b/plugins/MeAction/class.meaction.plugin.php
@@ -7,7 +7,8 @@ $PluginInfo['MeAction'] = array(
     'MobileFriendly' => true,
     'Author' => 'Lincoln Russell',
     'AuthorEmail' => 'lincoln@vanillaforums.com',
-    'AuthorUrl' => 'http://lincolnwebs.com'
+    'AuthorUrl' => 'http://lincolnwebs.com',
+    'License' => 'GNU GPLv2'
 );
 
 class MeActionPlugin extends Gdn_Plugin {

--- a/plugins/MessageLink/class.messagelink.plugin.php
+++ b/plugins/MessageLink/class.messagelink.plugin.php
@@ -8,7 +8,8 @@ $PluginInfo['MessageLink'] = array(
    'MobileFriendly' => TRUE,
    'Author' => "Lincoln Russell",
    'AuthorEmail' => 'lincoln@vanillaforums.com',
-   'AuthorUrl' => 'http://lincolnwebs.com'
+   'AuthorUrl' => 'http://lincolnwebs.com',
+   'License' => 'GNU GPLv2'
 );
 
 class MessageLinkPlugin extends Gdn_Plugin {

--- a/plugins/Minify/class.minify.plugin.php
+++ b/plugins/Minify/class.minify.plugin.php
@@ -15,7 +15,8 @@ $PluginInfo['Minify'] = array(
    'Version' => '1.0.3b',
    'Author' => "Mark O'Sullivan",
    'AuthorEmail' => 'mark@vanillaforums.com',
-   'AuthorUrl' => 'http://markosullivan.ca'
+   'AuthorUrl' => 'http://markosullivan.ca',
+   'License' => 'GNU GPLv2'
 );
 
 class MinifyPlugin extends Gdn_Plugin {

--- a/plugins/Mollom/class.mollom.plugin.php
+++ b/plugins/Mollom/class.mollom.plugin.php
@@ -13,7 +13,8 @@ $PluginInfo['Mollom'] = array(
    'SettingsUrl' => '/settings/mollom',
    'SettingsPermission' => 'Garden.Settings.Manage',
    'Author' => 'Lincoln Russell',
-   'AuthorEmail' => 'lincoln@vanillaforums.com'
+   'AuthorEmail' => 'lincoln@vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 class MollomPlugin extends Gdn_Plugin {

--- a/plugins/Multilingual/class.multilingual.plugin.php
+++ b/plugins/Multilingual/class.multilingual.plugin.php
@@ -18,7 +18,8 @@ $PluginInfo['Multilingual'] = array(
     'Author' => "Lincoln Russell",
     'AuthorEmail' => 'lincoln@vanillaforums.com',
     'AuthorUrl' => 'http://lincolnwebs.com',
-    'Icon' => 'multilingual.png'
+    'Icon' => 'multilingual.png',
+    'License' => 'GNU GPLv2'
 );
 
 /* Change Log

--- a/plugins/NBBC/class.nbbc.plugin.php
+++ b/plugins/NBBC/class.nbbc.plugin.php
@@ -18,7 +18,8 @@ $PluginInfo['NBBC'] = array(
     'Icon' => 'nbbc.png',
     'Author' => "Todd Burry",
     'AuthorEmail' => 'todd@vanillaforums.com',
-    'AuthorUrl' => 'http://vanillaforums.com/profile/todd'
+    'AuthorUrl' => 'http://vanillaforums.com/profile/todd',
+    'License' => 'GNU GPLv2'
 );
 
 Gdn::FactoryInstall('BBCodeFormatter', 'NBBCPlugin', __FILE__, Gdn::FactorySingleton);

--- a/plugins/NoBump/class.nobump.plugin.php
+++ b/plugins/NoBump/class.nobump.plugin.php
@@ -8,7 +8,8 @@ $PluginInfo['NoBump'] = array(
    'MobileFriendly' => TRUE,
    'Author' => "Lincoln Russell",
    'AuthorEmail' => 'lincolnwebs@gmail.com',
-   'AuthorUrl' => 'http://lincolnwebs.com'
+   'AuthorUrl' => 'http://lincolnwebs.com',
+   'License' => 'GNU GPLv2'
 );
 
 class NoBumpPlugin extends Gdn_Plugin {

--- a/plugins/NoIndex/class.noindex.plugin.php
+++ b/plugins/NoIndex/class.noindex.plugin.php
@@ -8,7 +8,8 @@ $PluginInfo['NoIndex'] = array(
    'MobileFriendly' => TRUE,
    'Author' => "Lincoln Russell",
    'AuthorEmail' => 'lincolnwebs@gmail.com',
-   'AuthorUrl' => 'http://lincolnwebs.com'
+   'AuthorUrl' => 'http://lincolnwebs.com',
+   'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/Participated/class.participated.plugin.php
+++ b/plugins/Participated/class.participated.plugin.php
@@ -19,7 +19,8 @@ $PluginInfo['Participated'] = [
     'Author' => 'Tim Gunter',
     'AuthorEmail' => 'tim@vanillaforums.com',
     'AuthorUrl' => 'http://www.vanillaforums.com',
-    'Icon' => 'participated-discussions.png'
+    'Icon' => 'participated-discussions.png',
+    'License' => 'GNU GPLv2'
 ];
 
 class ParticipatedPlugin extends Gdn_Plugin {

--- a/plugins/PostCount/class.postcount.plugin.php
+++ b/plugins/PostCount/class.postcount.plugin.php
@@ -22,7 +22,8 @@ $PluginInfo['PostCount'] = array(
    'Icon' => 'post_count.png',
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.com'
+   'AuthorUrl' => 'http://www.vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 class PostCountPlugin extends Gdn_Plugin {

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -15,7 +15,8 @@ $PluginInfo['QnA'] = array(
     'Author' => 'Todd Burry',
     'AuthorEmail' => 'todd@vanillaforums.com',
     'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd',
-    'Icon' => 'qna.png'
+    'Icon' => 'qna.png',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/ReactionsStub/class.reactionsstub.plugin.php
+++ b/plugins/ReactionsStub/class.reactionsstub.plugin.php
@@ -10,7 +10,8 @@ $PluginInfo['ReactionsStub'] = array(
    'HasLocale' => FALSE,
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.com'
+   'AuthorUrl' => 'http://www.vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 class ReactionsStubPlugin extends Gdn_Plugin {

--- a/plugins/Reporting/class.reporting.plugin.php
+++ b/plugins/Reporting/class.reporting.plugin.php
@@ -23,7 +23,8 @@ $PluginInfo['Reporting'] = array(
    'SettingsPermission' => 'Garden.Users.Manage',
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
-   'AuthorUrl' => 'http://www.vanillaforums.com'
+   'AuthorUrl' => 'http://www.vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 class ReportingPlugin extends Gdn_Plugin {

--- a/plugins/Resolved/class.resolved.plugin.php
+++ b/plugins/Resolved/class.resolved.plugin.php
@@ -16,7 +16,8 @@ $PluginInfo['Resolved'] = array(
     'Icon' => 'resolved_discussions.png',
     'Author' => "Matt Lincoln Russell",
     'AuthorEmail' => 'lincolnwebs@gmail.com',
-    'AuthorUrl' => 'http://lincolnwebs.com'
+    'AuthorUrl' => 'http://lincolnwebs.com',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/RightToLeft/class.righttoleft.plugin.php
+++ b/plugins/RightToLeft/class.righttoleft.plugin.php
@@ -18,7 +18,8 @@ $PluginInfo['RightToLeft'] = array(
     'Icon' => 'right_to_left.png',
     'Author' => 'Becky Van Bussel',
     'AuthorEmail' => 'becky@vanillaforums.com',
-    'AuthorUrl' => 'http://www.vanillaforums.org/'
+    'AuthorUrl' => 'http://www.vanillaforums.org/',
+    'License' => 'GNU GPLv2'
 );
 
 class RightToLeftPlugin extends Gdn_Plugin {

--- a/plugins/RoleTitle/class.roletitle.plugin.php
+++ b/plugins/RoleTitle/class.roletitle.plugin.php
@@ -9,7 +9,8 @@ $PluginInfo['RoleTitle'] = [
    'Icon' => 'role_titles.png',
    'Author' => 'Matt Lincoln Russell',
    'AuthorEmail' => 'lincolnwebs@gmail.com',
-   'AuthorUrl' => 'http://lincolnwebs.com'
+   'AuthorUrl' => 'http://lincolnwebs.com',
+   'License' => 'GNU GPLv2'
 ];
 
 class RoleTitlePlugin extends Gdn_Plugin {

--- a/plugins/SMFCompatibility/class.smfcompatibility.plugin.php
+++ b/plugins/SMFCompatibility/class.smfcompatibility.plugin.php
@@ -21,7 +21,8 @@ $PluginInfo['SMFCompatibility'] = array(
    'Author' => "Todd Burry",
    'AuthorEmail' => 'todd@vanillaforums.com',
    'AuthorUrl' => 'http://vanillaforums.com/profile/todd',
-   'License' => 'Simple Machines license'
+   'License' => 'Simple Machines license',
+   'License' => 'GNU GPLv2'
 );
 
 Gdn::FactoryInstall('BBCodeFormatter', 'SMFCompatibilityPlugin', __FILE__, Gdn::FactorySingleton);

--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -23,7 +23,8 @@ $PluginInfo['ShareThis'] = array(
    'Icon' => 'sharethis.png',
    'Author' => "Brendan Sera-Shriar a.k.a digibomb",
    'AuthorEmail' => 'brendan@vanillaforums.com',
-   'AuthorUrl' => 'http://www.dropthedigibomb.com'
+   'AuthorUrl' => 'http://www.dropthedigibomb.com',
+   'License' => 'GNU GPLv2'
 );
 
 

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -37,7 +37,8 @@ $PluginInfo['Signatures'] = [
     'MobileFriendly' => true,
     'SettingsUrl' => '/settings/signatures',
     'SettingsPermission' => 'Garden.Settings.Manage',
-    'Icon' => 'signatures.png'
+    'Icon' => 'signatures.png',
+    'License' => 'GNU GPLv2'
 ];
 
 class SignaturesPlugin extends Gdn_Plugin {

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -25,7 +25,8 @@ $PluginInfo['Sitemaps'] = [
     'AuthorUrl' => 'http://www.vanillaforums.com',
     'SettingsUrl' => '/settings/sitemaps',
     'SettingsPermission' => 'Garden.Settings.Manage',
-    'Icon' => 'site-maps.png'
+    'Icon' => 'site-maps.png',
+    'License' => 'GNU GPLv2'
 ];
 
 class SitemapsPlugin extends Gdn_Plugin {

--- a/plugins/Solr/class.solr.plugin.php
+++ b/plugins/Solr/class.solr.plugin.php
@@ -14,6 +14,7 @@ $PluginInfo['Solr'] = array(
    'AuthorEmail' => 'todd@vanillaforums.com',
    'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd',
    'SettingsUrl' => '/settings/solr',
+   'License' => 'GNU GPLv2'
 );
 
 class SolrPlugin extends Gdn_Plugin {

--- a/plugins/Spoof/class.spoof.plugin.php
+++ b/plugins/Spoof/class.spoof.plugin.php
@@ -11,7 +11,8 @@ $PluginInfo['Spoof'] = array(
    'Icon' => 'spoof.png',
    'Author' => "Mark O'Sullivan",
    'AuthorEmail' => 'mark@vanillaforums.com',
-   'AuthorUrl' => 'http://vanillaforums.com'
+   'AuthorUrl' => 'http://vanillaforums.com',
+   'License' => 'GNU GPLv2'
 );
 
 class SpoofPlugin implements Gdn_IPlugin {

--- a/plugins/SteamConnect/class.steamconnect.plugin.php
+++ b/plugins/SteamConnect/class.steamconnect.plugin.php
@@ -12,7 +12,8 @@ $PluginInfo['SteamConnect'] = array(
     'Icon'            => 'steam_connect.png',
     'SettingsUrl'     => '/settings/steamconnect',
     'SocialConnect'   => true,
-    'SettingsPermission' => 'Garden.Settings.Manage'
+    'SettingsPermission' => 'Garden.Settings.Manage',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/StopAutoDraft/class.stopautodraft.plugin.php
+++ b/plugins/StopAutoDraft/class.stopautodraft.plugin.php
@@ -16,7 +16,8 @@ $PluginInfo['StopAutoDraft'] = array(
    'Author' => "Mark O'Sullivan",
    'AuthorEmail' => 'mark@vanillaforums.com',
    'AuthorUrl' => 'http://markosullivan.ca',
-   'Icon' => 'stop_auto_draft.png'
+   'Icon' => 'stop_auto_draft.png',
+   'License' => 'GNU GPLv2'
 );
 
 class StopAutoDraftPlugin extends Gdn_Plugin {

--- a/plugins/SubmarineDiscussions/class.submarinediscussions.plugin.php
+++ b/plugins/SubmarineDiscussions/class.submarinediscussions.plugin.php
@@ -11,7 +11,8 @@ $PluginInfo['SubmarineDiscussions'] = array(
    'RequiredApplications' => array('Vanilla' => '2.0.17'),
    'MobileFriendly' => TRUE,
    'SettingsUrl' => '/settings/submarinediscussions',
-   'SettingsPermission' => 'Garden.Settings.Manage'
+   'SettingsPermission' => 'Garden.Settings.Manage',
+   'License' => 'GNU GPLv2'
 );
 
 class SubmarineDiscussionsPlugin extends Gdn_Plugin {

--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -12,7 +12,8 @@ $PluginInfo['TouchIcon'] = array(
    'MobileFriendly' => TRUE,
    'Icon' => 'touch_icon.png',
    'SettingsUrl' => '/settings/touchicon',
-   'SettingsPermission' => 'Garden.Settings.Manage'
+   'SettingsPermission' => 'Garden.Settings.Manage',
+   'License' => 'GNU GPLv2'
 );
 
 class TouchIconPlugin extends Gdn_Plugin {

--- a/plugins/TrackingCodes/class.trackingcodes.plugin.php
+++ b/plugins/TrackingCodes/class.trackingcodes.plugin.php
@@ -11,7 +11,8 @@ $PluginInfo['TrackingCodes'] = array(
    'Author' => "Mark O'Sullivan",
    'AuthorEmail' => 'mark@vanillaforums.com',
    'AuthorUrl' => 'http://vanillaforums.com',
-	'SettingsUrl' => 'settings/trackingcodes'
+   'SettingsUrl' => 'settings/trackingcodes',
+   'License' => 'GNU GPLv2'
 );
 
 class TrackingCodesPlugin extends Gdn_Plugin {

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -14,7 +14,8 @@ $PluginInfo['TrollManagement'] = array(
     'Icon' => 'troll_management.png',
     'Author' => "Mark O'Sullivan",
     'AuthorEmail' => 'mark@vanillaforums.com',
-    'AuthorUrl' => 'http://vanillaforums.com'
+    'AuthorUrl' => 'http://vanillaforums.com',
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/Vanoogle/class.vanoogle.plugin.php
+++ b/plugins/Vanoogle/class.vanoogle.plugin.php
@@ -26,7 +26,8 @@ $PluginInfo["Vanoogle"] = array(
     "SettingsUrl" => "/settings/vanoogle",
     "SettingsPermission" => "Garden.Settings.Manage",
     "AuthorUrl" => "http://blog.canofsleep.com",
-    "RequiredApplications" => array("Vanilla" => "2.0.17") // This needs to be bumped when Vanilla releases with my contributed changes
+    "RequiredApplications" => array("Vanilla" => "2.0.17"), // This needs to be bumped when Vanilla releases with my contributed changes
+    'License' => 'GNU GPLv2'
 );
 
 /**

--- a/plugins/Voting/class.voting.plugin.php
+++ b/plugins/Voting/class.voting.plugin.php
@@ -18,7 +18,8 @@ $PluginInfo['Voting'] = array(
    'AuthorUrl' => 'http://markosullivan.ca',
    'RequiredApplications' => array('Vanilla' => '2.0.17'),
    'SettingsUrl' => '/settings/voting',
-   'SettingsPermission' => 'Garden.Settings.Manage'
+   'SettingsPermission' => 'Garden.Settings.Manage',
+   'License' => 'GNU GPLv2'
 );
 
 class VotingPlugin extends Gdn_Plugin {

--- a/plugins/Whispers/class.whispers.plugin.php
+++ b/plugins/Whispers/class.whispers.plugin.php
@@ -14,7 +14,8 @@ $PluginInfo['Whispers'] = array(
    'Author' => 'Todd Burry',
    'AuthorEmail' => 'todd@vanillaforums.com',
    'AuthorUrl' => 'http://www.vanillaforums.org/profile/todd',
-   'RegisterPermissions' => array('Plugins.Whispers.Allow' => 'Garden.Moderation.Manage')
+   'RegisterPermissions' => array('Plugins.Whispers.Allow' => 'Garden.Moderation.Manage'),
+   'License' => 'GNU GPLv2'
 );
 
 class WhispersPlugin extends Gdn_Plugin {

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -17,7 +17,8 @@ $PluginInfo['jsconnect'] = [
     'SettingsUrl' => '/settings/jsconnect',
     'UsePopupSettings' => false,
     'SettingsPermission' => 'Garden.Settings.Manage',
-    'Icon' => 'jsconnect.png'
+    'Icon' => 'jsconnect.png',
+    'License' => 'GNU GPLv2'
 ];
 
 /**

--- a/plugins/vBulletinCompatibility/class.vbulletincompatibility.plugin.php
+++ b/plugins/vBulletinCompatibility/class.vbulletincompatibility.plugin.php
@@ -22,7 +22,8 @@ $PluginInfo['vBulletinCompatibility'] = array(
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
    'AuthorUrl' => 'http://www.vanillaforums.com',
-   'Hidden' => TRUE
+   'Hidden' => TRUE,
+   'License' => 'GNU GPLv2'
 );
 
 class VbulletinCompatibilityPlugin extends Gdn_Plugin {


### PR DESCRIPTION
The license was missing from most of the plugins PluginInfo array. That key is needed when the plugin should be upload to open.vanillaforums.com