### PR TITLE
Fixing when question with no comments would get set to Answered

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -305,7 +305,11 @@ class QnAPlugin extends Gdn_Plugin {
 
         // Mark the question as answered.
         if (strtolower($Discussion['Type']) == 'question' && !$Discussion['Sink'] && !in_array($Discussion['QnA'], array('Answered', 'Accepted'))) {
-            $sender->SQL->set('QnA', 'Answered');
+            if($args['Counts']['CountComments'] > 0) {
+                $sender->SQL->set('QnA', 'Answered');
+            } else {
+                $sender->SQL->set('QnA', 'Unanswered');
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/addons/issues/496

Question (post) requiring approval would get set to "Answered" upon approval. 