### PR TITLE
Adding question link to accepted answer notification

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -523,7 +523,7 @@ class QnAPlugin extends Gdn_Plugin {
                 }
             }
 
-            $headlineFormat = t('HeadlineFormat.AcceptAnswer', '{ActivityUserID,You} accepted {NotifyUserID,your} answer.');
+            $headlineFormat = t('HeadlineFormat.AcceptAnswer', '{ActivityUserID,You} accepted {NotifyUserID,your} answer to question: <a href="{Url,html}">{Data.Name,text}</a>');
 
             // Record the activity.
             if ($QnA == 'Accepted') {
@@ -536,6 +536,9 @@ class QnAPlugin extends Gdn_Plugin {
                     'Route' => commentUrl($Comment, '/'),
                     'Emailed' => ActivityModel::SENT_PENDING,
                     'Notified' => ActivityModel::SENT_PENDING,
+                    'Data' => array(
+                        'Name' => val('Name', $Discussion)
+                    )
                 );
 
                 $ActivityModel = new ActivityModel();

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -523,7 +523,7 @@ class QnAPlugin extends Gdn_Plugin {
                 }
             }
 
-            $headlineFormat = t('HeadlineFormat.AcceptAnswer', '{ActivityUserID,You} accepted {NotifyUserID,your} answer to question: <a href="{Url,html}">{Data.Name,text}</a>');
+            $headlineFormat = t('HeadlineFormat.AcceptAnswer', '{ActivityUserID,You} accepted {NotifyUserID,your} answer to a question: <a href="{Url,html}">{Data.Name,text}</a>');
 
             // Record the activity.
             if ($QnA == 'Accepted') {


### PR DESCRIPTION
Asker was receiving an answer notification with a link to the question when a user replied to his question.

Answerer was receiving a notification saying his answer was accepted but with no link to the question. This PR adds this link to the notification.

Fixes https://github.com/vanilla/addons/issues/449