### PR TITLE
Clear floats for signatures plugin

### DIFF
--- a/plugins/Signatures/design/signature.css
+++ b/plugins/Signatures/design/signature.css
@@ -4,6 +4,7 @@
    padding-top: 4px;
    font-size: 11px;
    margin-top: 10px;
+   clear: both;
 }
 
 .UserSignature p {


### PR DESCRIPTION
Signatures didn't clear floats, creating issues when the last element was floating right (like a right align for example)

Fixes: https://github.com/vanilla/addons/issues/521