### PR TITLE
[Pockets] Fix undefined offset notice in Pockets

### DIFF
--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -630,7 +630,7 @@ class PocketsPlugin extends Gdn_Plugin {
                 }
             };
 
-            $result = preg_replace_callback('`{{(\w+)}}`', $callback, $result);
+            $result = preg_replace_callback('/{{(\w+)}}/', $callback, $result);
         }
 
         return $result;

--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -621,21 +621,32 @@ class PocketsPlugin extends Gdn_Plugin {
         if (is_array($data)) {
             $data = array_change_key_case($data);
 
-            self::pocketStringCb($data, true);
-            $result = preg_replace_callback('`{{(\w+)}}`', ['PocketsPlugin', 'PocketStringCb'], $result);
+            $callback = function ($matches) use ($data) {
+                $key = strtolower($matches[1]);
+                if (isset($data[$key])) {
+                    return $data[$key];
+                } else {
+                    return '';
+                }
+            };
+
+            $result = preg_replace_callback('`{{(\w+)}}`', $callback, $result);
         }
 
         return $result;
     }
 
     /**
+     * DEPRECATED - Callback function for preg_replace_callback
      *
-     *
-     * @param null $match
+     * @deprecated 2.4
+     * @param array|null $match
      * @param bool|false $setArgs
      * @return string
      */
     public static function pocketStringCb($match = null, $setArgs = false) {
+        deprecated(__METHOD__);
+
         static $data;
         if ($setArgs) {
             $data = $match;


### PR DESCRIPTION
A notice was being thrown by this callback function `PocketsPlugin::pocketStringCb()` because it was being called outside of `preg_replace_callback()`. This PR:

- deprecates `pocketStringCb` function which should never have been marked as public
- moves the function into a lambda
- removes the extra call the callback

This should make it into 2.5 so I've added a task to delete the deprecated function in 2.6 - #530 