### PR TITLE
Fix translation of error message for images in signatures.

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -282,7 +282,7 @@ class SignaturesPlugin extends Gdn_Plugin {
                 $rulesParams['maxImages'] = $MaxNumberImages;
                 $rules[] = formatString(t('Use up to {maxImages,plural,%s image, %s images}.'), $rulesParams);
             } else {
-                $rules[] = t('Images not allowed.');
+                $rules[] = t('Images not allowed');
                 $imagesAllowed = false;
             }
         }


### PR DESCRIPTION
There were two strings in the Signature plugin that gave the same message. One had a period, the other not. When translated the one with the period remained in English.