### PR TITLE
Civil Tongue: Add filtering to activity & notifications

### DIFF
--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -384,7 +384,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
      * @param $Sender
      * @param $Args
      */
-    public function activityModel_BeforeSave_Handler($Sender, &$Args) {
+    public function activityModel_beforeSave_handler($Sender, &$Args) {
         $activity = val('Activity', $Args);
         setValue('Story', $activity, $this->replace(val('Story', $activity)));
     }

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -384,7 +384,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
      * @param $Sender
      * @param $Args
      */
-    public function ActivityModel_BeforeSave_Handler($Sender, &$Args) {
+    public function activityModel_BeforeSave_Handler($Sender, &$Args) {
         $activity = val('Activity', $Args);
         setValue('Story', $activity, $this->replace(val('Story', $activity)));
     }

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -387,6 +387,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
     public function activityModel_beforeSave_handler($sender, &$args) {
         $activity = val('Activity', $args);
         setValue('Story', $activity, $this->replace(val('Story', $activity)));
+        $sender->EventArguments['Activity'] = $activity;
     }
 
 

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -384,8 +384,8 @@ class CivilTonguePlugin extends Gdn_Plugin {
      * @param $Sender
      * @param $Args
      */
-    public function activityModel_beforeSave_handler($Sender, &$Args) {
-        $activity = val('Activity', $Args);
+    public function activityModel_beforeSave_handler($sender, &$args) {
+        $activity = val('Activity', $args);
         setValue('Story', $activity, $this->replace(val('Story', $activity)));
     }
 

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -379,6 +379,18 @@ class CivilTonguePlugin extends Gdn_Plugin {
     }
 
     /**
+     * Cleanup Activity messages.
+     *
+     * @param $Sender
+     * @param $Args
+     */
+    public function ActivityModel_BeforeSave_Handler($Sender, &$Args) {
+        $activity = val('Activity', $Args);
+        setValue('Story', $activity, $this->replace(val('Story', $activity)));
+    }
+
+
+    /**
      * Cleanup private messages displayed on the messages page.
      *
      * @param $Sender


### PR DESCRIPTION
Hooked into "beforeSave" to filter out activity messages in Civil Tongue plugin.

Closes https://github.com/vanilla/addons/issues/467