### PR TITLE
Fix new post count not being displayed on Participated Discussions page

### DIFF
--- a/plugins/Participated/class.participated.plugin.php
+++ b/plugins/Participated/class.participated.plugin.php
@@ -65,6 +65,9 @@ class ParticipatedPlugin extends Gdn_Plugin {
 
         $sender->SQL->reset();
         $sender->SQL->select('d.*')
+            ->select('ud.DateLastViewed, ud.Dismissed, ud.Bookmarked')
+            ->select('ud.UserID', '', 'WatchUserID')
+            ->select('ud.CountComments', '', 'CountCommentWatch')
             ->from('UserDiscussion ud')
             ->join('Discussion d', 'ud.DiscussionID = d.DiscussionID')
             ->join('Comment c', 'ud.DiscussionID = c.DiscussionID and c.InsertUserID = ud.UserID')


### PR DESCRIPTION
https://github.com/vanilla/addons/pull/477 attempted to optimize the querying of a user's participated discussions, but it also removed some fields that were necessary for calculating new post counts on the /discussions/participated page.

This update re-adds the necessary fields from the `UserDiscussion` table as part of the discussion query and restores proper rendering of counts on the aforementioned page.

Closes #490 

Backport to [release/2017-Q2-2](https://github.com/vanilla/addons/tree/release/2017-Q2-2)