### PR TITLE
Fix broken add-on info array in Role Titles plug-in

### DIFF
--- a/plugins/RoleTitle/class.roletitle.plugin.php
+++ b/plugins/RoleTitle/class.roletitle.plugin.php
@@ -1,14 +1,4 @@
 <?php
-classes to their comments for theming.",
-   'Version' => '1.0',
-   'RequiredApplications' => ['Vanilla' => '2.0.18'],
-   'MobileFriendly' => true,
-   'RegisterPermissions' => false,
-   'Icon' => 'role_titles.png',
-   'Author' => 'Matt Lincoln Russell',
-   'AuthorEmail' => 'lincolnwebs@gmail.com',
-   'AuthorUrl' => 'http://lincolnwebs.com'
-];
 
 class RoleTitlePlugin extends Gdn_Plugin {
 


### PR DESCRIPTION
https://github.com/vanilla/addons/pull/491 broke the addon info array for the Role Titles plug-in. This update removes the broken array.