### PR TITLE
Refactor arrays to short syntax

### DIFF
--- a/plugins/Akismet/class.akismet.php
+++ b/plugins/Akismet/class.akismet.php
@@ -72,7 +72,7 @@ class Akismet
 	private $akismetVersion;
 	
 	// This prevents some potentially sensitive information from being sent accross the wire.
-	private $ignore = array('HTTP_COOKIE', 
+	private $ignore = ['HTTP_COOKIE', 
 							'HTTP_X_FORWARDED_FOR', 
 							'HTTP_X_FORWARDED_HOST', 
 							'HTTP_MAX_FORWARDS', 
@@ -83,7 +83,7 @@ class Akismet
 							'DOCUMENT_ROOT',
 							'SERVER_ADMIN',
 							'QUERY_STRING',
-							'PHP_SELF' );
+							'PHP_SELF' ];
 	
 	/**
 	 *	@param	string	$blogURL			The URL of your blog.

--- a/plugins/AllowRawFormat/class.allowrawformat.plugin.php
+++ b/plugins/AllowRawFormat/class.allowrawformat.plugin.php
@@ -7,7 +7,7 @@
 class AllowRawFormatPlugin extends Gdn_Plugin {
    public function Base_BeforeDispatch_Handler($Sender, $Args) {
       if (Gdn::Session()->CheckPermission('Plugins.AllowRawFormat.Allow')) {
-         SaveToConfig('Garden.InputFormatter', 'Raw', array('Save' => FALSE));
+         SaveToConfig('Garden.InputFormatter', 'Raw', ['Save' => FALSE]);
       }
    }
 }

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -42,12 +42,12 @@ class CivilTonguePlugin extends Gdn_Plugin {
      * @param $Sender
      * @param array $Args
      */
-    public function pluginController_tongue_create($Sender, $Args = array()) {
+    public function pluginController_tongue_create($Sender, $Args = []) {
         $Sender->permission('Garden.Settings.Manage');
         $Sender->Form = new Gdn_Form();
         $Validation = new Gdn_Validation();
         $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
-        $ConfigurationModel->setField(array('Plugins.CivilTongue.Words', 'Plugins.CivilTongue.Replacement'));
+        $ConfigurationModel->setField(['Plugins.CivilTongue.Words', 'Plugins.CivilTongue.Replacement']);
         $Sender->Form->setModel($ConfigurationModel);
 
         if ($Sender->Form->authenticatedPostBack() === FALSE) {
@@ -306,7 +306,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
         static $Patterns = NULL;
 
         if ($Patterns === NULL) {
-            $Patterns = array();
+            $Patterns = [];
             $Words = c('Plugins.CivilTongue.Words', null);
             if ($Words !== null) {
                 $ExplodedWords = explode(';', $Words);

--- a/plugins/CivilTongueEx/views/index.php
+++ b/plugins/CivilTongueEx/views/index.php
@@ -14,7 +14,7 @@ echo $this->Form->Errors();
             echo wrap(t('Separate each word with a semi-colon ";"'), 'div', ['class' => 'info']); ?>
         </div>
         <div class="input-wrap">
-            <?php echo $this->Form->TextBox('Plugins.CivilTongue.Words', array('MultiLine' => TRUE)); ?>
+            <?php echo $this->Form->TextBox('Plugins.CivilTongue.Words', ['MultiLine' => TRUE]); ?>
         </div>
     </li>
     <li class="form-group">

--- a/plugins/CloudflareSupport/class.cloudflaresupport.plugin.php
+++ b/plugins/CloudflareSupport/class.cloudflaresupport.plugin.php
@@ -24,7 +24,7 @@
 class CloudflareSupportPlugin extends Gdn_Plugin {
 
    // CloudFlare IP ranges listed at https://www.cloudflare.com/ips
-   protected $CloudflareSourceIPs = array(
+   protected $CloudflareSourceIPs = [
       '103.21.244.0/22',
       '103.22.200.0/22',
       '103.31.4.0/22',
@@ -39,7 +39,7 @@ class CloudflareSupportPlugin extends Gdn_Plugin {
       '197.234.240.0/22',
       '198.41.128.0/17',
       '199.27.128.0/21'
-    );
+    ];
 
    public function __construct() {
       parent::__construct();

--- a/plugins/CssThemes/class.cssthemes.plugin.php
+++ b/plugins/CssThemes/class.cssthemes.plugin.php
@@ -30,7 +30,7 @@ class CssThemes extends Gdn_Plugin {
 
 	/// Properties ///
 
-	public $MissingSettings = array();
+	public $MissingSettings = [];
 
 	protected $_OrignialPath;
 	protected $_AppName;
@@ -50,17 +50,17 @@ class CssThemes extends Gdn_Plugin {
 
 		$Css = file_get_contents($OriginalPath);
 		// Process the urls.
-		$Css = preg_replace_callback(self::UrlRegEx, array($this, '_ApplyUrl'), $Css);
+		$Css = preg_replace_callback(self::UrlRegEx, [$this, '_ApplyUrl'], $Css);
 
 		// Go through the css and replace its colors with the theme colors.
-		$Css = preg_replace_callback(self::RegEx, array($this, '_ApplyThemeSetting'), $Css);
+		$Css = preg_replace_callback(self::RegEx, [$this, '_ApplyThemeSetting'], $Css);
 
 		// Insert the missing settings into the database.
 		if($InsertNames) {
 			foreach($this->MissingSettings as $Name => $Setting) {
-				$SQL->Insert('ThemeSetting', array('Name' => $Name, 'Setting' => $Setting));
+				$SQL->Insert('ThemeSetting', ['Name' => $Name, 'Setting' => $Setting]);
 			}
-			$this->MissingSettings = array();
+			$this->MissingSettings = [];
 		}
 
 		// Save the theme to the cache path.
@@ -90,14 +90,14 @@ class CssThemes extends Gdn_Plugin {
 
 		if($NoFollow !== FALSE) {
 			// Don't apply the theme to this import.
-			$OriginalAssetPath = str_replace(array(PATH_ROOT, DS), array('', '/'), $this->_OrignialPath);
-			$Url = Asset(CombinePaths(array(dirname($OriginalAssetPath), $Url), '/'));
+			$OriginalAssetPath = str_replace([PATH_ROOT, DS], ['', '/'], $this->_OrignialPath);
+			$Url = Asset(CombinePaths([dirname($OriginalAssetPath), $Url], '/'));
 		} else {
 			// Also parse the import.
 			$OrignalPath = $this->_OrignialPath;
-			$ImportPath = CombinePaths(array(dirname($OrignalPath), $Url));
+			$ImportPath = CombinePaths([dirname($OrignalPath), $Url]);
 			$Url = $this->Get($ImportPath, $this->_AppName);
-			$Url = str_replace(array(PATH_ROOT, DS), array('', '/'), $Url);
+			$Url = str_replace([PATH_ROOT, DS], ['', '/'], $Url);
 			$Url = Asset($Url);
 
 			$this->_OrignalPath = $OrignalPath;
@@ -115,14 +115,14 @@ class CssThemes extends Gdn_Plugin {
 
 		if($NoFollow !== FALSE || strcasecmp($Extension, '.css') != 0) {
 			// Don't apply the theme to this import.
-			$OriginalAssetPath = str_replace(array(PATH_ROOT, DS), array('', '/'), $this->_OrignialPath);
-			$Url = Asset(CombinePaths(array(dirname($OriginalAssetPath), $Url.$Extension), '/'));
+			$OriginalAssetPath = str_replace([PATH_ROOT, DS], ['', '/'], $this->_OrignialPath);
+			$Url = Asset(CombinePaths([dirname($OriginalAssetPath), $Url.$Extension], '/'));
 		} else {
 			// Cache the css too.
 			$OrignalPath = $this->_OrignialPath;
-			$ImportPath = CombinePaths(array(dirname($OrignalPath), $Url.$Extension));
+			$ImportPath = CombinePaths([dirname($OrignalPath), $Url.$Extension]);
 			$Url = $this->Get($ImportPath, $this->_AppName);
-			$Url = str_replace(array(PATH_ROOT, DS), array('', '/'), $Url);
+			$Url = str_replace([PATH_ROOT, DS], ['', '/'], $Url);
 			$Url = Asset($Url);
 
 			$this->_OrignalPath = $OrignalPath;
@@ -156,7 +156,7 @@ class CssThemes extends Gdn_Plugin {
 	}
 
 	public function GetNames($Css, $InsertNames = FALSE) {
-		$Result = array();
+		$Result = [];
 
 		if(preg_match_all(self::RegEx, $Css, $Matches)) {
 			foreach($Matches as $Match) {
@@ -173,7 +173,7 @@ class CssThemes extends Gdn_Plugin {
 			// Insert the necessary settings.
 			if($InsertNames) {
 				foreach($Insert as $Name => $Setting) {
-					$SQL->Insert('ThemeSetting', array('Name' => $Name, 'Setting' => $Setting));
+					$SQL->Insert('ThemeSetting', ['Name' => $Name, 'Setting' => $Setting]);
 				}
 			}
 		}
@@ -189,7 +189,7 @@ class CssThemes extends Gdn_Plugin {
 	public function PluginController_Colors_Create($Sender) {
 		$Sender->Form = Gdn::Factory('Form');
 
-		$this->Colors = array();
+		$this->Colors = [];
 
 		$this->ParseCss(PATH_APPLICATIONS);
 		//$this->ParseCss(PATH_THEMES);
@@ -218,7 +218,7 @@ class CssThemes extends Gdn_Plugin {
 				//$Css = preg_replace_callback(self::UrlRegEx, array($this, '_ApplyUrl'), $Css);
 
 				// Go through the css and replace its colors with the theme colors.
-				$Css = preg_replace_callback(self::RegEx2, array($this, 'GetColors'), $Css);
+				$Css = preg_replace_callback(self::RegEx2, [$this, 'GetColors'], $Css);
 
 			}
 		}
@@ -227,7 +227,7 @@ class CssThemes extends Gdn_Plugin {
 		$Paths = glob($Path.DS.'*', GLOB_ONLYDIR);
 		if($Paths) {
 			foreach($Paths as $Path) {
-				if(in_array(strrchr($Path, DS), array(DS.'vforg', DS.'vfcom')))
+				if(in_array(strrchr($Path, DS), [DS.'vforg', DS.'vfcom']))
 					continue;
 				$this->ParseCss($Path);
 			}
@@ -235,7 +235,7 @@ class CssThemes extends Gdn_Plugin {
 	}
 
 	public function RGB($Color) {
-		return array(hexdec(substr($Color, 0, 2)), hexdec(substr($Color, 2, 2)), hexdec(substr($Color, 4, 2)));
+		return [hexdec(substr($Color, 0, 2)), hexdec(substr($Color, 2, 2)), hexdec(substr($Color, 4, 2))];
 	}
 
 	public function GetColors($Match) {
@@ -273,7 +273,7 @@ class CssThemes extends Gdn_Plugin {
 
 		$V = $Max;
 		if($V == 0)
-			return array(1000, $S, $V);
+			return [1000, $S, $V];
 
 		$R /= $V;
 		$G /= $V;
@@ -283,7 +283,7 @@ class CssThemes extends Gdn_Plugin {
 
 		$S = $Max - $Min;
 		if($S == 0)
-			return array(1000, $S, $V);
+			return [1000, $S, $V];
 
 		$R = ($R - $Min) / ($Max - $Min);
 		$G = ($G - $Min) / ($Max - $Min);
@@ -297,7 +297,7 @@ class CssThemes extends Gdn_Plugin {
 		else
 			$H = 240 + 60 * ($R - $G);
 
-		return array($H, $S, $V);
+		return [$H, $S, $V];
 	}
 
 	/**
@@ -322,8 +322,8 @@ class CssThemes extends Gdn_Plugin {
 			foreach($Data as $Row) {
 				$SQL->Put(
 					'ThemeSetting',
-					array('Setting' => $Row['Setting']),
-					array('Name' => $Row['Name']));
+					['Setting' => $Row['Setting']],
+					['Name' => $Row['Name']]);
 			}
 
 			// Clear out the css cache.

--- a/plugins/CssThemes/views/colors.php
+++ b/plugins/CssThemes/views/colors.php
@@ -26,7 +26,7 @@ foreach($this->Colors as $Color => $HSV) {
 		echo "\n<div class='Box'> \n";
 		$LastHue = $Hue;
 	}
-	$RGB = array(hexdec(substr($Color, 0, 2)), hexdec(substr($Color, 2, 2)), hexdec(substr($Color, 4, 2)));
+	$RGB = [hexdec(substr($Color, 0, 2)), hexdec(substr($Color, 2, 2)), hexdec(substr($Color, 4, 2))];
 	$R += $RGB[0];
 	$G += $RGB[1];
 	$B += $RGB[2];

--- a/plugins/CssThemes/views/cssthemes.php
+++ b/plugins/CssThemes/views/cssthemes.php
@@ -31,8 +31,8 @@ foreach($this->Data["ThemeSettings"] as $Row) {
 		</td>
 		<td>
 			<?php
-				echo $this->Form->Input('Name[]', 'hidden', array('value' => $Row['Name']));
-				echo $this->Form->Input('Setting[]', 'text', array('value' => $Row['Setting'], 'class' => 'Setting'));
+				echo $this->Form->Input('Name[]', 'hidden', ['value' => $Row['Name']]);
+				echo $this->Form->Input('Setting[]', 'text', ['value' => $Row['Setting'], 'class' => 'Setting']);
 			?>
 		</td>
 	</tr>

--- a/plugins/CustomizeText/class.customizetext.plugin.php
+++ b/plugins/CustomizeText/class.customizetext.plugin.php
@@ -60,7 +60,7 @@ class CustomizeTextPlugin extends Gdn_Plugin {
             $Method = 'save';
       }
       
-      $Matches = array();
+      $Matches = [];
       $Keywords = NULL;
       switch ($Method) {
          case 'none':
@@ -102,7 +102,7 @@ class CustomizeTextPlugin extends Gdn_Plugin {
                else
                   $CurrentDefinition = $BaseDefinition;
 
-               $Matches[$Key] = array('def' => $CurrentDefinition, 'mod' => $Modified);
+               $Matches[$Key] = ['def' => $CurrentDefinition, 'mod' => $Modified];
                if ($CurrentDefinition[0] == "\r\n")
                   $CurrentDefinition = "\r\n{$CurrentDefinition}";
                else if ($CurrentDefinition[0] == "\r")
@@ -123,11 +123,11 @@ class CustomizeTextPlugin extends Gdn_Plugin {
                         $SaveDefinition = str_replace("\r\n", "\n", $SaveDefinition);
                      }
                      
-                     Gdn::Locale()->SetTranslation($Key, $SaveDefinition, array(
+                     Gdn::Locale()->SetTranslation($Key, $SaveDefinition, [
                         'Save'         => TRUE,
                         'RemoveEmpty'  => TRUE
-                     ));
-                     $Matches[$Key] = array('def' => $SuppliedDefinition, 'mod' => !is_null($SaveDefinition));
+                     ]);
+                     $Matches[$Key] = ['def' => $SuppliedDefinition, 'mod' => !is_null($SaveDefinition)];
                      $Changed = TRUE;
                   }
                }

--- a/plugins/CustomizeText/views/customizetext.php
+++ b/plugins/CustomizeText/views/customizetext.php
@@ -55,7 +55,7 @@ if ($this->Form->GetValue('Keywords', '') != '') {
 
         echo '<li class="form-group">';
         echo '<div class="label-wrap">';
-        echo Wrap(Gdn_Format::Text($Key), 'label', array('for' => "Form_{$ElementName}"));
+        echo Wrap(Gdn_Format::Text($Key), 'label', ['for' => "Form_{$ElementName}"]);
 
         if ($this->Form->IsPostBack()) {
             $SuppliedDefinition = $this->Form->GetValue($ElementName);
@@ -65,7 +65,7 @@ if ($this->Form->GetValue('Keywords', '') != '') {
                 if (!$DefinitionModified) $CSSClass .= " Modified";
         }
         echo '</div>';
-        echo $this->Form->textBoxWrap($ElementName, array('multiline' => TRUE, 'class' => $CSSClass));
+        echo $this->Form->textBoxWrap($ElementName, ['multiline' => TRUE, 'class' => $CSSClass]);
         echo '</li>';
     }
     echo '</ul>';

--- a/plugins/CustomizeText/views/rebuild.php
+++ b/plugins/CustomizeText/views/rebuild.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 
 // ajax request common pages to fill the locale file with translations to edit.
-$Urls = array(
+$Urls = [
 	'/vanilla/discussions/index',
 	'/vanilla/discussions/bookmarked',
 	'/vanilla/discussions/mine',
@@ -28,7 +28,7 @@ $Urls = array(
 	'/dashboard/entry/signin',
 	'/dashboard/entry/register',
 	'/dashboard/entry/passwordrequest'
-);
+];
 array_map('Url', $Urls);
 $Locale = Gdn::Locale();
 $Definitions = $Locale->GetDeveloperDefinitions();

--- a/plugins/Disqus/class.disqus.plugin.php
+++ b/plugins/Disqus/class.disqus.plugin.php
@@ -57,11 +57,11 @@ class DisqusPlugin extends Gdn_Plugin {
             return '';
         }
 
-        $Qs = array(
+        $Qs = [
             'client_id' => $Provider['AuthenticationKey'],
             'scope' => 'read',
             'response_type' => 'code',
-        );
+        ];
 
         $SigninHref = 'https://disqus.com/api/oauth/2.0/authorize/?'.http_build_query($Qs);
 
@@ -106,10 +106,10 @@ class DisqusPlugin extends Gdn_Plugin {
             $Url = $this->authorizeUri();
 
             // Add the Disqus method to the controller.
-            $Method = array(
+            $Method = [
                 'Name' => 'Disqus',
                 'SignInHtml' => socialSigninButton('Disqus', $Url, 'button')
-            );
+            ];
             $Sender->Data['Methods'][] = $Method;
         }
     }
@@ -156,7 +156,7 @@ class DisqusPlugin extends Gdn_Plugin {
         }
 
         if (!Gdn::session()->isValid()) {
-            echo "\n".wrap($this->_getButton(), 'li', array('class' => 'Connect DisqusConnect'));
+            echo "\n".wrap($this->_getButton(), 'li', ['class' => 'Connect DisqusConnect']);
         }
     }
 
@@ -175,7 +175,7 @@ class DisqusPlugin extends Gdn_Plugin {
             $Sender->Form->setFormValue(Gdn_AuthenticationProviderModel::COLUMN_NAME, 'Disqus');
             $Sender->Form->setModel($Model);
 
-            if ($Sender->Form->save(array('PK' => Gdn_AuthenticationProviderModel::COLUMN_ALIAS))) {
+            if ($Sender->Form->save(['PK' => Gdn_AuthenticationProviderModel::COLUMN_ALIAS])) {
                 $Sender->informMessage(t("Your settings have been saved."));
             }
         } else {
@@ -222,13 +222,13 @@ class DisqusPlugin extends Gdn_Plugin {
         // Get the access token.
         if ($Code && !$AccessToken) {
             // Exchange the token for an access token.
-            $Qs = array(
+            $Qs = [
                 'grant_type' => 'authorization_code',
                 'client_id' => $AppID,
                 'client_secret' => $Secret,
                 'code' => $Code,
                 'redirect_uri' => url('/entry/connect/disqus', true),
-            );
+            ];
 
             $Url = 'https://disqus.com/api/oauth/2.0/access_token/'; //.http_build_query($Qs);
 
@@ -259,11 +259,11 @@ class DisqusPlugin extends Gdn_Plugin {
 
         if ($AccessToken) {
             // Grab the user's profile.
-            $Qs = array(
+            $Qs = [
                 'access_token' => $AccessToken,
                 'api_key' => $AppID,
                 'api_secret' => $Secret
-            );
+            ];
 
             $Url = 'https://disqus.com/api/3.0/users/details.json?'.http_build_query($Qs);
             $C = curl_init();

--- a/plugins/Disqus/views/settings.php
+++ b/plugins/Disqus/views/settings.php
@@ -17,9 +17,9 @@ $form = $this->Form;
 echo $form->open();
 echo $form->errors();
 
-echo $form->simple(array(
-    'AuthenticationKey' => array('LabelCode' => 'Consumer Key'),
-    'AssociationSecret' => array('LabelCode' => 'Consumer Secret')
-));
+echo $form->simple([
+    'AuthenticationKey' => ['LabelCode' => 'Consumer Key'],
+    'AssociationSecret' => ['LabelCode' => 'Consumer Secret']
+]);
 
 echo $form->close('Save'); ?>

--- a/plugins/EmailPasswordSync/class.emailpasswordsync.plugin.php
+++ b/plugins/EmailPasswordSync/class.emailpasswordsync.plugin.php
@@ -71,15 +71,15 @@ class MultipleEmailsPlugin extends Gdn_Plugin {
          return;
 
       // See if there is a user with the same email/password.
-      $Users = $UserModel->GetWhere(array('Email' => GetValueR('InsertFields.Email', $Args)))->ResultArray();
+      $Users = $UserModel->GetWhere(['Email' => GetValueR('InsertFields.Email', $Args)])->ResultArray();
       $Hasher = new Gdn_PasswordHash();
 
       foreach ($Users as $User) {
          if ($Hasher->CheckPassword($Password, $User['Password'], $User['HashMethod'])) {
             $UserModel->SQL->Put(
                'User',
-               array('Password' => $User['Password'], 'HashMethod' => $User['HashMethod']),
-               array('UserID' => GetValue('InsertUserID', $Args)));
+               ['Password' => $User['Password'], 'HashMethod' => $User['HashMethod']],
+               ['UserID' => GetValue('InsertUserID', $Args)]);
             return;
          }
       }
@@ -107,7 +107,7 @@ class MultipleEmailsPlugin extends Gdn_Plugin {
       $UserID = GetValueR('FormPostValues.UserID', $Args);
       if ($UserID) {
          $CurrentUser = $UserModel->GetID($UserID, DATASET_TYPE_ARRAY);
-         $this->_OldPasswordHash = array($CurrentUser['Password'], $CurrentUser['HashMethod']);
+         $this->_OldPasswordHash = [$CurrentUser['Password'], $CurrentUser['HashMethod']];
       }
    }
 
@@ -134,7 +134,7 @@ class MultipleEmailsPlugin extends Gdn_Plugin {
       $Email = $Args['Email'];
       $Users =& $Args['Users'];
 
-      $Names = array();
+      $Names = [];
 
       foreach ($Users as $Index => $User) {
          if ($User->Email == $Email) {

--- a/plugins/Emotify/class.emotify.plugin.php
+++ b/plugins/Emotify/class.emotify.plugin.php
@@ -44,7 +44,7 @@ class EmotifyPlugin implements Gdn_IPlugin {
 	 * Return an array of emoticons.
 	 */
 	public static function GetEmoticons() {
-		return array(
+		return [
 			':)]' => '100',
 			';))' => '71',
 			':)>-' => '67',
@@ -189,7 +189,7 @@ class EmotifyPlugin implements Gdn_IPlugin {
 			':bz' => '115',
 			':ar!' => 'pirate'
 //			'[..]' => 'transformer'
-		);
+		];
 	}
 	
 	/**
@@ -211,7 +211,7 @@ class EmotifyPlugin implements Gdn_IPlugin {
       $BBCode = $Args['BBCode'];
       $BBCode->smiley_url = SmartAsset('/plugins/Emotify/design/images');
       
-      $Smileys = array();
+      $Smileys = [];
       foreach (self::GetEmoticons() as $Text => $Filename) {
          $Smileys[$Text]= $Filename.'.gif';
       }
@@ -243,7 +243,7 @@ class EmotifyPlugin implements Gdn_IPlugin {
 	private function _EmotifySetup($Sender) {
 		$Sender->AddJsFile('emotify.js', 'plugins/Emotify');  
 		// Deliver the emoticons to the page.
-      $Emoticons = array();
+      $Emoticons = [];
       foreach ($this->GetEmoticons() as $i => $gif) {
          if (!isset($Emoticons[$gif]))
             $Emoticons[$gif] = $i;

--- a/plugins/FacebookID/class.facebookid.plugin.php
+++ b/plugins/FacebookID/class.facebookid.plugin.php
@@ -2,14 +2,14 @@
 
 class FacebookIDPlugin extends Gdn_Plugin {
    /** @var array */
-   public $FacebookIDs = array();
+   public $FacebookIDs = [];
 
    public function UserInfoModule_OnBasicInfo_Handler($Sender, $Args) {
       if (Gdn::Session()->CheckPermission('Plugins.FacebookID.View')) {
          // Grab the facebook ID.
          $FacebookID = Gdn::SQL()->GetWhere(
             'UserAuthentication',
-            array('ProviderKey' => 'facebook', 'UserID' => $Sender->User->UserID)
+            ['ProviderKey' => 'facebook', 'UserID' => $Sender->User->UserID]
          )->Value('ForeignUserKey', T('n/a'));
 
          echo '<dt class="Value">'.T('Facebook ID').'</dt><dd>'.$FacebookID.'</dd>';
@@ -27,7 +27,7 @@ class FacebookIDPlugin extends Gdn_Plugin {
          return;
 
       if (!$this->FacebookIDs)
-         $this->FacebookIDs = $this->GetFacebookIDs(array($Sender->Data['Discussion'], $Sender->Data['Comments']), 'InsertUserID');
+         $this->FacebookIDs = $this->GetFacebookIDs([$Sender->Data['Discussion'], $Sender->Data['Comments']], 'InsertUserID');
 
 
       $UserID = GetValue('InsertUserID',$Sender->EventArguments['Object'],'0');
@@ -49,14 +49,14 @@ class FacebookIDPlugin extends Gdn_Plugin {
     * @return <type>
     */
    public function UserController_Render_Before($Sender, $Args) {
-      if (!in_array($Sender->RequestMethod, array('index', 'browse')))
+      if (!in_array($Sender->RequestMethod, ['index', 'browse']))
          return;
       if (!Gdn::Session()->CheckPermission('Plugins.FacebookID.View'))
          return;
    }
 
    public function GetFacebookIDs($Datas, $UserIDColumn) {
-      $UserIDs = array();
+      $UserIDs = [];
       foreach ($Datas as $Data) {
          if ($UserID = GetValue($UserIDColumn, $Data))
             $UserIDs[] = $UserID;
@@ -70,7 +70,7 @@ class FacebookIDPlugin extends Gdn_Plugin {
          ->WhereIn('UserID', array_unique($UserIDs))
          ->GetWhere(
          'UserAuthentication',
-         array('ProviderKey' => 'facebook'))->ResultArray();
+         ['ProviderKey' => 'facebook'])->ResultArray();
 
       $Result = array_column($FbIDs, 'ForeignUserKey', 'UserID');
       return $Result;

--- a/plugins/FileUpload/class.fileupload.plugin.php
+++ b/plugins/FileUpload/class.fileupload.plugin.php
@@ -106,10 +106,10 @@ class FileUploadPlugin extends Gdn_Plugin {
         $Sender->deliveryMethod(DELIVERY_METHOD_JSON);
         $Sender->deliveryType(DELIVERY_TYPE_VIEW);
 
-        $Delete = array(
+        $Delete = [
             'MediaID'    => $MediaID,
             'Status'     => 'failed'
-        );
+        ];
 
         $Media = $this->mediaModel()->getID($MediaID);
         $ForeignTable = val('ForeignTable', $Media);
@@ -245,7 +245,7 @@ class FileUploadPlugin extends Gdn_Plugin {
      */
     protected function cacheAttachedMedia($Sender) {
         $Comments = $Sender->data('Comments');
-        $CommentIDList = array();
+        $CommentIDList = [];
 
         if ($Comments instanceof Gdn_DataSet && $Comments->numRows()) {
             $Comments->dataSeek(-1);
@@ -317,7 +317,7 @@ class FileUploadPlugin extends Gdn_Plugin {
      * @param SettingsController $Sender
      */
     public function settingsController_addEditCategory_handler($Sender) {
-        $Sender->Data['_PermissionFields']['AllowFileUploads'] = array('Control' => 'CheckBox');
+        $Sender->Data['_PermissionFields']['AllowFileUploads'] = ['Control' => 'CheckBox'];
     }
 
     /**
@@ -379,9 +379,9 @@ class FileUploadPlugin extends Gdn_Plugin {
             $Filename = $Media->Name;
         }
 
-        $DownloadPath = combinePaths(array(self::pathUploads(),val('Path', $Media)));
+        $DownloadPath = combinePaths([self::pathUploads(),val('Path', $Media)]);
 
-        if (in_array(strtolower(pathinfo($Filename, PATHINFO_EXTENSION)), array('bmp', 'gif', 'jpg', 'jpeg', 'png'))) {
+        if (in_array(strtolower(pathinfo($Filename, PATHINFO_EXTENSION)), ['bmp', 'gif', 'jpg', 'jpeg', 'png'])) {
             $ServeMode = 'inline';
         } else {
             $ServeMode = 'attachment';
@@ -461,7 +461,7 @@ class FileUploadPlugin extends Gdn_Plugin {
         $Log = val('Log', $Args);
         $Type = strtolower(val('RecordType', $Log));
         $Operation = val('Operation', $Log);
-        if (!in_array($Type, array('discussion', 'comment')) || $Operation != 'Pending') {
+        if (!in_array($Type, ['discussion', 'comment']) || $Operation != 'Pending') {
             return;
         }
 
@@ -486,7 +486,7 @@ class FileUploadPlugin extends Gdn_Plugin {
 
         // Only trigger if restoring discussion or comment
         $Type = strtolower(val('RecordType', $Log));
-        if (!in_array($Type, array('discussion', 'comment'))) {
+        if (!in_array($Type, ['discussion', 'comment'])) {
             return;
         }
 
@@ -531,7 +531,7 @@ class FileUploadPlugin extends Gdn_Plugin {
      * @param UtilityController $Sender
      * @param array $Args
      */
-    public function utilityController_thumbnail_create($Sender, $Args = array()) {
+    public function utilityController_thumbnail_create($Sender, $Args = []) {
         $MediaID = array_shift($Args);
         if (!is_numeric($MediaID)) {
             array_unshift($Args, $MediaID);
@@ -554,11 +554,11 @@ class FileUploadPlugin extends Gdn_Plugin {
         $SHeight = $ImageSize[1];
         $SWidth = $ImageSize[0];
 
-        if (!in_array($ImageSize[2], array(IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG))) {
+        if (!in_array($ImageSize[2], [IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG])) {
             if (is_numeric($MediaID)) {
                 // Fix the thumbnail information so this isn't requested again and again.
                 $Model = new MediaModel();
-                $Media = array('MediaID' => $MediaID, 'ImageWidth' => 0, 'ImageHeight' => 0, 'ThumbPath' => null);
+                $Media = ['MediaID' => $MediaID, 'ImageWidth' => 0, 'ImageHeight' => 0, 'ThumbPath' => null];
                 $Model->save($Media);
             }
 
@@ -566,7 +566,7 @@ class FileUploadPlugin extends Gdn_Plugin {
             redirectTo($Url, 301);
         }
 
-        $Options = array();
+        $Options = [];
 
         $ThumbHeight = self::thumbnailHeight();
         $ThumbWidth = self::thumbnailWidth();
@@ -600,7 +600,7 @@ class FileUploadPlugin extends Gdn_Plugin {
         if (is_numeric($MediaID)) {
             // Save the thumbnail information.
             $Model = new MediaModel();
-            $Media = array('MediaID' => $MediaID, 'ThumbWidth' => $ThumbParsed['Width'], 'ThumbHeight' => $ThumbParsed['Height'], 'ThumbPath' => $ThumbParsed['SaveName']);
+            $Media = ['MediaID' => $MediaID, 'ThumbWidth' => $ThumbParsed['Width'], 'ThumbHeight' => $ThumbParsed['Height'], 'ThumbPath' => $ThumbParsed['SaveName']];
             $Model->save($Media);
         }
 
@@ -643,7 +643,7 @@ class FileUploadPlugin extends Gdn_Plugin {
      */
     protected function placeMedia(&$Media, $UserID) {
         $NewFolder = FileUploadPlugin::findLocalMediaFolder($Media->MediaID, $UserID, true, false);
-        $CurrentPath = array();
+        $CurrentPath = [];
         foreach ($NewFolder as $FolderPart) {
             array_push($CurrentPath, $FolderPart);
             $TestFolder = CombinePaths($CurrentPath);
@@ -654,8 +654,8 @@ class FileUploadPlugin extends Gdn_Plugin {
         }
 
         $FileParts = pathinfo($Media->Name);
-        $SourceFilePath = combinePaths(array(self::pathUploads(), $Media->Path));
-        $NewFilePath = combinePaths(array($TestFolder,$Media->MediaID.'.'.$FileParts['extension']));
+        $SourceFilePath = combinePaths([self::pathUploads(), $Media->Path]);
+        $NewFilePath = combinePaths([$TestFolder,$Media->MediaID.'.'.$FileParts['extension']]);
         $Success = rename($SourceFilePath, $NewFilePath);
         if (!$Success) {
             throw new Exception("Failed renaming '{$SourceFilePath}' -> '{$NewFilePath}'");
@@ -679,7 +679,7 @@ class FileUploadPlugin extends Gdn_Plugin {
     public static function findLocalMediaFolder($MediaID, $UserID, $Absolute = false, $ReturnString = false) {
         $DispersionFactor = c('Plugin.FileUpload.DispersionFactor', 20);
         $FolderID = $MediaID % $DispersionFactor;
-        $ReturnArray = array('FileUpload',$FolderID);
+        $ReturnArray = ['FileUpload',$FolderID];
 
         if ($Absolute) {
             array_unshift($ReturnArray, self::pathUploads());
@@ -778,7 +778,7 @@ class FileUploadPlugin extends Gdn_Plugin {
             // Analyze file extension
             $FileNameParts = pathinfo($FileName);
             $Extension = strtolower($FileNameParts['extension']);
-            $AllowedExtensions = C('Garden.Upload.AllowedFileExtensions', array("*"));
+            $AllowedExtensions = C('Garden.Upload.AllowedFileExtensions', ["*"]);
             if (!in_array($Extension, $AllowedExtensions) && !in_array('*',$AllowedExtensions)) {
                 throw new FileUploadPluginUploadErrorException("Uploaded file type is not allowed.", 11, $FileName, $FileKey);
             }
@@ -842,7 +842,7 @@ class FileUploadPlugin extends Gdn_Plugin {
             }
 
             // Save Media data
-            $Media = array(
+            $Media = [
                 'Name' => $FileName,
                 'Type' => $FileType,
                 'Size' => $FileSize,
@@ -851,11 +851,11 @@ class FileUploadPlugin extends Gdn_Plugin {
                 'InsertUserID' => Gdn::session()->UserID,
                 'DateInserted' => date('Y-m-d H:i:s'),
                 'Path' => $SaveFilename
-            );
+            ];
             $MediaID = $this->mediaModel()->save($Media);
             $Media['MediaID'] = $MediaID;
 
-            $MediaResponse = array(
+            $MediaResponse = [
                 'Status' => 'success',
                 'MediaID' => $MediaID,
                 'Filename' => $FileName,
@@ -865,14 +865,14 @@ class FileUploadPlugin extends Gdn_Plugin {
                 'Thumbnail' => base64_encode(MediaThumbnail($Media)),
                 'FinalImageLocation' => Url(self::url($Media)),
                 'Parsed' => $Parsed
-            );
+            ];
         } catch (FileUploadPluginUploadErrorException $e) {
-            $MediaResponse = array(
+            $MediaResponse = [
                 'Status' => 'failed',
                 'ErrorCode' => $e->getCode(),
                 'Filename' => $e->getFilename(),
                 'StrError' => $e->getMessage()
-            );
+            ];
 
             if (!is_null($e->getApcKey())) {
                 $MediaResponse['ProgressKey'] = $e->getApcKey();
@@ -882,11 +882,11 @@ class FileUploadPlugin extends Gdn_Plugin {
                 $MediaResponse['StrError'] = '('.$e->getFilename().') '.$MediaResponse['StrError'];
             }
         } catch (Exception $Ex) {
-            $MediaResponse = array(
+            $MediaResponse = [
                 'Status' => 'failed',
                 'ErrorCode' => $Ex->getCode(),
                 'StrError' => $Ex->getMessage()
-            );
+            ];
         }
 
         $Sender->setJSON('MediaResponse', $MediaResponse);
@@ -917,11 +917,11 @@ class FileUploadPlugin extends Gdn_Plugin {
         $ApcAvailable = self::apcAvailable();
 
 
-        $Progress = array(
+        $Progress = [
             'key' => $ApcKey,
             'uploader' => $UploaderID,
             'apc' => ($ApcAvailable) ? 'yes' : 'no'
-        );
+        ];
 
         if ($ApcAvailable) {
             $Success = false;

--- a/plugins/FileUpload/views/fileupload_functions.php
+++ b/plugins/FileUpload/views/fileupload_functions.php
@@ -32,9 +32,9 @@ function MediaThumbnail($Media, $Data = FALSE) {
          }
       }
       if ($Data)
-         $Result = array('src' => $Src, 'width' => GetValue('ThumbWidth', $Media), 'height' => GetValue('ThumbHeight', $Media));
+         $Result = ['src' => $Src, 'width' => GetValue('ThumbWidth', $Media), 'height' => GetValue('ThumbHeight', $Media)];
       else
-         $Result = Img($Src, array('class' => 'ImageThumbnail', 'width' => GetValue('ThumbWidth', $Media), 'height' => GetValue('ThumbHeight', $Media)));
+         $Result = Img($Src, ['class' => 'ImageThumbnail', 'width' => GetValue('ThumbWidth', $Media), 'height' => GetValue('ThumbHeight', $Media)]);
 
       return $Result;
 
@@ -43,7 +43,7 @@ function MediaThumbnail($Media, $Data = FALSE) {
 function DefaultMediaThumbnail($Media) {
   $Result = '<span class="Thumb-Default">'.
    '<span class="Thumb-Extension">'.pathinfo($Media['Name'], PATHINFO_EXTENSION).'</span>'.
-   Img('/plugins/FileUpload/images/file.png', array('class' => 'ImageThumbnail', 'height' => GetValue('ThumbHeight', $Media))).
+   Img('/plugins/FileUpload/images/file.png', ['class' => 'ImageThumbnail', 'height' => GetValue('ThumbHeight', $Media)]).
    '</span>';
 
    return $Result;

--- a/plugins/ForumMerge/class.forummerge.plugin.php
+++ b/plugins/ForumMerge/class.forummerge.plugin.php
@@ -43,7 +43,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
     *
     * @return string CSV list of columns in both copies of the table minus the primary key.
     */
-   public function GetColumns($Table, $OldDatabase, $OldPrefix, $Options = array()) {
+   public function GetColumns($Table, $OldDatabase, $OldPrefix, $Options = []) {
       Gdn::Structure()->Database->DatabasePrefix = '';
       $OldColumns = Gdn::Structure()->Get($OldDatabase.'.'.$OldPrefix.$Table)->Columns();
 
@@ -135,7 +135,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
       // CATEGORIES //
       if ($this->OldTableExists('Category')) {
-         $CategoryColumnOptions = array('Legacy' => $DoLegacy);
+         $CategoryColumnOptions = ['Legacy' => $DoLegacy];
          $CategoryColumns = $this->GetColumns('Category', $OldDatabase, $OldPrefix, $CategoryColumnOptions);
 
          /*if ($this->MergeCategories) {
@@ -164,12 +164,12 @@ class ForumMergePlugin implements Gdn_IPlugin {
          }
 
          // Remap hierarchy in the ugliest way possible
-         $CategoryMap = array();
+         $CategoryMap = [];
          $Categories = Gdn::SQL()->Select('CategoryID')
             ->Select('ParentCategoryID')
             ->Select('OldID')
             ->From('Category')
-            ->Where(array('OldID >' => 0))
+            ->Where(['OldID >' => 0])
             ->Get()->Result(DATASET_TYPE_ARRAY);
          foreach ($Categories as $Category) {
             $CategoryMap[$Category['OldID']] = $Category['CategoryID'];
@@ -178,8 +178,8 @@ class ForumMergePlugin implements Gdn_IPlugin {
             if ($Category['ParentCategoryID'] > 0 && !empty($CategoryMap[$Category['ParentCategoryID']])) {
                $ParentID = $CategoryMap[$Category['ParentCategoryID']];
                Gdn::SQL()->Update('Category')
-                  ->Set(array('ParentCategoryID' => $ParentID))
-                  ->Where(array('CategoryID' => $Category['CategoryID']))
+                  ->Set(['ParentCategoryID' => $ParentID])
+                  ->Where(['CategoryID' => $Category['CategoryID']])
                   ->Put();
             }
          }
@@ -195,7 +195,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
       // DISCUSSIONS //
       if ($this->OldTableExists('Discussion')) {
-         $DiscussionColumnOptions = array('Legacy' => $DoLegacy);
+         $DiscussionColumnOptions = ['Legacy' => $DoLegacy];
          $DiscussionColumns = $this->GetColumns('Discussion', $OldDatabase, $OldPrefix, $DiscussionColumnOptions);
 
          // Copy over all discussions
@@ -234,7 +234,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
       // COMMENTS //
       if ($this->OldTableExists('Comment')) {
-         $CommentColumnOptions = array('Legacy' => $DoLegacy);
+         $CommentColumnOptions = ['Legacy' => $DoLegacy];
          $CommentColumns = $this->GetColumns('Comment', $OldDatabase, $OldPrefix, $CommentColumnOptions);
 
          // Copy over all comments
@@ -308,7 +308,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
          // a. Build userid lookup
 
          $Users = Gdn::SQL()->Query('select UserID, OldID from '.$NewPrefix.'User');
-         $UserIDLookup = array();
+         $UserIDLookup = [];
          foreach($Users->Result() as $User) {
             $OldID = GetValue('OldID', $User);
             $UserIDLookup[$OldID] = GetValue('UserID', $User);
@@ -321,7 +321,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
             $Contributors = dbdecode(GetValue('Contributors', $Conversation));
             if (!is_array($Contributors))
                continue;
-            $UpdatedContributors = array();
+            $UpdatedContributors = [];
             foreach($Contributors as $UserID) {
                if (isset($UserIDLookup[$UserID]))
                   $UpdatedContributors[] = $UserIDLookup[$UserID];
@@ -474,7 +474,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
       // Preparing to capture SQL (not execute) for operations that may need to be performed manually by the user
       Gdn::Structure()->CaptureOnly = TRUE;
-      Gdn::Structure()->Database->CapturedSql = array();
+      Gdn::Structure()->Database->CapturedSql = [];
 
       // Comment table threshold check
       $CurrentComments =  GDN::SQL()->Query("show table status where Name = '{$Px}Comment'")->FirstRow()->Rows;

--- a/plugins/HipChat/class.hipchat.plugin.php
+++ b/plugins/HipChat/class.hipchat.plugin.php
@@ -19,30 +19,30 @@ class HipChatPlugin extends Gdn_Plugin {
     public function settingsController_hipChat_create($sender) {
         $sender->permission('Garden.Settings.Manage');
         $conf = new ConfigurationModule($sender);
-        $conf->initialize(array(
+        $conf->initialize([
             //'HipChat.Checkbox' => array('Control' => 'CheckBox', 'LabelCode' => 'A checkbox to tick'),
             //'HipChat.Select' => array('Control' => 'Dropdown', 'LabelCode' => '@'.sprintf(t('Max number of %s'), t('images')),
                 // 'Items' => array('Unlimited' => t('Unlimited'), 'None' => t('None'), 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5)),
 
-            'HipChat.Account' => array(
+            'HipChat.Account' => [
                 'Control' => 'TextBox',
                 'Type' => 'string',
                 'LabelCode' => t('Account Name'),
-                'Options' => array('class' => 'InputBox LargeInput')
-            ),
-            'HipChat.Room' => array(
+                'Options' => ['class' => 'InputBox LargeInput']
+            ],
+            'HipChat.Room' => [
                 'Control' => 'TextBox',
                 'Type' => 'int',
                 'LabelCode' => t('Room ID'),
-                'Options' => array('class' => 'InputBox SmallInput')
-            ),
-            'HipChat.Token' => array(
+                'Options' => ['class' => 'InputBox SmallInput']
+            ],
+            'HipChat.Token' => [
                 'Control' => 'TextBox',
                 'Type' => 'string',
                 'LabelCode' => t('Authorization Token'),
-                'Options' => array('class' => 'InputBox LargeInput')
-            ),
-        ));
+                'Options' => ['class' => 'InputBox LargeInput']
+            ],
+        ]);
 
         $sender->addSideMenu();
         $sender->setData('Title', sprintf(T('%s Settings'), 'HipChat'));
@@ -89,12 +89,12 @@ class HipChatPlugin extends Gdn_Plugin {
         // Determine how to link their name.
         $name = val('Name', $args['InsertFields']);
         if (c('Garden.Registration.Method') == 'Approval') {
-            $user = anchor($name, '/user/applicants', '', array('WithDomain' => true));
+            $user = anchor($name, '/user/applicants', '', ['WithDomain' => true]);
             $reason = sliceParagraph(val('DiscoveryText', $args['InsertFields']));
             $message = sprintf(t('New member: %1$s (%2$s)'), $user, $reason);
         } else {
             // Use conservative name linking structure.
-            $user = anchor($name, '/profile/'.$args['InsertUserID'].'/'.$name, '', array('WithDomain' => true));
+            $user = anchor($name, '/profile/'.$args['InsertUserID'].'/'.$name, '', ['WithDomain' => true]);
             $message = sprintf(t('New member: %1$s'), $user);
         }
 

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -27,12 +27,12 @@ class IPBFormatterPlugin extends Gdn_Plugin {
      * @return mixed|string
      */
     public function format($string) {
-        $string = str_replace(array('&quot;', '&#39;', '&#58;', 'Â'), array('"', "'", ':', ''), $string);
+        $string = str_replace(['&quot;', '&#39;', '&#58;', 'Â'], ['"', "'", ':', ''], $string);
         $string = str_replace('<#EMO_DIR#>', 'default', $string);
         $string = str_replace('<{POST_SNAPBACK}>', '<span class="SnapBack">»</span>', $string);
 
         // There is an issue with using uppercase code blocks, so they're forced to lowercase here
-        $string = str_replace(array('[CODE]', '[/CODE]'), array('[code]', '[/code]'), $string);
+        $string = str_replace(['[CODE]', '[/CODE]'], ['[code]', '[/code]'], $string);
 
         /**
          * IPB inserts line break markup tags at line breaks.  They need to be removed in code blocks.
@@ -41,7 +41,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
         $string = preg_replace_callback(
             '/\[code\].*?\[\/code\]/is',
             function ($codeBlocks) {
-                return str_replace(array('<br />'), array(''), $codeBlocks[0]);
+                return str_replace(['<br />'], [''], $codeBlocks[0]);
             },
             $string
         );
@@ -89,8 +89,8 @@ class IPBFormatterPlugin extends Gdn_Plugin {
         $result = Emoji::instance()->translateToHtml($result);
 
         // Make sure to clean filter the html in the end.
-        $config = array(
-            'anti_link_spam' => array('`.`', ''),
+        $config = [
+            'anti_link_spam' => ['`.`', ''],
             'comment' => 1,
             'cdata' => 3,
             'css_expression' => 1,
@@ -101,7 +101,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
             'schemes' => 'classid:clsid; href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, telnet; style: nil; *:file, http, https',
             // clsid allowed in class
             'valid_xml' => 2
-        );
+        ];
 
         $spec = 'object=-classid-type, -codebase; embed=type(oneof=application/x-shockwave-flash)';
         $result = Htmlawed::filter($result, $config, $spec);
@@ -119,16 +119,16 @@ class IPBFormatterPlugin extends Gdn_Plugin {
             $this->_NBBC = $plugin->nbbc();
             $this->_NBBC->setIgnoreNewlines(true);
 
-            $this->_NBBC->addRule('attachment', array(
+            $this->_NBBC->addRule('attachment', [
                 'mode' => Nbbc\BBCode::BBCODE_MODE_CALLBACK,
-                'method' => array($this, "DoAttachment"),
+                'method' => [$this, "DoAttachment"],
                 'class' => 'image',
-                'allow_in' => array('listitem', 'block', 'columns', 'inline', 'link'),
+                'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
                 'end_tag' => Nbbc\BBCode::BBCODE_PROHIBIT,
                 'content' => Nbbc\BBCode::BBCODE_PROHIBIT,
                 'plain_start' => "[image]",
-                'plain_content' => array(),
-            ));
+                'plain_content' => [],
+            ]);
         }
 
         return $this->_NBBC;
@@ -142,7 +142,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
     public function media() {
         if ($this->_Media === null) {
             // Set _Media to a non-null value, so we only do this once.
-            $this->_Media = array();
+            $this->_Media = [];
 
             // Fire up a basic model, configured for the Media table
             $mediaModel = new Gdn_Model('Media');
@@ -155,7 +155,7 @@ class IPBFormatterPlugin extends Gdn_Plugin {
 
             // Grab comment data set from the current controller and verify it's populated
             $comments = $controller->data('Comments');
-            $commentIDs = array();
+            $commentIDs = [];
             if ($comments instanceof Gdn_DataSet && $comments->numRows()) {
                 // Build a collection of comment IDs
                 while ($currentComment = $comments->nextRow()) {

--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -50,17 +50,17 @@ class IgnorePlugin extends Gdn_Plugin {
    public function SimpleApiPlugin_Mapper_Handler($Sender) {
       switch ($Sender->Mapper->Version) {
          case '1.0':
-            $Sender->Mapper->AddMap(array(
+            $Sender->Mapper->AddMap([
                'ignore/list'           => 'profile/ignore',
                'ignore/add'            => 'profile/ignore/add',
                'ignore/remove'         => 'profile/ignore/remove',
                'ignore/restrict'       => 'profile/ignore/restrict'
-            ), NULL, array(
-               'ignore/list'           => array('IgnoreList', 'IgnoreLimit', 'IgnoreRestricted'),
-               'ignore/add'            => array('Success'),
-               'ignore/remove'         => array('Success'),
-               'ignore/restrict'       => array('Success')
-            ));
+            ], NULL, [
+               'ignore/list'           => ['IgnoreList', 'IgnoreLimit', 'IgnoreRestricted'],
+               'ignore/add'            => ['Success'],
+               'ignore/remove'         => ['Success'],
+               'ignore/restrict'       => ['Success']
+            ]);
             break;
       }
    }
@@ -73,9 +73,9 @@ class IgnorePlugin extends Gdn_Plugin {
       $ViewingUserID = Gdn::Session()->UserID;
 
       if ($Sender->User->UserID == $ViewingUserID) {
-         $SideMenu->AddLink('Options', Sprite('SpIgnoreList').' '.T('Ignore List'), '/profile/ignore', FALSE, array('class' => 'Popup'));
+         $SideMenu->AddLink('Options', Sprite('SpIgnoreList').' '.T('Ignore List'), '/profile/ignore', FALSE, ['class' => 'Popup']);
       } else {
-         $SideMenu->AddLink('Options', Sprite('SpIgnoreList').' '.T('Ignore List'), "/profile/ignore/{$Sender->User->UserID}/".Gdn_Format::Url($Sender->User->Name), 'Garden.Users.Edit', array('class' => 'Popup'));
+         $SideMenu->AddLink('Options', Sprite('SpIgnoreList').' '.T('Ignore List'), "/profile/ignore/{$Sender->User->UserID}/".Gdn_Format::Url($Sender->User->Name), 'Garden.Users.Edit', ['class' => 'Popup']);
       }
    }
 
@@ -95,7 +95,7 @@ class IgnorePlugin extends Gdn_Plugin {
 
       $Args = $Sender->RequestArgs;
       if (sizeof($Args) < 2)
-         $Args = array_merge($Args, array(0,0));
+         $Args = array_merge($Args, [0,0]);
       elseif (sizeof($Args) > 2)
          $Args = array_slice($Args, 0, 2);
 
@@ -154,7 +154,7 @@ class IgnorePlugin extends Gdn_Plugin {
       }
 
       $IgnoredUsersRaw = $this->GetUserMeta($UserID, 'Blocked.User.%');
-      $IgnoredUsersIDs = array();
+      $IgnoredUsersIDs = [];
       foreach ($IgnoredUsersRaw as $IgnoredUsersKey => $IgnoredUsersIgnoreDate) {
          $IgnoredUsersKeyArray = explode('.', $IgnoredUsersKey);
          $IgnoredUsersID = array_pop($IgnoredUsersKeyArray);
@@ -263,7 +263,7 @@ class IgnorePlugin extends Gdn_Plugin {
          throw new Exception("No such user '{$UserID}'", 404);
 
       $Restricted = strtolower(Gdn::Request()->Get('Restricted', 'no'));
-      $Restricted = in_array($Restricted, array('yes', 'true', 'on', TRUE)) ? TRUE : NULL;
+      $Restricted = in_array($Restricted, ['yes', 'true', 'on', TRUE]) ? TRUE : NULL;
       $this->SetUserMeta($UserID, 'Forbidden', $Restricted);
 
       $Sender->SetData('Success', sprintf(T($Restricted ?
@@ -295,9 +295,9 @@ class IgnorePlugin extends Gdn_Plugin {
          // Add to dropdown
          $UserIgnored = $this->Ignored($Sender->User->UserID);
          $Label = ($UserIgnored) ? Sprite('SpUnignore').' '.T('Unignore') : Sprite('SpIgnore').' '.T('Ignore');
-         $Args['ProfileOptions'][] = array('Text' => $Label,
+         $Args['ProfileOptions'][] = ['Text' => $Label,
             'Url' => "/user/ignore/toggle/{$Sender->User->UserID}/".Gdn_Format::Url($Sender->User->Name),
-            'CssClass' => 'Popup');
+            'CssClass' => 'Popup'];
       }
    }
 
@@ -369,7 +369,7 @@ class IgnorePlugin extends Gdn_Plugin {
 
       $Args = $Sender->RequestArgs;
       if (sizeof($Args) < 3)
-         $Args = array_merge($Args, array(0,0));
+         $Args = array_merge($Args, [0,0]);
       elseif (sizeof($Args) > 2)
          $Args = array_slice($Args, 1, 3);
 
@@ -483,7 +483,7 @@ class IgnorePlugin extends Gdn_Plugin {
 
       $Args = $Sender->RequestArgs;
       if (sizeof($Args) < 3)
-         $Args = array_merge($Args, array(0,0));
+         $Args = array_merge($Args, [0,0]);
       elseif (sizeof($Args) > 2)
          $Args = array_slice($Args, 1, 3);
 
@@ -561,10 +561,10 @@ class IgnorePlugin extends Gdn_Plugin {
       if (class_exists('ConversationModel')) {
          // Remove from conversations
          $Conversations = $this->IgnoreConversations($IgnoreUserID, $ForUserID);
-         Gdn::SQL()->Delete('UserConversation', array(
+         Gdn::SQL()->Delete('UserConversation', [
              'UserID' => $ForUserID,
              'ConversationID' => $Conversations
-         ));
+         ]);
          $conversationModel = new ConversationModel();
          $conversationModel->countUnread($ForUserID, true);
       }
@@ -669,7 +669,7 @@ class IgnorePlugin extends Gdn_Plugin {
 
       // Avoid a call to the database if the Conversation application is turned off.
       if (!class_exists('ConversationModel')) {
-         return array();
+         return [];
       }
 
       // Get ignore user's conversation IDs

--- a/plugins/Ignore/views/confirm.php
+++ b/plugins/Ignore/views/confirm.php
@@ -26,8 +26,8 @@ switch ($this->Data('Mode')) {
 }
 
 echo '<div class="Buttons Buttons-Confirm">';
-echo $this->Form->Button('OK', array('class' => 'Button Primary'));
-echo $this->Form->Button('Cancel', array('type' => 'button', 'class' => 'Button Close'));
+echo $this->Form->Button('OK', ['class' => 'Button Primary']);
+echo $this->Form->Button('Cancel', ['type' => 'button', 'class' => 'Button Close']);
 echo '<div>';
 echo $this->Form->Close();
 ?>

--- a/plugins/Ignore/views/ignore.php
+++ b/plugins/Ignore/views/ignore.php
@@ -58,11 +58,11 @@ endif;
    <div class="Info">
       <?php echo sprintf(T("%s prohibited from using the ignore feature."),$ReferTo); ?>
       <?php if ($Moderator && $this->Data('ForceEditing', TRUE)):
-         echo Anchor('Restore', "/user/ignorelist/allow/{$this->User->UserID}/".Gdn_Format::Url($this->User->Name), 'Ignore Hijack', array('id' => 'revoke'));
+         echo Anchor('Restore', "/user/ignorelist/allow/{$this->User->UserID}/".Gdn_Format::Url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']);
       endif; ?>
    </div>
 <?php elseif ($Moderator && $this->Data('ForceEditing', TRUE)): ?>
-   <div class="Warning"><?php echo sprintf(T("Revoke <b>%s</b>'s ignore list privileges?"), $this->Data('ForceEditing')); ?> <?php echo Anchor('Revoke', "/user/ignorelist/revoke/{$this->User->UserID}/".Gdn_Format::Url($this->User->Name), 'Ignore Hijack', array('id' => 'revoke')); ?></div>
+   <div class="Warning"><?php echo sprintf(T("Revoke <b>%s</b>'s ignore list privileges?"), $this->Data('ForceEditing')); ?> <?php echo Anchor('Revoke', "/user/ignorelist/revoke/{$this->User->UserID}/".Gdn_Format::Url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']); ?></div>
 <?php endif; ?>
 
 <?php if (!$this->Data('ForceEditing') && !$Restricted): ?>

--- a/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
+++ b/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
@@ -21,7 +21,7 @@ class InvisibilityCloakPlugin extends Gdn_Plugin {
      */
     public function base_render_before($sender) {
         if ($sender->Head) {
-            $sender->Head->addTag('meta', array('name' => 'robots', 'content' => 'noindex,noarchive'));
+            $sender->Head->addTag('meta', ['name' => 'robots', 'content' => 'noindex,noarchive']);
         }
     }
 }

--- a/plugins/LastEdited/class.lastedited.plugin.php
+++ b/plugins/LastEdited/class.lastedited.plugin.php
@@ -88,12 +88,12 @@ class LastEditedPlugin extends Gdn_Plugin {
         $UpdatedUserID = $Data->UpdateUserID;
 
         $UserData = Gdn::userModel()->getID($UpdatedUserID);
-        $Edited = array(
+        $Edited = [
             'EditUser' => val('Name', $UserData, t('Unknown User')),
             'EditDate' => Gdn_Format::date($Data->DateUpdated, 'html'),
             'EditLogUrl' => url("/log/record/{$RecordType}/{$RecordID}"),
             'EditWord' => 'at'
-        );
+        ];
 
         $DateUpdateTime = Gdn_Format::toTimestamp($Data->DateUpdated);
         if (date('ymd', $DateUpdateTime) != date('ymd')) {

--- a/plugins/LocaleDeveloper/class.developerlocale.php
+++ b/plugins/LocaleDeveloper/class.developerlocale.php
@@ -6,7 +6,7 @@
  */
 
 class DeveloperLocale extends Gdn_Locale {
-    public $_CapturedDefinitions = array();
+    public $_CapturedDefinitions = [];
 
     /**
      * Gets all of the definitions in the current locale.
@@ -33,7 +33,7 @@ class DeveloperLocale extends Gdn_Locale {
                     return self::PrefixFromPath($Row['file']);
             }
             if (strcasecmp($Row['function'], 'Translate') === 0) {
-                if (!in_array(basename($Row['file']), array('functions.general.php', 'class.gdn.php'))) {
+                if (!in_array(basename($Row['file']), ['functions.general.php', 'class.gdn.php'])) {
                     return self::PrefixFromPath($Row['file']);
                 }
             }
@@ -48,7 +48,7 @@ class DeveloperLocale extends Gdn_Locale {
         if (preg_match('`/plugins/([^/]+)`i', $Path, $Matches)) {
             $Plugin = strtolower($Matches[1]);
 
-            if (in_array($Plugin, array('buttonbar', 'fileupload', 'facebook', 'twitter', 'quotes', 'signatures', 'splitmerge', 'tagging', 'nbbc'))) {
+            if (in_array($Plugin, ['buttonbar', 'fileupload', 'facebook', 'twitter', 'quotes', 'signatures', 'splitmerge', 'tagging', 'nbbc'])) {
                 $Result .= 'core';
             } else
                 $Result .= $Plugin.'_plugin';
@@ -57,7 +57,7 @@ class DeveloperLocale extends Gdn_Locale {
         } elseif (preg_match('`/applications/([^/]+)`i', $Path, $Matches)) {
             $App = strtolower($Matches[1]);
 
-            if (in_array($App, array('conversations', 'vanilla', 'dashboard'))) {
+            if (in_array($App, ['conversations', 'vanilla', 'dashboard'])) {
                 // This is a core app.
                 $Result .= 'core';
             } else {

--- a/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
+++ b/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
@@ -43,27 +43,27 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
 
         // Load the core definitions.
         if (file_exists($this->LocalePath.'/captured_site_core.php')) {
-            $Definition = array();
+            $Definition = [];
             include $this->LocalePath.'/captured_site_core.php';
             $Core = $Definition;
         } else {
-            $Core = array();
+            $Core = [];
         }
 
         // Load the admin definitions.
         if (file_exists($this->LocalePath.'/captured_dash_core.php')) {
-            $Definition = array();
+            $Definition = [];
             include $this->LocalePath.'/captured_dash_core.php';
             $Admin = $Definition;
         } else {
-            $Admin = array();
+            $Admin = [];
         }
 
         // Load the ignore file.
-        $Definition = array();
+        $Definition = [];
         include dirname(__FILE__).'/ignore.php';
         $Ignore = $Definition;
-        $Definition = array();
+        $Definition = [];
 
         $CapturedDefinitions = $Locale->CapturedDefinitions();
 
@@ -135,7 +135,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
      *
      * @var SettingsController $Sender
      */
-    public function SettingsController_LocaleDeveloper_Create($Sender, $Args = array()) {
+    public function SettingsController_LocaleDeveloper_Create($Sender, $Args = []) {
         $Sender->Permission('Garden.Settings.Manage');
 
         $Sender->AddSideMenu();
@@ -238,7 +238,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
                 unset($Info[$Key]);
         }
 
-        $InfoArray = array(GetValue('Key', $Info, 'LocaleDeveloper') => array(
+        $InfoArray = [GetValue('Key', $Info, 'LocaleDeveloper') => [
             'Locale' => GetValue('Locale', $Info, Gdn::Locale()->Current()),
             'Name' => GetValue('Name', $Info, 'Locale Developer'),
             'Description' => 'Automatically gernerated by the Locale Developer plugin.',
@@ -247,7 +247,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
             'AuthorEmail' => 'Your Email',
             'AuthorUrl' => 'http://your.domain.com',
             'License' => 'Your choice of license'
-        ));
+        ]];
 
         return $InfoArray;
     }
@@ -288,7 +288,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         // Grab the existing locale packs.
         $LocaleModel = new LocaleModel();
         $LocalePacks = $LocaleModel->AvailableLocalePacks();
-        $LocalArray = array();
+        $LocalArray = [];
         foreach ($LocalePacks as $Key => $Info) {
             $LocaleArray[$Key] = GetValue('Name', $Info, $Key);
         }
@@ -296,14 +296,14 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
 
         if ($this->Form->IsPostBack()) {
             if ($this->Form->GetFormValue('Save')) {
-                $Values = ArrayTranslate($this->Form->FormValues(), array('Key', 'Name', 'Locale', 'CaptureDefinitions'));
-                $SaveValues = array();
+                $Values = ArrayTranslate($this->Form->FormValues(), ['Key', 'Name', 'Locale', 'CaptureDefinitions']);
+                $SaveValues = [];
                 foreach ($Values as $Key => $Value) {
                     $SaveValues['Plugins.LocaleDeveloper.'.$Key] = $Value;
                 }
 
                 // Save the settings.
-                SaveToConfig($SaveValues, '', array('RemoveEmpty' => TRUE));
+                SaveToConfig($SaveValues, '', ['RemoveEmpty' => TRUE]);
 
                 $Sender->StatusMessage = T('Your changes have been saved.');
             } elseif ($this->Form->GetFormValue('GenerateChanges')) {
@@ -389,7 +389,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         $Zip->open($TmpPath, ZIPARCHIVE::CREATE);
 
         // Add all of the files in the locale to the zip.
-        $Files = SafeGlob(rtrim($this->LocalePath, '/').'/*.*', array('php', 'txt'));
+        $Files = SafeGlob(rtrim($this->LocalePath, '/').'/*.*', ['php', 'txt']);
         foreach ($Files as $File) {
             $LocalPath = $Key.'/'.basename($File);
             $Zip->addFile($File, $LocalPath);

--- a/plugins/LocaleDeveloper/views/googletranslate.php
+++ b/plugins/LocaleDeveloper/views/googletranslate.php
@@ -10,7 +10,7 @@ function googleTranslateElementInit() {
 </script><script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <?php
 
-$Definitions = (array)$this->Data('Definitions', array());
+$Definitions = (array)$this->Data('Definitions', []);
 
 foreach ($Definitions as $Code => $Translation) {
    echo '<div class="Definition" Code="'.urlencode($Code).'">',

--- a/plugins/LocaleDeveloper/views/localedeveloper.php
+++ b/plugins/LocaleDeveloper/views/localedeveloper.php
@@ -33,7 +33,7 @@ echo $Form->Errors();
    <li>
       <?php
       echo $this->Form->Label('_Locale', 'Locale'),
-         $this->Form->TextBox('Locale', array('Class' => 'SmallInput'));
+         $this->Form->TextBox('Locale', ['Class' => 'SmallInput']);
       ?>
    </li>
    <li>
@@ -58,7 +58,7 @@ echo $Form->Errors();
          echo T('Capture locale pack changes.', 'Capture the changes between one of your locale packs and the Locale Developer. It will be put in the <code>changes.php</code> file.');
          echo $Form->Label('Choose a locale pack', 'LocalePackForChanges');
          echo $Form->DropDown('LocalePackForChanges', $this->Data('LocalePacks'));
-         echo $Form->Button('Generate', array('Name' => 'Form/GenerateChanges'));
+         echo $Form->Button('Generate', ['Name' => 'Form/GenerateChanges']);
       ?>
    </li>
    <li>

--- a/plugins/Minify/class.minify.plugin.php
+++ b/plugins/Minify/class.minify.plugin.php
@@ -26,16 +26,16 @@ class MinifyPlugin extends Gdn_Plugin {
       $Tags = $Head->Tags();
 
       // Grab all of the CSS
-      $CssToCache = array();
-      $JsToCache = array(); // Add the global js files
-      $GlobalJS = array(
+      $CssToCache = [];
+      $JsToCache = []; // Add the global js files
+      $GlobalJS = [
          'jquery.js',
          'jquery.livequery.js',
          'jquery.form.js',
          'jquery.popup.js',
          'jquery.gardenhandleajaxform.js',
          'global.js'
-      );
+      ];
       
       // Process all tags, finding JS & CSS files
       foreach ($Tags as $Index => $Tag) {
@@ -117,7 +117,7 @@ class MinifyPlugin extends Gdn_Plugin {
     */
    protected function _PrepareToken($Files, $Suffix = '') {
       // Build token.
-      $Query = array('f' => implode(',', array_unique($Files)));
+      $Query = ['f' => implode(',', array_unique($Files))];
       if ($this->BasePath != '')
          $Query['b'] = $this->BasePath;
       $Query = serialize($Query);

--- a/plugins/Minify/min/builder/index.php
+++ b/plugins/Minify/min/builder/index.php
@@ -156,7 +156,7 @@ $(function () {
 
 <?php
 
-$serveOpts = array(
+$serveOpts = [
     'content' => ob_get_contents()
     ,'id' => __FILE__
     ,'lastModifiedTime' => max(
@@ -166,7 +166,7 @@ $serveOpts = array(
     )
     ,'minifyAll' => true
     ,'encodeOutput' => $encodeOutput
-);
+];
 ob_end_clean();
 
 set_include_path(dirname(__FILE__) . '/../lib' . PATH_SEPARATOR . get_include_path());

--- a/plugins/Minify/min/builder/ocCheck.php
+++ b/plugins/Minify/min/builder/ocCheck.php
@@ -22,10 +22,10 @@ if (isset($_GET['hello'])) {
     
     require $min_libPath . '/HTTP/Encoder.php';
     HTTP_Encoder::$encodeToIe6  = true; // just in case
-    $he = new HTTP_Encoder(array(
+    $he = new HTTP_Encoder([
         'content' => 'World!'
         ,'method' => 'deflate'
-    ));
+    ]);
     $he->encode();
     $he->sendAll();
 

--- a/plugins/Minify/min/config.php
+++ b/plugins/Minify/min/config.php
@@ -145,7 +145,7 @@ $min_serveOptions['minApp']['maxFiles'] = 50;
  * array('//static' => 'D:\\staticStorage')  // Windows
  * </code>
  */
-$min_symlinks = array();
+$min_symlinks = [];
 
 
 /**
@@ -184,7 +184,7 @@ ini_set('zlib.output_compression', '0');
  */
 function realpath2($path) {
    $parts = explode('/', str_replace('\\', '/', $path));
-   $result = array();
+   $result = [];
 
    foreach ($parts as $part) {
       if (!$part || $part == '.')

--- a/plugins/Minify/min/groupsConfig.php
+++ b/plugins/Minify/min/groupsConfig.php
@@ -22,15 +22,15 @@ if ($WebRoot != '')
 else
    $WebRoot = '//';
    
-return array(
-   'globaljs' => array(
+return [
+   'globaljs' => [
       $WebRoot.'js/library/jquery.js',
       $WebRoot.'js/library/jquery.livequery.js',
       $WebRoot.'js/library/jquery.form.js',
       $WebRoot.'js/library/jquery.popup.js',
       $WebRoot.'js/library/jquery.gardenhandleajaxform.js',
       $WebRoot.'js/global.js'
-   )
+   ]
    
     // 'js' => array('//js/file1.js', '//js/file2.js'),
     // 'css' => array('//css/file1.css', '//css/file2.css'),
@@ -53,4 +53,4 @@ return array(
             'minifier' => array('Minify_Packer', 'minify')
         ))
     ),//*/
-);
+];

--- a/plugins/Minify/min/lib/FirePHP.php
+++ b/plugins/Minify/min/lib/FirePHP.php
@@ -163,21 +163,21 @@ class FirePHP {
    * 
    * @var array
    */
-  protected $options = array();
+  protected $options = [];
   
   /**
    * Filters used to exclude object members when encoding
    * 
    * @var array
    */
-  protected $objectFilters = array();
+  protected $objectFilters = [];
   
   /**
    * A stack of objects used to detect recursion during object encoding
    * 
    * @var object
    */
-  protected $objectStack = array();
+  protected $objectStack = [];
   
   /**
    * Flag to enable/disable logging
@@ -202,7 +202,7 @@ class FirePHP {
    * @return array
    */  
   public function __sleep() {
-    return array('options','objectFilters','enabled');
+    return ['options','objectFilters','enabled'];
   }
     
   /**
@@ -287,7 +287,7 @@ class FirePHP {
     //      E_CORE_WARNING, E_COMPILE_ERROR,
     //      E_COMPILE_WARNING, E_STRICT
     
-    set_error_handler(array($this,'errorHandler'));     
+    set_error_handler([$this,'errorHandler']);     
   }
 
   /**
@@ -318,7 +318,7 @@ class FirePHP {
    */
   public function registerExceptionHandler()
   {
-    set_exception_handler(array($this,'exceptionHandler'));     
+    set_exception_handler([$this,'exceptionHandler']);     
   }
   
   /**
@@ -532,7 +532,7 @@ class FirePHP {
       return false;
     }
   
-    $meta = array();
+    $meta = [];
     $skipFinalObjectEncode = false;
   
     if($Object instanceof Exception) {
@@ -560,20 +560,20 @@ class FirePHP {
           case E_USER_DEPRECATED: $severity = 'E_USER_DEPRECATED'; break;
         }
            
-        $Object = array('Class'=>get_class($Object),
+        $Object = ['Class'=>get_class($Object),
                         'Message'=>$severity.': '.$Object->getMessage(),
                         'File'=>$this->_escapeTraceFile($Object->getFile()),
                         'Line'=>$Object->getLine(),
                         'Type'=>'trigger',
-                        'Trace'=>$this->_escapeTrace(array_splice($trace,2)));
+                        'Trace'=>$this->_escapeTrace(array_splice($trace,2))];
         $skipFinalObjectEncode = true;
       } else {
-        $Object = array('Class'=>get_class($Object),
+        $Object = ['Class'=>get_class($Object),
                         'Message'=>$Object->getMessage(),
                         'File'=>$this->_escapeTraceFile($Object->getFile()),
                         'Line'=>$Object->getLine(),
                         'Type'=>'throw',
-                        'Trace'=>$this->_escapeTrace($trace));
+                        'Trace'=>$this->_escapeTrace($trace)];
         $skipFinalObjectEncode = true;
       }
       $Type = self::EXCEPTION;
@@ -602,14 +602,14 @@ class FirePHP {
         if($trace[$i]['function']=='fb'
            || $trace[$i]['function']=='trace'
            || $trace[$i]['function']=='send') {
-          $Object = array('Class'=>isset($trace[$i]['class'])?$trace[$i]['class']:'',
+          $Object = ['Class'=>isset($trace[$i]['class'])?$trace[$i]['class']:'',
                           'Type'=>isset($trace[$i]['type'])?$trace[$i]['type']:'',
                           'Function'=>isset($trace[$i]['function'])?$trace[$i]['function']:'',
                           'Message'=>$trace[$i]['args'][0],
                           'File'=>isset($trace[$i]['file'])?$this->_escapeTraceFile($trace[$i]['file']):'',
                           'Line'=>isset($trace[$i]['line'])?$trace[$i]['line']:'',
                           'Args'=>isset($trace[$i]['args'])?$this->encodeObject($trace[$i]['args']):'',
-                          'Trace'=>$this->_escapeTrace(array_splice($trace,$i+1)));
+                          'Trace'=>$this->_escapeTrace(array_splice($trace,$i+1))];
 
           $skipFinalObjectEncode = true;
           $meta['file'] = isset($trace[$i]['file'])?$this->_escapeTraceFile($trace[$i]['file']):'';
@@ -685,7 +685,7 @@ class FirePHP {
     if($Type==self::DUMP) {
     	$msg = '{"'.$Label.'":'.$this->jsonEncode($Object, $skipFinalObjectEncode).'}';
     } else {
-      $msg_meta = array('Type'=>$Type);
+      $msg_meta = ['Type'=>$Type];
       if($Label!==null) {
         $msg_meta['Label'] = $Label;
       }
@@ -857,7 +857,7 @@ class FirePHP {
    */
   protected function encodeObject($Object, $ObjectDepth = 1, $ArrayDepth = 1)
   {
-    $return = array();
+    $return = [];
     
     if (is_object($Object)) {
 
@@ -875,7 +875,7 @@ class FirePHP {
         $return['__className'] = $class = get_class($Object);
 
         $reflectionClass = new ReflectionClass($class);  
-        $properties = array();
+        $properties = [];
         foreach( $reflectionClass->getProperties() as $property) {
           $properties[$property->getName()] = $property;
         }
@@ -1074,7 +1074,7 @@ class FirePHP {
   /**
    * Keep a list of objects as we descend into the array so we can detect recursion.
    */
-  private $json_objectStack = array();
+  private $json_objectStack = [];
 
 
  /**
@@ -1284,7 +1284,7 @@ class FirePHP {
                   
                   $this->json_objectStack[] = $var;
 
-                  $properties = array_map(array($this, 'json_name_value'),
+                  $properties = array_map([$this, 'json_name_value'],
                                           array_keys($var),
                                           array_values($var));
 
@@ -1302,7 +1302,7 @@ class FirePHP {
               $this->json_objectStack[] = $var;
 
               // treat it like a regular array
-              $elements = array_map(array($this, 'json_encode'), $var);
+              $elements = array_map([$this, 'json_encode'], $var);
 
               array_pop($this->json_objectStack);
 
@@ -1319,7 +1319,7 @@ class FirePHP {
 
               $this->json_objectStack[] = $var;
 
-              $properties = array_map(array($this, 'json_name_value'),
+              $properties = array_map([$this, 'json_name_value'],
                                       array_keys($vars),
                                       array_values($vars));
 

--- a/plugins/Minify/min/lib/HTTP/ConditionalGet.php
+++ b/plugins/Minify/min/lib/HTTP/ConditionalGet.php
@@ -233,7 +233,7 @@ class HTTP_ConditionalGet {
      *
      * @return null     
      */
-    public static function check($lastModifiedTime = null, $isPublic = false, $options = array())
+    public static function check($lastModifiedTime = null, $isPublic = false, $options = [])
     {
         if (null !== $lastModifiedTime) {
             $options['lastModifiedTime'] = (int)$lastModifiedTime;
@@ -263,7 +263,7 @@ class HTTP_ConditionalGet {
         return gmdate('D, d M Y H:i:s \G\M\T', $time);
     }
     
-    protected $_headers = array();
+    protected $_headers = [];
     protected $_lmTime = null;
     protected $_etag = null;
     protected $_stripEtag = false;

--- a/plugins/Minify/min/lib/HTTP/Encoder.php
+++ b/plugins/Minify/min/lib/HTTP/Encoder.php
@@ -96,9 +96,9 @@ class HTTP_Encoder {
             $this->_headers['Content-Type'] = $spec['type'];
         }
         if (isset($spec['method'])
-            && in_array($spec['method'], array('gzip', 'deflate', 'compress', '')))
+            && in_array($spec['method'], ['gzip', 'deflate', 'compress', '']))
         {
-            $this->_encodeMethod = array($spec['method'], $spec['method']);
+            $this->_encodeMethod = [$spec['method'], $spec['method']];
         } else {
             $this->_encodeMethod = self::getAcceptedEncoding();
         }
@@ -197,21 +197,21 @@ class HTTP_Encoder {
         if (! isset($_SERVER['HTTP_ACCEPT_ENCODING'])
             || self::_isBuggyIe())
         {
-            return array('', '');
+            return ['', ''];
         }
         $ae = $_SERVER['HTTP_ACCEPT_ENCODING'];
         // gzip checks (quick)
         if (0 === strpos($ae, 'gzip,')             // most browsers
             || 0 === strpos($ae, 'deflate, gzip,') // opera
         ) {
-            return array('gzip', 'gzip');
+            return ['gzip', 'gzip'];
         }
         // gzip checks (slow)
         if (preg_match(
                 '@(?:^|,)\\s*((?:x-)?gzip)\\s*(?:$|,|;\\s*q=(?:0\\.|1))@'
                 ,$ae
                 ,$m)) {
-            return array('gzip', $m[1]);
+            return ['gzip', $m[1]];
         }
         if ($allowDeflate) {
             // deflate checks    
@@ -222,16 +222,16 @@ class HTTP_Encoder {
                 // slow parsing
                 || preg_match(
                     '@(?:^|,)\\s*deflate\\s*(?:$|,|;\\s*q=(?:0\\.|1))@', $ae)) {
-                return array('deflate', 'deflate');
+                return ['deflate', 'deflate'];
             }
         }
         if ($allowCompress && preg_match(
                 '@(?:^|,)\\s*((?:x-)?compress)\\s*(?:$|,|;\\s*q=(?:0\\.|1))@'
                 ,$ae
                 ,$m)) {
-            return array('compress', $m[1]);
+            return ['compress', $m[1]];
         }
-        return array('', '');
+        return ['', ''];
     }
 
     /**
@@ -296,15 +296,15 @@ class HTTP_Encoder {
         if (null === $compressionLevel) {
             $compressionLevel = self::$compressionLevel;
         }
-        $he = new HTTP_Encoder(array('content' => $content));
+        $he = new HTTP_Encoder(['content' => $content]);
         $ret = $he->encode($compressionLevel);
         $he->sendAll();
         return $ret;
     }
     
     protected $_content = '';
-    protected $_headers = array();
-    protected $_encodeMethod = array('', '');
+    protected $_headers = [];
+    protected $_encodeMethod = ['', ''];
 
     /**
      * Is the browser an IE version earlier than 6 SP2?  

--- a/plugins/Minify/min/lib/JSMinPlus.php
+++ b/plugins/Minify/min/lib/JSMinPlus.php
@@ -89,7 +89,7 @@ define('STATEMENT_FORM', 2);
 class JSMinPlus
 {
 	private $parser;
-	private $reserved = array(
+	private $reserved = [
 		'break', 'case', 'catch', 'continue', 'default', 'delete', 'do',
 		'else', 'finally', 'for', 'function', 'if', 'in', 'instanceof',
 		'new', 'return', 'switch', 'this', 'throw', 'try', 'typeof', 'var',
@@ -103,7 +103,7 @@ class JSMinPlus
 		// These are not reserved, but should be taken into account
 		// in isValidIdentifier (See jslint source code)
 		'arguments', 'eval', 'true', 'false', 'Infinity', 'NaN', 'null', 'undefined'
-	);
+	];
 
 	private function __construct()
 	{
@@ -478,7 +478,7 @@ class JSParser
 {
 	private $t;
 
-	private $opPrecedence = array(
+	private $opPrecedence = [
 		';' => 0,
 		',' => 1,
 		'=' => 2, '?' => 2, ':' => 2,
@@ -500,9 +500,9 @@ class JSParser
 		'.' => 17,
 		JS_NEW_WITH_ARGS => 0, JS_INDEX => 0, JS_CALL => 0,
 		JS_ARRAY_INIT => 0, JS_OBJECT_INIT => 0, JS_GROUP => 0
-	);
+	];
 
-	private $opArity = array(
+	private $opArity = [
 		',' => -2,
 		'=' => 2,
 		'?' => 3,
@@ -524,7 +524,7 @@ class JSParser
 		JS_NEW_WITH_ARGS => 2, JS_INDEX => 2, JS_CALL => 2,
 		JS_ARRAY_INIT => 1, JS_OBJECT_INIT => 1, JS_GROUP => 1,
 		TOKEN_CONDCOMMENT_MULTILINE => 1
-	);
+	];
 
 	public function __construct()
 	{
@@ -612,7 +612,7 @@ class JSParser
 				$this->t->mustMatch(OP_LEFT_PAREN);
 				$n->discriminant = $this->Expression($x);
 				$this->t->mustMatch(OP_RIGHT_PAREN);
-				$n->cases = array();
+				$n->cases = [];
 				$n->defaultIndex = -1;
 
 				array_push($x->stmtStack, $n);
@@ -768,7 +768,7 @@ class JSParser
 			case KEYWORD_TRY:
 				$n = new JSNode($this->t);
 				$n->tryBlock = $this->Block($x);
-				$n->catchClauses = array();
+				$n->catchClauses = [];
 
 				while ($this->t->match(KEYWORD_CATCH))
 				{
@@ -906,7 +906,7 @@ class JSParser
 			throw $this->t->newSyntaxError('Missing function identifier');
 
 		$this->t->mustMatch(OP_LEFT_PAREN);
-			$f->params = array();
+			$f->params = [];
 
 		while (($tt = $this->t->get()) != OP_RIGHT_PAREN)
 		{
@@ -965,8 +965,8 @@ class JSParser
 
 	private function Expression($x, $stop=false)
 	{
-		$operators = array();
-		$operands = array();
+		$operators = [];
+		$operands = [];
 		$n = false;
 
 		$bl = $x->bracketLevel;
@@ -1403,9 +1403,9 @@ class JSCompilerContext
 	public $parenLevel = 0;
 	public $hookLevel = 0;
 
-	public $stmtStack = array();
-	public $funDecls = array();
-	public $varDecls = array();
+	public $stmtStack = [];
+	public $funDecls = [];
+	public $varDecls = [];
 
 	public function __construct($inFunction)
 	{
@@ -1421,9 +1421,9 @@ class JSNode
 	private $start;
 	private $end;
 
-	public $treeNodes = array();
-	public $funDecls = array();
-	public $varDecls = array();
+	public $treeNodes = [];
+	public $funDecls = [];
+	public $varDecls = [];
 
 	public function __construct($t, $type=0)
 	{
@@ -1474,7 +1474,7 @@ class JSTokenizer
 	private $cursor = 0;
 	private $source;
 
-	public $tokens = array();
+	public $tokens = [];
 	public $tokenIndex = 0;
 	public $lookahead = 0;
 	public $scanNewlines = false;
@@ -1483,7 +1483,7 @@ class JSTokenizer
 	public $filename;
 	public $lineno;
 
-	private $keywords = array(
+	private $keywords = [
 		'break',
 		'case', 'catch', 'const', 'continue',
 		'debugger', 'default', 'delete', 'do',
@@ -1496,9 +1496,9 @@ class JSTokenizer
 		'this', 'throw', 'true', 'try', 'typeof',
 		'var', 'void',
 		'while', 'with'
-	);
+	];
 
-	private $opTypeNames = array(
+	private $opTypeNames = [
 		';'	=> 'SEMICOLON',
 		','	=> 'COMMA',
 		'?'	=> 'HOOK',
@@ -1537,9 +1537,9 @@ class JSTokenizer
 		'('	=> 'LEFT_PAREN',
 		')'	=> 'RIGHT_PAREN',
 		'@*/'	=> 'CONDCOMMENT_END'
-	);
+	];
 
-	private $assignOps = array('|', '^', '&', '<<', '>>', '>>>', '+', '-', '*', '/', '%');
+	private $assignOps = ['|', '^', '&', '<<', '>>', '>>>', '+', '-', '*', '/', '%'];
 	private $opRegExp;
 
 	public function __construct()
@@ -1564,7 +1564,7 @@ class JSTokenizer
 		$this->lineno = $lineno;
 
 		$this->cursor = 0;
-		$this->tokens = array();
+		$this->tokens = [];
 		$this->tokenIndex = 0;
 		$this->lookahead = 0;
 		$this->scanNewlines = false;
@@ -1695,7 +1695,7 @@ class JSTokenizer
 		if ($input == '')
 		{
 			$tt = TOKEN_END;
-			$match = array('');
+			$match = [''];
 		}
 		elseif ($conditional_comment)
 		{
@@ -1794,7 +1794,7 @@ class JSTokenizer
 				case '(':
 				case ')':
 					// these are all single
-					$match = array($input[0]);
+					$match = [$input[0]];
 					$tt = $input[0];
 				break;
 
@@ -1805,7 +1805,7 @@ class JSTokenizer
 				case "\n":
 					if ($this->scanNewlines)
 					{
-						$match = array("\n");
+						$match = ["\n"];
 						$tt = TOKEN_NEWLINE;
 					}
 					else

--- a/plugins/Minify/min/lib/Minify.php
+++ b/plugins/Minify/min/lib/Minify.php
@@ -157,7 +157,7 @@ class Minify {
      * with keys "success" (bool), "statusCode" (int), "content" (string), and
      * "headers" (array).
      */
-    public static function serve($controller, $options = array())
+    public static function serve($controller, $options = [])
     {
         if (is_string($controller)) {
             // make $controller into object
@@ -184,12 +184,12 @@ class Minify {
                 return;
             } else {
                 list(,$statusCode) = explode(' ', self::$_options['badRequestHeader']);
-                return array(
+                return [
                     'success' => false
                     ,'statusCode' => (int)$statusCode
                     ,'content' => ''
-                    ,'headers' => array()
-                );
+                    ,'headers' => []
+                ];
             }
         }
         
@@ -219,11 +219,11 @@ class Minify {
         
         // check client cache
         require_once 'HTTP/ConditionalGet.php';
-        $cgOptions = array(
+        $cgOptions = [
             'lastModifiedTime' => self::$_options['lastModifiedTime']
             ,'isPublic' => self::$_options['isPublic']
             ,'encoding' => self::$_options['encodeMethod']
-        );
+        ];
         if (self::$_options['maxAge'] > 0) {
             $cgOptions['maxAge'] = self::$_options['maxAge'];
         }
@@ -234,12 +234,12 @@ class Minify {
                 $cg->sendHeaders();
                 return;
             } else {
-                return array(
+                return [
                     'success' => true
                     ,'statusCode' => 304
                     ,'content' => ''
                     ,'headers' => $cg->getHeaders()
-                );
+                ];
             }
         } else {
             // client will need output
@@ -317,14 +317,14 @@ class Minify {
                 echo $content;
             }
         } else {
-            return array(
+            return [
                 'success' => true
                 ,'statusCode' => 200
                 ,'content' => $cacheIsReady
                     ? self::$_cache->fetch($fullCacheId)
                     : $content
                 ,'headers' => $headers
-            );
+            ];
         }
     }
     
@@ -340,16 +340,16 @@ class Minify {
      * 
      * @return string
      */
-    public static function combine($sources, $options = array())
+    public static function combine($sources, $options = [])
     {
         $cache = self::$_cache;
         self::$_cache = null;
-        $options = array_merge(array(
+        $options = array_merge([
             'files' => (array)$sources
             ,'quiet' => true
             ,'encodeMethod' => ''
             ,'lastModifiedTime' => 0
-        ), $options);
+        ], $options);
         $out = self::serve('Files', $options);
         self::$_cache = $cache;
         return $out['content'];
@@ -406,11 +406,11 @@ class Minify {
     protected static function _setupDebug($sources)
     {
         foreach ($sources as $source) {
-            $source->minifier = array('Minify_Lines', 'minify');
+            $source->minifier = ['Minify_Lines', 'minify'];
             $id = $source->getId();
-            $source->minifyOptions = array(
+            $source->minifyOptions = [
                 'id' => (is_file($id) ? basename($id) : $id)
-            );
+            ];
         }
     }
     
@@ -433,7 +433,7 @@ class Minify {
         // these
         $defaultOptions = isset(self::$_options['minifierOptions'][$type])
             ? self::$_options['minifierOptions'][$type]
-            : array();
+            : [];
         // if minifier not set, default is no minification. source objects
         // may still override this
         $defaultMinifier = isset(self::$_options['minifiers'][$type])
@@ -498,13 +498,13 @@ class Minify {
        if (defined('MINIFY_TOKEN'))
           return MINIFY_TOKEN;
 
-        return md5(serialize(array(
+        return md5(serialize([
             Minify_Source::getDigest(self::$_controller->sources)
             ,self::$_options['minifiers'] 
             ,self::$_options['minifierOptions']
             ,self::$_options['postprocessor']
             ,self::$_options['bubbleCssImports']
-        )));
+        ]));
     }
     
     /**

--- a/plugins/Minify/min/lib/Minify/CSS.php
+++ b/plugins/Minify/min/lib/Minify/CSS.php
@@ -48,7 +48,7 @@ class Minify_CSS {
      * 
      * @return string
      */
-    public static function minify($css, $options = array()) 
+    public static function minify($css, $options = []) 
     {
         require_once 'Minify/CSS/Compressor.php';
         if (isset($options['preserveComments']) 
@@ -58,8 +58,8 @@ class Minify_CSS {
             require_once 'Minify/CommentPreserver.php';
             $css = Minify_CommentPreserver::process(
                 $css
-                ,array('Minify_CSS_Compressor', 'process')
-                ,array($options)
+                ,['Minify_CSS_Compressor', 'process']
+                ,[$options]
             );
         }
         if (! isset($options['currentDir']) && ! isset($options['prependRelativePath'])) {
@@ -71,7 +71,7 @@ class Minify_CSS {
                 $css
                 ,$options['currentDir']
                 ,isset($options['docRoot']) ? $options['docRoot'] : $_SERVER['DOCUMENT_ROOT']
-                ,isset($options['symlinks']) ? $options['symlinks'] : array()
+                ,isset($options['symlinks']) ? $options['symlinks'] : []
             );  
         } else {
             return Minify_CSS_UriRewriter::prepend(

--- a/plugins/Minify/min/lib/Minify/CSS/Compressor.php
+++ b/plugins/Minify/min/lib/Minify/CSS/Compressor.php
@@ -29,7 +29,7 @@ class Minify_CSS_Compressor {
      * 
      * @return string
      */
-    public static function process($css, $options = array())
+    public static function process($css, $options = [])
     {
         $obj = new Minify_CSS_Compressor($options);
         return $obj->_process($css);
@@ -81,7 +81,7 @@ class Minify_CSS_Compressor {
         
         // apply callback to all valid comments (and strip out surrounding ws
         $css = preg_replace_callback('@\\s*/\\*([\\s\\S]*?)\\*/\\s*@'
-            ,array($this, '_commentCB'), $css);
+            ,[$this, '_commentCB'], $css);
 
         // remove ws around { } and last semicolon in declaration block
         $css = preg_replace('/\\s*{\\s*/', '{', $css);
@@ -123,7 +123,7 @@ class Minify_CSS_Compressor {
                 [^~>+,\\s]+      # selector part
                 {                # open declaration block
             /x'
-            ,array($this, '_selectorsCB'), $css);
+            ,[$this, '_selectorsCB'], $css);
         
         // minimize hex colors
         $css = preg_replace('/([^=])#([a-f\\d])\\2([a-f\\d])\\3([a-f\\d])\\4([\\s;\\}])/i'
@@ -131,7 +131,7 @@ class Minify_CSS_Compressor {
         
         // remove spaces between font families
         $css = preg_replace_callback('/font-family:([^;}]+)([;}])/'
-            ,array($this, '_fontFamilyCB'), $css);
+            ,[$this, '_fontFamilyCB'], $css);
         
         $css = preg_replace('/@import\\s+url/', '@import url', $css);
         

--- a/plugins/Minify/min/lib/Minify/CSS/UriRewriter.php
+++ b/plugins/Minify/min/lib/Minify/CSS/UriRewriter.php
@@ -47,13 +47,13 @@ class Minify_CSS_UriRewriter {
      * 
      * @return string
      */
-    public static function rewrite($css, $currentDir, $docRoot = null, $symlinks = array()) 
+    public static function rewrite($css, $currentDir, $docRoot = null, $symlinks = []) 
     {
         self::$_docRoot = self::_realpath(
             $docRoot ? $docRoot : $_SERVER['DOCUMENT_ROOT']
         );
         self::$_currentDir = self::_realpath($currentDir);
-        self::$_symlinks = array();
+        self::$_symlinks = [];
         
         // normalize symlinks
         foreach ($symlinks as $link => $target) {
@@ -75,9 +75,9 @@ class Minify_CSS_UriRewriter {
         
         // rewrite
         $css = preg_replace_callback('/@import\\s+([\'"])(.*?)[\'"]/'
-            ,array(self::$className, '_processUriCB'), $css);
+            ,[self::$className, '_processUriCB'], $css);
         $css = preg_replace_callback('/url\\(\\s*([^\\)\\s]+)\\s*\\)/'
-            ,array(self::$className, '_processUriCB'), $css);
+            ,[self::$className, '_processUriCB'], $css);
 
         return $css;
     }
@@ -99,9 +99,9 @@ class Minify_CSS_UriRewriter {
         
         // append
         $css = preg_replace_callback('/@import\\s+([\'"])(.*?)[\'"]/'
-            ,array(self::$className, '_processUriCB'), $css);
+            ,[self::$className, '_processUriCB'], $css);
         $css = preg_replace_callback('/url\\(\\s*([^\\)\\s]+)\\s*\\)/'
-            ,array(self::$className, '_processUriCB'), $css);
+            ,[self::$className, '_processUriCB'], $css);
 
         self::$_prependPath = null;
         return $css;
@@ -122,7 +122,7 @@ class Minify_CSS_UriRewriter {
      * @var array directory replacements to map symlink targets back to their
      * source (within the document root) E.g. '/var/www/symlink' => '/var/realpath'
      */
-    private static $_symlinks = array();
+    private static $_symlinks = [];
     
     /**
      * @var string path to prepend
@@ -210,7 +210,7 @@ class Minify_CSS_UriRewriter {
      * 
      * @return string
      */
-    public static function rewriteRelative($uri, $realCurrentDir, $realDocRoot, $symlinks = array())
+    public static function rewriteRelative($uri, $realCurrentDir, $realDocRoot, $symlinks = [])
     {
         // prepend path with current dir separator (OS-independent)
         $path = strtr($realCurrentDir, '/', DIRECTORY_SEPARATOR)  

--- a/plugins/Minify/min/lib/Minify/CommentPreserver.php
+++ b/plugins/Minify/min/lib/Minify/CommentPreserver.php
@@ -40,7 +40,7 @@ class Minify_CommentPreserver {
      * function (default = array())
      * @return string
      */
-    public static function process($content, $processor, $args = array())
+    public static function process($content, $processor, $args = [])
     {
         $ret = '';
         while (true) {
@@ -75,12 +75,12 @@ class Minify_CommentPreserver {
             false === ($start = strpos($in, '/*!'))
             || false === ($end = strpos($in, '*/', $start + 3))
         ) {
-            return array($in, false, false);
+            return [$in, false, false];
         }
-        $ret = array(
+        $ret = [
             substr($in, 0, $start)
             ,self::$prepend . '/*' . substr($in, $start + 3, $end - $start - 1) . self::$append
-        );
+        ];
         $endChars = (strlen($in) - $end - 2);
         $ret[] = (0 === $endChars)
             ? ''

--- a/plugins/Minify/min/lib/Minify/Controller/Base.php
+++ b/plugins/Minify/min/lib/Minify/Controller/Base.php
@@ -39,12 +39,12 @@ abstract class Minify_Controller_Base {
      * @return array options for Minify
      */
     public function getDefaultMinifyOptions() {
-        return array(
+        return [
             'isPublic' => true
             ,'encodeOutput' => function_exists('gzdeflate')
             ,'encodeMethod' => null // determine later
             ,'encodeLevel' => 9
-            ,'minifierOptions' => array() // no minifier options
+            ,'minifierOptions' => [] // no minifier options
             ,'contentTypeCharset' => 'utf-8'
             ,'maxAge' => 1800 // 30 minutes
             ,'rewriteCssUris' => true
@@ -60,7 +60,7 @@ abstract class Minify_Controller_Base {
             ,'postprocessor' => null
             // file to require to load preprocessor
             ,'postprocessorRequire' => null
-        );
+        ];
     }  
 
     /**
@@ -71,9 +71,9 @@ abstract class Minify_Controller_Base {
      * @return array minifier callbacks for common types
      */
     public function getDefaultMinifers() {
-        $ret[Minify::TYPE_JS] = array('JSMin', 'minify');
-        $ret[Minify::TYPE_CSS] = array('Minify_CSS', 'minify');
-        $ret[Minify::TYPE_HTML] = array('Minify_HTML', 'minify');
+        $ret[Minify::TYPE_JS] = ['JSMin', 'minify'];
+        $ret[Minify::TYPE_CSS] = ['Minify_CSS', 'minify'];
+        $ret[Minify::TYPE_HTML] = ['Minify_HTML', 'minify'];
         return $ret;
     }
     
@@ -132,7 +132,7 @@ abstract class Minify_Controller_Base {
             return false;
         }
         list($revExt) = explode('.', strrev($base));
-        return in_array(strrev($revExt), array('js', 'css', 'html', 'txt'));
+        return in_array(strrev($revExt), ['js', 'css', 'html', 'txt']);
     }
     
     /**
@@ -141,7 +141,7 @@ abstract class Minify_Controller_Base {
      * 
      * @see Minify_Source
      */
-    public $sources = array();
+    public $sources = [];
     
     /**
      * Mix in default controller options with user-given options
@@ -156,7 +156,7 @@ abstract class Minify_Controller_Base {
             $this->getDefaultMinifyOptions(), $options
         );
         if (! isset($options['minifiers'])) {
-            $options['minifiers'] = array();
+            $options['minifiers'] = [];
         }
         $ret['minifiers'] = array_merge(
             $this->getDefaultMinifers(), $options['minifiers']
@@ -172,7 +172,7 @@ abstract class Minify_Controller_Base {
      * 
      * @return array options for Minify
      */
-    public final function analyzeSources($options = array()) 
+    public final function analyzeSources($options = []) 
     {
         if ($this->sources) {
             if (! isset($options['contentType'])) {

--- a/plugins/Minify/min/lib/Minify/Controller/Files.php
+++ b/plugins/Minify/min/lib/Minify/Controller/Files.php
@@ -44,13 +44,13 @@ class Minify_Controller_Files extends Minify_Controller_Base {
         $files = $options['files'];
         // if $files is a single object, casting will break it
         if (is_object($files)) {
-            $files = array($files);
+            $files = [$files];
         } elseif (! is_array($files)) {
             $files = (array)$files;
         }
         unset($options['files']);
         
-        $sources = array();
+        $sources = [];
         foreach ($files as $file) {
             if ($file instanceof Minify_Source) {
                 $sources[] = $file;
@@ -61,9 +61,9 @@ class Minify_Controller_Files extends Minify_Controller_Base {
             }
             $realPath = realpath($file);
             if (is_file($realPath)) {
-                $sources[] = new Minify_Source(array(
+                $sources[] = new Minify_Source([
                     'filepath' => $realPath
-                ));    
+                ]);    
             } else {
                 $this->log("The path \"{$file}\" could not be found (or was not a file)");
                 return $options;

--- a/plugins/Minify/min/lib/Minify/Controller/Groups.php
+++ b/plugins/Minify/min/lib/Minify/Controller/Groups.php
@@ -58,12 +58,12 @@ class Minify_Controller_Groups extends Minify_Controller_Base {
             $this->log("Missing PATH_INFO or no group set for \"$pi\"");
             return $options;
         }
-        $sources = array();
+        $sources = [];
         
         $files = $groups[$pi];
         // if $files is a single object, casting will break it
         if (is_object($files)) {
-            $files = array($files);
+            $files = [$files];
         } elseif (! is_array($files)) {
             $files = (array)$files;
         }
@@ -77,9 +77,9 @@ class Minify_Controller_Groups extends Minify_Controller_Base {
             }
             $realPath = realpath($file);
             if (is_file($realPath)) {
-                $sources[] = new Minify_Source(array(
+                $sources[] = new Minify_Source([
                     'filepath' => $realPath
-                ));    
+                ]);    
             } else {
                 $this->log("The path \"{$file}\" could not be found (or was not a file)");
                 return $options;

--- a/plugins/Minify/min/lib/Minify/Controller/MinApp.php
+++ b/plugins/Minify/min/lib/Minify/Controller/MinApp.php
@@ -24,16 +24,16 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
     public function setupSources($options) {
         // filter controller options
         $cOptions = array_merge(
-            array(
+            [
                 'allowDirs' => '//'
                 ,'groupsOnly' => false
-                ,'groups' => array()
+                ,'groups' => []
                 ,'maxFiles' => 10                
-            )
-            ,(isset($options['minApp']) ? $options['minApp'] : array())
+            ]
+            ,(isset($options['minApp']) ? $options['minApp'] : [])
         );
         unset($options['minApp']);
-        $sources = array();
+        $sources = [];
         if (isset($_GET['g'])) {
             // try groups
             if (! isset($cOptions['groups'][$_GET['g']])) {
@@ -44,7 +44,7 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
             $files = $cOptions['groups'][$_GET['g']];
             // if $files is a single object, casting will break it
             if (is_object($files)) {
-                $files = array($files);
+                $files = [$files];
             } elseif (! is_array($files)) {
                 $files = (array)$files;
             }
@@ -58,9 +58,9 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
                 }
                 $file = realpath($file);
                 if (is_file($file)) {
-                    $sources[] = new Minify_Source(array(
+                    $sources[] = new Minify_Source([
                         'filepath' => $file
-                    ));    
+                    ]);    
                 } else {
                     $this->log("The path \"{$file}\" could not be found (or was not a file)");
                     return $options;
@@ -102,7 +102,7 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
             } else {
                 $base = '/';
             }
-            $allowDirs = array();
+            $allowDirs = [];
             foreach ((array)$cOptions['allowDirs'] as $allowDir) {
                 $allowDirs[] = realpath(str_replace('//', $_SERVER['DOCUMENT_ROOT'] . '/', $allowDir));
             }
@@ -116,9 +116,9 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
                     $this->log("Path \"{$path}\" failed Minify_Controller_Base::_fileIsSafe()");
                     return $options;
                 } else {
-                    $sources[] = new Minify_Source(array(
+                    $sources[] = new Minify_Source([
                         'filepath' => $file
-                    ));
+                    ]);
                 }
             }
         }

--- a/plugins/Minify/min/lib/Minify/Controller/Page.php
+++ b/plugins/Minify/min/lib/Minify/Controller/Page.php
@@ -37,23 +37,23 @@ class Minify_Controller_Page extends Minify_Controller_Base {
      */
     public function setupSources($options) {
         if (isset($options['file'])) {
-            $sourceSpec = array(
+            $sourceSpec = [
                 'filepath' => $options['file']
-            );
+            ];
         } else {
             // strip controller options
-            $sourceSpec = array(
+            $sourceSpec = [
                 'content' => $options['content']
                 ,'id' => $options['id']
-            );
+            ];
             unset($options['content'], $options['id']);
         }
         if (isset($options['minifyAll'])) {
             // this will be the 2nd argument passed to Minify_HTML::minify()
-            $sourceSpec['minifyOptions'] = array(
-                'cssMinifier' => array('Minify_CSS', 'minify')
-                ,'jsMinifier' => array('JSMin', 'minify')
-            );
+            $sourceSpec['minifyOptions'] = [
+                'cssMinifier' => ['Minify_CSS', 'minify']
+                ,'jsMinifier' => ['JSMin', 'minify']
+            ];
             $this->_loadCssJsMinifiers = true;
             unset($options['minifyAll']);
         }

--- a/plugins/Minify/min/lib/Minify/Controller/Version1.php
+++ b/plugins/Minify/min/lib/Minify/Controller/Version1.php
@@ -63,8 +63,8 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
             . DIRECTORY_SEPARATOR;
         $prependAbsPaths = $_SERVER['DOCUMENT_ROOT'];
         
-        $sources = array();
-        $goodFiles = array();
+        $sources = [];
+        $goodFiles = [];
         $hasBadSource = false;
         
         $allowDirs = isset($options['allowDirs'])
@@ -81,9 +81,9 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
                 && !in_array($file, $goodFiles)) 
             {
                 $goodFiles[] = $file;
-                $srcOptions = array(
+                $srcOptions = [
                     'filepath' => $file
-                );
+                ];
                 $this->sources[] = new Minify_Source($srcOptions);
             } else {
                 $hasBadSource = true;
@@ -91,7 +91,7 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
             }
         }
         if ($hasBadSource) {
-            $this->sources = array();
+            $this->sources = [];
         }
         if (! MINIFY_REWRITE_CSS_URLS) {
             $options['rewriteCssUris'] = false;
@@ -101,13 +101,13 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
     
     private static function _setupDefines()
     {
-        $defaults = array(
+        $defaults = [
             'MINIFY_BASE_DIR' => realpath($_SERVER['DOCUMENT_ROOT'])
             ,'MINIFY_ENCODING' => 'utf-8'
             ,'MINIFY_MAX_FILES' => 16
             ,'MINIFY_REWRITE_CSS_URLS' => true
             ,'MINIFY_USE_CACHE' => true
-        );
+        ];
         foreach ($defaults as $const => $val) {
             if (! defined($const)) {
                 define($const, $val);

--- a/plugins/Minify/min/lib/Minify/HTML.php
+++ b/plugins/Minify/min/lib/Minify/HTML.php
@@ -36,7 +36,7 @@ class Minify_HTML {
      * 
      * @return string
      */
-    public static function minify($html, $options = array()) {
+    public static function minify($html, $options = []) {
         $min = new Minify_HTML($html, $options);
         return $min->process();
     }
@@ -60,7 +60,7 @@ class Minify_HTML {
      * 
      * @return null
      */
-    public function __construct($html, $options = array())
+    public function __construct($html, $options = [])
     {
         $this->_html = str_replace("\r\n", "\n", trim($html));
         if (isset($options['xhtml'])) {
@@ -87,35 +87,35 @@ class Minify_HTML {
         }
         
         $this->_replacementHash = 'MINIFYHTML' . md5($_SERVER['REQUEST_TIME']);
-        $this->_placeholders = array();
+        $this->_placeholders = [];
         
         // replace SCRIPTs (and minify) with placeholders
         $this->_html = preg_replace_callback(
             '/(\\s*)(<script\\b[^>]*?>)([\\s\\S]*?)<\\/script>(\\s*)/i'
-            ,array($this, '_removeScriptCB')
+            ,[$this, '_removeScriptCB']
             ,$this->_html);
         
         // replace STYLEs (and minify) with placeholders
         $this->_html = preg_replace_callback(
             '/\\s*(<style\\b[^>]*?>)([\\s\\S]*?)<\\/style>\\s*/i'
-            ,array($this, '_removeStyleCB')
+            ,[$this, '_removeStyleCB']
             ,$this->_html);
         
         // remove HTML comments (not containing IE conditional comments).
         $this->_html = preg_replace_callback(
             '/<!--([\\s\\S]*?)-->/'
-            ,array($this, '_commentCB')
+            ,[$this, '_commentCB']
             ,$this->_html);
         
         // replace PREs with placeholders
         $this->_html = preg_replace_callback('/\\s*(<pre\\b[^>]*?>[\\s\\S]*?<\\/pre>)\\s*/i'
-            ,array($this, '_removePreCB')
+            ,[$this, '_removePreCB']
             ,$this->_html);
         
         // replace TEXTAREAs with placeholders
         $this->_html = preg_replace_callback(
             '/\\s*(<textarea\\b[^>]*?>[\\s\\S]*?<\\/textarea>)\\s*/i'
-            ,array($this, '_removeTextareaCB')
+            ,[$this, '_removeTextareaCB']
             ,$this->_html);
         
         // trim each line.
@@ -132,7 +132,7 @@ class Minify_HTML {
         // remove ws outside of all elements
         $this->_html = preg_replace_callback(
             '/>([^<]+)</'
-            ,array($this, '_outsideTagCB')
+            ,[$this, '_outsideTagCB']
             ,$this->_html);
         
         // use newlines before 1st attribute in open tags (to limit line lengths)
@@ -163,7 +163,7 @@ class Minify_HTML {
 
     protected $_isXhtml = null;
     protected $_replacementHash = null;
-    protected $_placeholders = array();
+    protected $_placeholders = [];
     protected $_cssMinifier = null;
     protected $_jsMinifier = null;
 
@@ -234,7 +234,7 @@ class Minify_HTML {
     protected function _removeCdata($str)
     {
         return (false !== strpos($str, '<![CDATA['))
-            ? str_replace(array('<![CDATA[', ']]>'), '', $str)
+            ? str_replace(['<![CDATA[', ']]>'], '', $str)
             : $str;
     }
     

--- a/plugins/Minify/min/lib/Minify/ImportProcessor.php
+++ b/plugins/Minify/min/lib/Minify/ImportProcessor.php
@@ -19,11 +19,11 @@
  */
 class Minify_ImportProcessor {
     
-    public static $filesIncluded = array();
+    public static $filesIncluded = [];
     
     public static function process($file)
     {
-        self::$filesIncluded = array();
+        self::$filesIncluded = [];
         self::$_isCss = (strtolower(substr($file, -4)) === '.css');
         $obj = new Minify_ImportProcessor(dirname($file));
         return $obj->_getContent($file);
@@ -74,7 +74,7 @@ class Minify_ImportProcessor {
                 ([a-zA-Z,\\s]*)?     # 2 = media list
                 ;                    # end token
             /x'
-            ,array($this, '_importCB')
+            ,[$this, '_importCB']
             ,$content
         );
         
@@ -82,7 +82,7 @@ class Minify_ImportProcessor {
             // rewrite remaining relative URIs
             $content = preg_replace_callback(
                 '/url\\(\\s*([^\\)\\s]+)\\s*\\)/'
-                ,array($this, '_urlCB')
+                ,[$this, '_urlCB']
                 ,$content
             );
         }

--- a/plugins/Minify/min/lib/Minify/Lines.php
+++ b/plugins/Minify/min/lib/Minify/Lines.php
@@ -34,7 +34,7 @@ class Minify_Lines {
      * 
      * @return string 
      */
-    public static function minify($content, $options = array()) 
+    public static function minify($content, $options = []) 
     {
         $id = (isset($options['id']) && $options['id'])
             ? $options['id']
@@ -46,7 +46,7 @@ class Minify_Lines {
         $padTo = strlen($numLines);
         $inComment = false;
         $i = 0;
-        $newLines = array();
+        $newLines = [];
         while (null !== ($line = array_shift($lines))) {
             if (('' !== $id) && (0 == $i % 50)) {
                 array_push($newLines, '', "/* {$id} */", '');
@@ -65,7 +65,7 @@ class Minify_Lines {
                  $content
                 ,$options['currentDir']
                 ,isset($options['docRoot']) ? $options['docRoot'] : $_SERVER['DOCUMENT_ROOT']
-                ,isset($options['symlinks']) ? $options['symlinks'] : array()
+                ,isset($options['symlinks']) ? $options['symlinks'] : []
             );
             $content = "/* Minify_CSS_UriRewriter::\$debugText\n\n" 
                      . Minify_CSS_UriRewriter::$debugText . "*/\n"

--- a/plugins/Minify/min/lib/Minify/Packer.php
+++ b/plugins/Minify/min/lib/Minify/Packer.php
@@ -28,7 +28,7 @@ if (false === (@include 'class.JavaScriptPacker.php')) {
  * @package Minify
  */
 class Minify_Packer {
-    public static function minify($code, $options = array())
+    public static function minify($code, $options = [])
     {
         // @todo: set encoding options based on $options :)
         $packer = new JavascriptPacker($code, 'Normal', true, false);

--- a/plugins/Minify/min/lib/Minify/Source.php
+++ b/plugins/Minify/min/lib/Minify/Source.php
@@ -154,9 +154,9 @@ class Minify_Source {
     public static function getDigest($sources)
     {
         foreach ($sources as $source) {
-            $info[] = array(
+            $info[] = [
                 $source->_id, $source->minifier, $source->minifyOptions
-            );
+            ];
         }
         return md5(serialize($info));
     }

--- a/plugins/Minify/min/lib/Minify/YUICompressor.php
+++ b/plugins/Minify/min/lib/Minify/YUICompressor.php
@@ -62,7 +62,7 @@ class Minify_YUICompressor {
      * 
      * @return string 
      */
-    public static function minifyJs($js, $options = array())
+    public static function minifyJs($js, $options = [])
     {
         return self::_minify('js', $js, $options);
     }
@@ -78,7 +78,7 @@ class Minify_YUICompressor {
      * 
      * @return string 
      */
-    public static function minifyCss($css, $options = array())
+    public static function minifyCss($css, $options = [])
     {
         return self::_minify('css', $css, $options);
     }
@@ -98,14 +98,14 @@ class Minify_YUICompressor {
     private static function _getCmd($userOptions, $type, $tmpFile)
     {
         $o = array_merge(
-            array(
+            [
                 'charset' => ''
                 ,'line-break' => 5000
                 ,'type' => $type
                 ,'nomunge' => false
                 ,'preserve-semi' => false
                 ,'disable-optimizations' => false
-            )
+            ]
             ,$userOptions
         );
         $cmd = self::$javaExecutable . ' -jar ' . escapeshellarg(self::$jarFile)
@@ -117,7 +117,7 @@ class Minify_YUICompressor {
                 ? ' --line-break ' . (int)$o['line-break']
                 : '');
         if ($type === 'js') {
-            foreach (array('nomunge', 'preserve-semi', 'disable-optimizations') as $opt) {
+            foreach (['nomunge', 'preserve-semi', 'disable-optimizations'] as $opt) {
                 $cmd .= $o[$opt] 
                     ? " --{$opt}"
                     : '';

--- a/plugins/Minify/min/utils.php
+++ b/plugins/Minify/min/utils.php
@@ -78,7 +78,7 @@ function Minify_groupsMtime($groups)
  */
 function _Minify_getBuild($group)
 {
-    static $builds = array();
+    static $builds = [];
     static $gc = false;
     if (false === $gc) {
         $gc = (require dirname(__FILE__) . '/groupsConfig.php');

--- a/plugins/Mollom/class.mollom.php
+++ b/plugins/Mollom/class.mollom.php
@@ -172,7 +172,7 @@ abstract class Mollom {
     *
     * @var array
     */
-   public $log = array();
+   public $log = [];
 
    function __construct() {
       $this->publicKey = $this->loadConfiguration('publicKey');
@@ -261,7 +261,7 @@ abstract class Mollom {
     * @see Mollom::writeLog()
     */
    final public function purgeLog() {
-      $this->log = array();
+      $this->log = [];
    }
 
    /**
@@ -286,7 +286,7 @@ abstract class Mollom {
     * @see Mollom::handleRequest()
     * @see Mollom::request()
     */
-   public function query($method, $path, array $data = array(), array $expected = array()) {
+   public function query($method, $path, array $data = [], array $expected = []) {
       // Reset list response properties.
       $this->listCount = NULL;
       $this->listOffset = 0;
@@ -342,7 +342,7 @@ abstract class Mollom {
             // In XML, the 'list' element is parsed as a string when the list is
             // empty.
             else {
-               $result['list'] = array();
+               $result['list'] = [];
             }
          }
          return $result;
@@ -409,7 +409,7 @@ abstract class Mollom {
     * @see Mollom::parseXML()
     * @see json_decode()
     */
-   protected function handleRequest($method, $server, $path, $data, $expected = array()) {
+   protected function handleRequest($method, $server, $path, $data, $expected = []) {
       if (!empty($this->publicKey) && !empty($this->privateKey)) {
          // @todo Move into class property.
          $headers['Accept'] = 'application/xml, application/json;q=0.8, */*;q=0.5';
@@ -428,7 +428,7 @@ abstract class Mollom {
          $response->isError = ($response->code < 200 || $response->code >= 300);
       }
       else {
-         $headers = array();
+         $headers = [];
          $response = new stdClass;
          $response->code = self::AUTH_ERROR;
          $response->message = 'Missing API keys.';
@@ -437,7 +437,7 @@ abstract class Mollom {
       }
 
       // Parse the response body string into an array.
-      $response->data = array();
+      $response->data = [];
       if (isset($response->body) && isset($response->headers['content-type'])) {
          if (strstr($response->headers['content-type'], 'application/json')) {
             $response->data = json_decode($response->body, TRUE);
@@ -481,14 +481,14 @@ abstract class Mollom {
          }
       }
 
-      $request_info = array(
+      $request_info = [
          'request' => $method . ' ' . $server . '/' . $path,
          'headers' => $headers,
          'data' => $data,
          'response_code' => $response->code,
          'response_message' => $response->message,
          'response' => !empty($response->data) ? $response->data : $response->body,
-      );
+      ];
       if ($response->isError) {
          if ($response->code <= 0) {
             throw new MollomNetworkException('Network error.', self::NETWORK_ERROR, NULL, $this, $request_info);
@@ -517,9 +517,9 @@ abstract class Mollom {
       else {
          $this->lastResponseCode = TRUE;
          // No message is logged in case of success.
-         $this->log[] = array(
+         $this->log[] = [
                'severity' => 'debug',
-            ) + $request_info;
+            ] + $request_info;
 
          return $response->data;
       }
@@ -596,11 +596,11 @@ abstract class Mollom {
       //   having GET query parameters first, and POST body data parameters last
       //   (if any)
       // delimited by "&". (3.4.1.1)
-      $base_string = implode('&', array(
+      $base_string = implode('&', [
          $method,
          self::rawurlencode($server . '/' . $path),
          self::rawurlencode($oauth_query),
-      ));
+      ]);
       // Key is unconditionally compound of client secret and token secret, even
       // if empty. (3.4.2)
       $key = self::rawurlencode($this->privateKey) . '&' . '';
@@ -635,7 +635,7 @@ abstract class Mollom {
     *   " " (spaces). (RFC 5849 3.4.1.3.1 and 3.6)
     */
    public static function rawurlencode($value) {
-      return strtr(rawurlencode($value), array('%7E' => '~', '+' => ' '));
+      return strtr(rawurlencode($value), ['%7E' => '~', '+' => ' ']);
    }
 
    /**
@@ -668,7 +668,7 @@ abstract class Mollom {
     *
     * @see Mollom::handleRequest()
     */
-   abstract protected function request($method, $server, $path, $query = NULL, array $headers = array());
+   abstract protected function request($method, $server, $path, $query = NULL, array $headers = []);
 
    /**
     * Converts a SimpleXMLIterator structure into an associative array.
@@ -687,8 +687,8 @@ abstract class Mollom {
     *   An associative, possibly multidimensional array.
     */
    public static function parseXML(SimpleXMLIterator $sxi) {
-      $a = array();
-      $remove = array();
+      $a = [];
+      $remove = [];
       for ($sxi->rewind(); $sxi->valid(); $sxi->next()) {
          $key = $sxi->key();
 
@@ -753,7 +753,7 @@ abstract class Mollom {
     * @see Mollom::httpParseQuery()
     */
    public static function httpBuildQuery(array $query, $parent = '') {
-      $params = array();
+      $params = [];
 
       foreach ($query as $key => $value) {
          // For indexed (unnamed) child array keys, use the same parameter name,
@@ -816,12 +816,12 @@ abstract class Mollom {
     */
    public static function httpParseQuery($query) {
       if ($query === '') {
-         return array();
+         return [];
       }
       // Explode parameters into arrays to check for duplicate names.
-      $params = array();
-      $seen = array();
-      $duplicate = array();
+      $params = [];
+      $seen = [];
+      $duplicate = [];
       foreach (explode('&', $query) as $chunk) {
          $param = explode('=', $chunk, 2);
          if (isset($seen[$param[0]])) {
@@ -873,7 +873,7 @@ abstract class Mollom {
     *   'Authorization' HTTP header, if any.
     */
    public static function getServerAuthentication() {
-      $header = array();
+      $header = [];
       // PHP as Apache module provides a SAPI function.
       // PHP 5.4+ enables getallheaders() also for FastCGI.
       if (function_exists('getallheaders')) {
@@ -907,7 +907,7 @@ abstract class Mollom {
     *   An array containing site resources, as returned by Mollom::getsite().
     */
    public function getSites() {
-      $result = $this->query('GET', 'site', array(), array('list'));
+      $result = $this->query('GET', 'site', [], ['list']);
       return isset($result['list']) ? $result['list'] : $result;
    }
 
@@ -941,7 +941,7 @@ abstract class Mollom {
          $publicKey = $this->publicKey;
       }
       $publicKey = rawurlencode($publicKey);
-      $result = $this->query('GET', 'site/' . $publicKey, array(), array('site', 'publicKey'));
+      $result = $this->query('GET', 'site/' . $publicKey, [], ['site', 'publicKey']);
       return isset($result['site']) ? $result['site'] : $result;
    }
 
@@ -957,11 +957,11 @@ abstract class Mollom {
     *   Mollom::getSite() for details. On failure, the error response code
     *   returned by the server. Or FALSE if 'url' or 'email' was not specified.
     */
-   public function createSite(array $data = array()) {
+   public function createSite(array $data = []) {
       if (empty($data['url']) || empty($data['email'])) {
          return FALSE;
       }
-      $result = $this->query('POST', 'site', $data, array('site', 'publicKey'));
+      $result = $this->query('POST', 'site', $data, ['site', 'publicKey']);
       return isset($result['site']) ? $result['site'] : $result;
    }
 
@@ -984,12 +984,12 @@ abstract class Mollom {
     *   Mollom::getSite() for details. On failure, the error response code
     *   returned by the server.
     */
-   public function updateSite(array $data = array(), $publicKey = NULL) {
+   public function updateSite(array $data = [], $publicKey = NULL) {
       if (!isset($publicKey)) {
          $publicKey = $this->publicKey;
       }
       $publicKey = rawurlencode($publicKey);
-      $result = $this->query('POST', 'site/' . $publicKey, $data, array('site', 'publicKey'));
+      $result = $this->query('POST', 'site/' . $publicKey, $data, ['site', 'publicKey']);
       return isset($result['site']) ? $result['site'] : $result;
    }
 
@@ -1100,7 +1100,7 @@ abstract class Mollom {
     *       'rateLimit' time-frame.
     *   On failure, the error response code returned by the server.
     */
-   public function checkContent(array $data = array()) {
+   public function checkContent(array $data = []) {
       $path = 'content';
       if (!empty($data['id'])) {
          // The ID originates from raw form input. Ensure we hit the right endpoint
@@ -1111,7 +1111,7 @@ abstract class Mollom {
          }
          unset($data['id']);
       }
-      $result = $this->query('POST', $path, $data, array('content', 'id'));
+      $result = $this->query('POST', $path, $data, ['content', 'id']);
 
       // parseXML() can only convert multiple sub-elements into an indexed array.
       if (isset($result['content']['languages']) && is_array($result['content']['languages'])) {
@@ -1142,12 +1142,12 @@ abstract class Mollom {
     *   On failure, the error response code returned by the server.
     *   Or FALSE if a unknown 'type' was specified.
     */
-   public function createCaptcha(array $data = array()) {
-      if (!isset($data['type']) || !in_array($data['type'], array('image', 'audio'))) {
+   public function createCaptcha(array $data = []) {
+      if (!isset($data['type']) || !in_array($data['type'], ['image', 'audio'])) {
          return FALSE;
       }
       $path = 'captcha';
-      $result = $this->query('POST', $path, $data, array('captcha', 'id'));
+      $result = $this->query('POST', $path, $data, ['captcha', 'id']);
 
       return isset($result['captcha']) ? $result['captcha'] : $result;
    }
@@ -1181,7 +1181,7 @@ abstract class Mollom {
     *   On failure, the error response code returned by the server.
     *   Or FALSE if no 'id' was specified.
     */
-   public function checkCaptcha(array $data = array()) {
+   public function checkCaptcha(array $data = []) {
       if (empty($data['id'])) {
          return FALSE;
       }
@@ -1193,7 +1193,7 @@ abstract class Mollom {
       }
       $path = 'captcha/' . rawurlencode($data['id']);
       unset($data['id']);
-      $result = $this->query('POST', $path, $data, array('captcha', 'id'));
+      $result = $this->query('POST', $path, $data, ['captcha', 'id']);
 
       return isset($result['captcha']) ? $result['captcha'] : $result;
    }
@@ -1245,7 +1245,7 @@ abstract class Mollom {
          $publicKey = $this->publicKey;
       }
       $publicKey = rawurlencode($publicKey);
-      $result = $this->query('GET', 'blacklist/' . $publicKey, array(), array('list'));
+      $result = $this->query('GET', 'blacklist/' . $publicKey, [], ['list']);
       return isset($result['list']) ? $result['list'] : $result;
    }
 
@@ -1283,7 +1283,7 @@ abstract class Mollom {
          $publicKey = $this->publicKey;
       }
       $path = 'blacklist/' . rawurlencode($publicKey) . '/' . rawurlencode($entryId);
-      $result = $this->query('GET', $path, array(), array('entry', 'id'));
+      $result = $this->query('GET', $path, [], ['entry', 'id']);
       return isset($result['entry']) ? $result['entry'] : $result;
    }
 
@@ -1303,7 +1303,7 @@ abstract class Mollom {
     *   Mollom::getBlacklistEntry() for details. On failure, the error response
     *   code returned by the server.
     */
-   public function saveBlacklistEntry(array $data = array(), $publicKey = NULL) {
+   public function saveBlacklistEntry(array $data = [], $publicKey = NULL) {
       if (!isset($publicKey)) {
          $publicKey = $this->publicKey;
       }
@@ -1312,7 +1312,7 @@ abstract class Mollom {
          $path .= '/' . rawurlencode($data['id']);
          unset($data['id']);
       }
-      $result = $this->query('POST', $path, $data, array('entry', 'id'));
+      $result = $this->query('POST', $path, $data, ['entry', 'id']);
       return isset($result['entry']) ? $result['entry'] : $result;
    }
 
@@ -1393,7 +1393,7 @@ class MollomException extends Exception {
    /**
     * Overrides Exception::__construct().
     */
-   function __construct($message = '', $code = 0, Exception $previous = NULL, Mollom $mollom, array $request_info = array()) {
+   function __construct($message = '', $code = 0, Exception $previous = NULL, Mollom $mollom, array $request_info = []) {
       // Fatal error on PHP <5.3 when passing more arguments to Exception.
       if (version_compare(phpversion(), '5.3') >= 0) {
          parent::__construct($message, $code, $previous);
@@ -1414,15 +1414,15 @@ class MollomException extends Exception {
       // php.net mention that it does not have an own cache and also does not use
       // the OS/platform's native DNS name resolver. Due to that, we only use it
       // under error conditions.
-      $message = array(
+      $message = [
          'severity' => $this->severity,
          'message' => 'Error @code: %message (@server-ip)',
-         'arguments' => array(
+         'arguments' => [
             '@code' => $code,
             '%message' => $message,
             '@server-ip' => gethostbyname($mollom->server),
-         ),
-      );
+         ],
+      ];
       // Add HTTP request information, if available.
       if (!empty($request_info)) {
          $message += $request_info;

--- a/plugins/Mollom/class.mollom.plugin.php
+++ b/plugins/Mollom/class.mollom.plugin.php
@@ -30,14 +30,14 @@ class MollomPlugin extends Gdn_Plugin {
       if (!$Mollom)
          return FALSE;
 
-      $Result = $Mollom->checkContent(array(
-         'checks' => array('spam'),
+      $Result = $Mollom->checkContent([
+         'checks' => ['spam'],
          'postTitle' => GetValue('Name', $Data),
          'postBody' => ConcatSep("\n\n", GetValue('Body', $Data),GetValue('Story', $Data)),
          'authorName' => $Data['Username'],
          'authorEmail' => $Data['Email'],
          'authorIp' => $Data['IPAddress']
-      ));
+      ]);
       return ($Result['spamClassification'] == 'spam') ? true : false;
    }
 
@@ -47,17 +47,17 @@ class MollomPlugin extends Gdn_Plugin {
 
    public function Structure() {
       // Get a user for operations.
-      $UserID = Gdn::SQL()->GetWhere('User', array('Name' => 'Mollom', 'Admin' => 2))->Value('UserID');
+      $UserID = Gdn::SQL()->GetWhere('User', ['Name' => 'Mollom', 'Admin' => 2])->Value('UserID');
 
       if (!$UserID) {
-         $UserID = Gdn::SQL()->Insert('User', array(
+         $UserID = Gdn::SQL()->Insert('User', [
             'Name' => 'Mollom',
             'Password' => RandomString('20'),
             'HashMethod' => 'Random',
             'Email' => 'mollom@domain.com',
             'DateInserted' => Gdn_Format::ToDateTime(),
             'Admin' => '2'
-         ));
+         ]);
       }
       SaveToConfig('Plugins.Mollom.UserID', $UserID);
    }
@@ -101,15 +101,15 @@ class MollomPlugin extends Gdn_Plugin {
       $Sender->EventArguments['IsSpam'] = $Result;
    }
 
-   public function SettingsController_Mollom_Create($Sender, $Args = array()) {
+   public function SettingsController_Mollom_Create($Sender, $Args = []) {
       $Sender->Permission('Garden.Settings.Manage');
       $Sender->SetData('Title', T('Mollom Settings'));
 
       $Cf = new ConfigurationModule($Sender);
-      $Cf->Initialize(array(
-          'Plugins.Mollom.publicKey' => array(),
-          'Plugins.Mollom.privateKey' => array()
-          ));
+      $Cf->Initialize([
+          'Plugins.Mollom.publicKey' => [],
+          'Plugins.Mollom.privateKey' => []
+          ]);
 
       $Sender->AddSideMenu('settings/plugins');
       $Cf->RenderAll();

--- a/plugins/Mollom/class.mollomvanilla.php
+++ b/plugins/Mollom/class.mollomvanilla.php
@@ -21,31 +21,31 @@ class MollomVanilla extends Mollom {
 
    public function getClientInformation() {
       $PluginInfo = Gdn::PluginManager()->AvailablePlugins();
-      return array(
+      return [
          'platformName' => 'Vanilla',
          'platformVersion' => APPLICATION_VERSION,
          'clientName' => 'Mollom Vanilla',
          'clientVersion' => $PluginInfo['Mollom']['Version']
-      );
+      ];
    }
 
-   protected function request($method, $server, $path, $query = NULL, array $headers = array()) {
+   protected function request($method, $server, $path, $query = NULL, array $headers = []) {
       $Request = new ProxyRequest();
       $Request->Request(
-         array('Method' => $method,
+         ['Method' => $method,
             'URL' => trim($server,'/').trim($path,'/'),
             //'Debug' => TRUE
-         ),
+         ],
          $query,
          NULL,
          $headers
       );
 
-      $MollomResponse = (object) array(
+      $MollomResponse = (object) [
          'code' => $Request->ResponseStatus,
          'headers' => $Request->ResponseHeaders,
          'body' => $Request->ResponseBody,
-      );
+      ];
       return $MollomResponse;
    }
 }

--- a/plugins/Multilingual/class.multilingual.plugin.php
+++ b/plugins/Multilingual/class.multilingual.plugin.php
@@ -45,7 +45,7 @@ class MultilingualPlugin extends Gdn_Plugin {
         $localeModel = new LocaleModel();
         if (class_exists('Locale')) {
             $localePacks = $localeModel->EnabledLocalePacks(false);
-            $locales = array();
+            $locales = [];
             foreach ($localePacks as $locale) {
                 if (isset(static::$overrides[$locale]['Name'])) {
                     $locales[$locale] = static::$overrides[$locale]['Name'];
@@ -63,7 +63,7 @@ class MultilingualPlugin extends Gdn_Plugin {
 
         if (!array_key_exists($defaultLocale, $locales)) {
             $locales = array_merge(
-                array($defaultLocale => $defaultName),
+                [$defaultLocale => $defaultName],
                 $locales
             );
         }

--- a/plugins/Multilingual/modules/class.localechoosermodule.php
+++ b/plugins/Multilingual/modules/class.localechoosermodule.php
@@ -19,7 +19,7 @@ class LocaleChooserModule extends Gdn_Module {
     public function buildLocaleLink($Name, $UrlCode) {
         $Url = 'profile/setlocale/'.$UrlCode.'/'.Gdn::Session()->TransientKey();
 
-        return Wrap(Anchor($Name, $Url), 'span', array('class' => 'LocaleOption '.$Name.'Locale'));
+        return Wrap(Anchor($Name, $Url), 'span', ['class' => 'LocaleOption '.$Name.'Locale']);
     }
 
     /**
@@ -47,6 +47,6 @@ class LocaleChooserModule extends Gdn_Module {
         if (!$this->Links)
             $this->Links = $this->BuildLocales();
 
-        echo Wrap($this->Links, 'div', array('class' => 'LocaleOptions'));
+        echo Wrap($this->Links, 'div', ['class' => 'LocaleOptions']);
     }
 }

--- a/plugins/NBBC/class.nbbc.plugin.php
+++ b/plugins/NBBC/class.nbbc.plugin.php
@@ -141,7 +141,7 @@ EOT;
             $url = '';
 
          if ($url)
-            $title = ConcatSep(' ', $title, Anchor('<span class="ArrowLink">»</span>', $url, array('class' => 'QuoteLink')));
+            $title = ConcatSep(' ', $title, Anchor('<span class="ArrowLink">»</span>', $url, ['class' => 'QuoteLink']));
       }
 
       if ($title)
@@ -221,7 +221,7 @@ EOT;
    }
 
    public function Format($Result) {
-      $Result = str_replace(array('[CODE]', '[/CODE]'), array('[code]', '[/code]'), $Result);
+      $Result = str_replace(['[CODE]', '[/CODE]'], ['[code]', '[/code]'], $Result);
       $Result = $this->NBBC()->Parse($Result);
       return $Result;
    }
@@ -233,10 +233,10 @@ EOT;
             $I = Gdn::PluginManager()->GetPluginInstance('FileUploadPlugin', Gdn_PluginManager::ACCESS_CLASSNAME);
             $M = $I->MediaCache();
          } catch (Exception $Ex) {
-            $M = array();
+            $M = [];
          }
 
-         $Media = array();
+         $Media = [];
          foreach ($M as $Key => $Data) {
             foreach ($Data as $Row) {
                $Media[$Row->MediaID] = $Row;
@@ -259,22 +259,22 @@ EOT;
          $BBCode->enable_smileys = false;
          $BBCode->SetAllowAmpersand(TRUE);
 
-         $BBCode->AddRule('attach', array(
+         $BBCode->AddRule('attach', [
             'mode' => BBCODE_MODE_CALLBACK,
-            'method' => array($this, "DoAttachment"),
+            'method' => [$this, "DoAttachment"],
             'class' => 'image',
-            'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+            'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
             'end_tag' => BBCODE_REQUIRED,
             'content' => BBCODE_REQUIRED,
             'plain_start' => "[image]",
-            'plain_content' => Array(),
-            ));
+            'plain_content' => [],
+            ]);
 
-         $BBCode->AddRule('code', Array(
+         $BBCode->AddRule('code', [
              'mode' => BBCODE_MODE_ENHANCED,
              'template' => "\n<pre>{\$_content/v}\n</pre>\n",
              'class' => 'code',
-             'allow_in' => Array('listitem', 'block', 'columns'),
+             'allow_in' => ['listitem', 'block', 'columns'],
              'content' => BBCODE_VERBATIM,
              'before_tag' => "sns",
              'after_tag' => "sn",
@@ -282,21 +282,21 @@ EOT;
              'after_endtag' => "sns",
              'plain_start' => "\n<b>Code:</b>\n",
              'plain_end' => "\n",
-         ));
+         ]);
 
 
-         $BBCode->AddRule('quote', array('mode' => BBCODE_MODE_CALLBACK,
-             'method' => array($this, "DoQuote"),
-             'allow_in' => Array('listitem', 'block', 'columns'),
+         $BBCode->AddRule('quote', ['mode' => BBCODE_MODE_CALLBACK,
+             'method' => [$this, "DoQuote"],
+             'allow_in' => ['listitem', 'block', 'columns'],
              'before_tag' => "sns",
              'after_tag' => "sns",
              'before_endtag' => "sns",
              'after_endtag' => "sns",
              'plain_start' => "\n<b>Quote:</b>\n",
              'plain_end' => "\n",
-         ));
+         ]);
 //
-         $BBCode->AddRule('spoiler', array(
+         $BBCode->AddRule('spoiler', [
              'mode' => BBCODE_MODE_CALLBACK,
              'method' => [$this, "doSpoiler"],
              'allow_in' => ['listitem', 'block', 'columns'],
@@ -306,24 +306,24 @@ EOT;
              'after_endtag' => "sns",
              'plain_start' => "\n",
              'plain_end' => "\n"
-             ));
+             ]);
 
-         $BBCode->AddRule('img', array(
+         $BBCode->AddRule('img', [
             'mode' => BBCODE_MODE_CALLBACK,
-            'method' => array($this, "DoImage"),
+            'method' => [$this, "DoImage"],
             'class' => 'image',
-            'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+            'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
             'end_tag' => BBCODE_REQUIRED,
             'content' => BBCODE_REQUIRED,
             'plain_start' => "[image]",
-            'plain_content' => Array(),
-            ));
+            'plain_content' => [],
+            ]);
 
-         $BBCode->AddRule('snapback', Array(
+         $BBCode->AddRule('snapback', [
              'mode' => BBCODE_MODE_ENHANCED,
              'template' => ' <a href="'.Url('/discussion/comment/{$_content/v}#Comment_{$_content/v}', TRUE).'" class="SnapBack">»</a> ',
              'class' => 'code',
-             'allow_in' => Array('listitem', 'block', 'columns'),
+             'allow_in' => ['listitem', 'block', 'columns'],
              'content' => BBCODE_VERBATIM,
              'before_tag' => "sns",
              'after_tag' => "sn",
@@ -331,83 +331,83 @@ EOT;
              'after_endtag' => "sns",
              'plain_start' => "\n<b>Snapback:</b>\n",
              'plain_end' => "\n",
-         ));
+         ]);
 
-         $BBCode->AddRule('video', array('mode' => BBCODE_MODE_CALLBACK,
-             'method' => array($this, "DoVideo"),
-             'allow_in' => Array('listitem', 'block', 'columns'),
+         $BBCode->AddRule('video', ['mode' => BBCODE_MODE_CALLBACK,
+             'method' => [$this, "DoVideo"],
+             'allow_in' => ['listitem', 'block', 'columns'],
              'before_tag' => "sns",
              'after_tag' => "sns",
              'before_endtag' => "sns",
              'after_endtag' => "sns",
              'plain_start' => "\n<b>Video:</b>\n",
              'plain_end' => "\n",
-         ));
+         ]);
 
-          $BBCode->AddRule('youtube', array(
+          $BBCode->AddRule('youtube', [
               'mode' => BBCODE_MODE_CALLBACK,
-              'method' => array($this, 'DoYouTube'),
+              'method' => [$this, 'DoYouTube'],
               'class' => 'link',
-              'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+              'allow_in' => ['listitem', 'block', 'columns', 'inline'],
               'content' => BBCODE_REQUIRED,
               'plain_start' => "\n<b>Video:</b>\n",
               'plain_end' => "\n",
-              'plain_content' => Array('_content', '_default'),
-              'plain_link' => Array('_default', '_content')
-          ));
+              'plain_content' => ['_content', '_default'],
+              'plain_link' => ['_default', '_content']
+          ]);
 
-          $BBCode->AddRule('hr', Array(
+          $BBCode->AddRule('hr', [
               'simple_start' => "",
               'simple_end' => "",
-              'allow_in' => Array('listitem', 'block', 'columns'),
+              'allow_in' => ['listitem', 'block', 'columns'],
               'before_tag' => "sns",
               'after_tag' => "sns",
               'before_endtag' => "sns",
               'after_endtag' => "sns",
               'plain_start' => "\n",
               'plain_end' => "\n"
-          ));
+          ]);
 
-          $BBCode->AddRule('attachment', array(
+          $BBCode->AddRule('attachment', [
               'mode' => BBCODE_MODE_CALLBACK,
-              'method' => array($this, "RemoveAttachment"),
+              'method' => [$this, "RemoveAttachment"],
               'class' => 'image',
-              'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+              'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
               'end_tag' => BBCODE_REQUIRED,
               'content' => BBCODE_REQUIRED,
               'plain_start' => "[image]",
-              'plain_content' => Array(),
-          ));
+              'plain_content' => [],
+          ]);
 
 
-          $BBCode->AddRule('url', array(
+          $BBCode->AddRule('url', [
              'mode' => BBCODE_MODE_CALLBACK,
-             'method' => array($this, 'DoURL'),
+             'method' => [$this, 'DoURL'],
              'class' => 'link',
-             'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+             'allow_in' => ['listitem', 'block', 'columns', 'inline'],
              'content' => BBCODE_REQUIRED,
              'plain_start' => "<a rel=\"nofollow\" href=\"{\$link}\">",
              'plain_end' => "</a>",
-             'plain_content' => Array('_content', '_default'),
-             'plain_link' => Array('_default', '_content')
-         ));
+             'plain_content' => ['_content', '_default'],
+             'plain_link' => ['_default', '_content']
+         ]);
 
           /**
            * Default size tag needs to be a little more flexible.  The original NBBC rule was copied here and the regex
            * was updated to meet our new criteria.
            */
-          $BBCode->addRule('size', array(
+          $BBCode->addRule('size', [
               'mode' => BBCODE_MODE_CALLBACK,
-              'allow' => array('_default' => '/^[0-9.]+(em|px)?$/D'),
-              'method' => array($this, 'doSize'),
+              'allow' => ['_default' => '/^[0-9.]+(em|px)?$/D'],
+              'method' => [$this, 'doSize'],
               'class' => 'inline',
-              'allow_in' => array('listitem', 'block', 'columns', 'inline', 'link'),
-          ));
+              'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+          ]);
 
           // Prevent unsupported tags from displaying
-          $BBCode->AddRule('table', array());
-          $BBCode->AddRule('tr', array());
-          $BBCode->AddRule('td', array());
+          $BBCode->AddRule('table', []);
+          $BBCode->AddRule('tr', []);
+          $BBCode->AddRule('td', []);
 
          $this->EventArguments['BBCode'] = $BBCode;
          $this->FireEvent('AfterNBBCSetup');

--- a/plugins/NBBC/nbbc/nbbc.php
+++ b/plugins/NBBC/nbbc/nbbc.php
@@ -81,9 +81,9 @@ var $pat_comment;
 var $pat_comment2;
 var $pat_wiki;
 function BBCodeLexer($string, $tagmarker = '[') {
-$regex_beginmarkers = Array( '[' => '\[', '<' => '<', '{' => '\{', '(' => '\(' );
-$regex_endmarkers = Array( '[' => '\]', '<' => '>', '{' => '\}', '(' => '\)' );
-$endmarkers = Array( '[' => ']', '<' => '>', '{' => '}', '(' => ')' );
+$regex_beginmarkers = [ '[' => '\[', '<' => '<', '{' => '\{', '(' => '\(' ];
+$regex_endmarkers = [ '[' => '\]', '<' => '>', '{' => '\}', '(' => '\)' ];
+$endmarkers = [ '[' => ']', '<' => '>', '{' => '}', '(' => ')' ];
 if (!isset($regex_endmarkers[$tagmarker])) $tagmarker = '[';
 $e = $regex_endmarkers[$tagmarker];
 $b = $regex_beginmarkers[$tagmarker];
@@ -202,7 +202,7 @@ $this->state = BBCODE_LEXSTATE_TEXT;
 return $this->token = BBCODE_NL;
 case 45:
 if (preg_match("/^-----/", $this->text)) {
-$this->tag = Array('_name' => 'rule', '_endtag' => false, '_default' => '');
+$this->tag = ['_name' => 'rule', '_endtag' => false, '_default' => ''];
 $this->state = BBCODE_LEXSTATE_TEXT;
 return $this->token = BBCODE_TAG;
 }
@@ -230,8 +230,8 @@ $this->state = BBCODE_LEXSTATE_TEXT;
 continue;
 }
 if (preg_match($this->pat_wiki, $this->text, $matches)) {
-$this->tag = Array('_name' => 'wiki', '_endtag' => false,
-'_default' => @$matches[1], 'title' => @$matches[2]);
+$this->tag = ['_name' => 'wiki', '_endtag' => false,
+'_default' => @$matches[1], 'title' => @$matches[2]];
 $this->state = BBCODE_LEXSTATE_TEXT;
 return $this->token = BBCODE_TAG;
 }
@@ -253,7 +253,7 @@ $this->unget = true;
 return $result;
 }
 function SaveState() {
-return Array(
+return [
 'token' => $this->token,
 'text' => $this->text,
 'tag' => $this->tag,
@@ -262,7 +262,7 @@ return Array(
 'ptr' => $this->ptr,
 'unget' => $this->unget,
 'verbatim' => $this->verbatim
-);
+];
 }
 function RestoreState($state) {
 if (!is_array($state)) return;
@@ -291,8 +291,8 @@ else if (preg_match("/^[\\x00-\\x20]+$/", $piece)) return ' ';
 else return 'A';
 }
 function Internal_DecodeTag($tag) {
-$result = Array('_tag' => $tag, '_endtag' => '', '_name' => '',
-'_hasend' => false, '_end' => false, '_default' => false);
+$result = ['_tag' => $tag, '_endtag' => '', '_name' => '',
+'_hasend' => false, '_end' => false, '_default' => false];
 $tag = substr($tag, 1, strlen($tag)-2);
 $ch = ord(substr($tag, 0, 1));
 if ($ch >= 0 && $ch <= 32) return $result;
@@ -310,10 +310,10 @@ $result['_end'] = false;
 }
 while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
 $ptr++;
-$params = Array();
+$params = [];
 if ($type != '=') {
 $result['_default'] = false;
-$params[] = Array('key' => '', 'value' => '');
+$params[] = ['key' => '', 'value' => ''];
 }
 else {
 $ptr++;
@@ -347,7 +347,7 @@ $value = trim($value);
 $ptr++;
 }
 $result['_default'] = $value;
-$params[] = Array('key' => '', 'value' => $value);
+$params[] = ['key' => '', 'value' => $value];
 }
 while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1) {
 while ($type == ' ') {
@@ -382,7 +382,7 @@ else $value = "";
 }
 if (substr($key, 0, 1) != '_')
 $result[$key] = $value;
-$params[] = Array('key' => $key, 'value' => $value);
+$params[] = ['key' => $key, 'value' => $value];
 }
 $result['_params'] = $params;
 return $result;
@@ -390,7 +390,7 @@ return $result;
 }
 
 class BBCodeLibrary {
-var $default_smileys = Array(
+var $default_smileys = [
 ':)' => 'smile.gif', ':-)' => 'smile.gif',
 '=)' => 'smile.gif', '=-)' => 'smile.gif',
 '=((' => 'brokensad.gif', ':-((' => 'waah.gif',
@@ -447,205 +447,205 @@ var $default_smileys = Array(
 ':zzz:' => 'sleepy.gif',
 '<3' => 'heart.gif',
 ':star:' => 'star.gif',
-);
-var $default_tag_rules = Array(
-'b' => Array(
+];
+var $default_tag_rules = [
+'b' => [
 'simple_start' => "<b>",
 'simple_end' => "</b>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 'plain_start' => "<b>",
 'plain_end' => "</b>",
-),
-'i' => Array(
+],
+'i' => [
 'simple_start' => "<i>",
 'simple_end' => "</i>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 'plain_start' => "<i>",
 'plain_end' => "</i>",
-),
-'u' => Array(
+],
+'u' => [
 'simple_start' => "<u>",
 'simple_end' => "</u>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 'plain_start' => "<u>",
 'plain_end' => "</u>",
-),
-'s' => Array(
+],
+'s' => [
 'simple_start' => "<strike>",
 'simple_end' => "</strike>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 'plain_start' => "<i>",
 'plain_end' => "</i>",
-),
-'font' => Array(
+],
+'font' => [
 'mode' => BBCODE_MODE_LIBRARY,
-'allow' => Array('_default' => '/^[a-zA-Z0-9._ ,-]+$/'),
+'allow' => ['_default' => '/^[a-zA-Z0-9._ ,-]+$/'],
 'method' => 'DoFont',
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'color' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'color' => [
 'mode' => BBCODE_MODE_ENHANCED,
-'allow' => Array('_default' => '/^#?[a-zA-Z0-9._ -]+$/'),
+'allow' => ['_default' => '/^#?[a-zA-Z0-9._ -]+$/'],
 'template' => '<span style="color:{$_default/tw}">{$_content/v}</span>',
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'size' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'size' => [
 'mode' => BBCODE_MODE_LIBRARY,
-'allow' => Array('_default' => '/^[0-9.]+$/D'),
+'allow' => ['_default' => '/^[0-9.]+$/D'],
 'method' => 'DoSize',
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'sup' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'sup' => [
 'simple_start' => "<sup>",
 'simple_end' => "</sup>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'sub' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'sub' => [
 'simple_start' => "<sub>",
 'simple_end' => "</sub>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'spoiler' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'spoiler' => [
 'simple_start' => "<span class=\"bbcode_spoiler\">",
 'simple_end' => "</span>",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'acronym' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'acronym' => [
 'mode' => BBCODE_MODE_ENHANCED,
 'template' => '<span class="bbcode_acronym" title="{$_default/e}">{$_content/v}</span>',
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-),
-'url' => Array(
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+],
+'url' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => 'DoURL',
 'class' => 'link',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 'content' => BBCODE_REQUIRED,
 'plain_start' => "<a href=\"{\$link}\">",
 'plain_end' => "</a>",
-'plain_content' => Array('_content', '_default'),
-'plain_link' => Array('_default', '_content'),
-),
-'email' => Array(
+'plain_content' => ['_content', '_default'],
+'plain_link' => ['_default', '_content'],
+],
+'email' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => 'DoEmail',
 'class' => 'link',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 'content' => BBCODE_REQUIRED,
 'plain_start' => "<a href=\"mailto:{\$link}\">",
 'plain_end' => "</a>",
-'plain_content' => Array('_content', '_default'),
-'plain_link' => Array('_default', '_content'),
-),
-'wiki' => Array(
+'plain_content' => ['_content', '_default'],
+'plain_link' => ['_default', '_content'],
+],
+'wiki' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => "DoWiki",
 'class' => 'link',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 'end_tag' => BBCODE_PROHIBIT,
 'content' => BBCODE_PROHIBIT,
 'plain_start' => "<b>[",
 'plain_end' => "]</b>",
-'plain_content' => Array('title', '_default'),
-'plain_link' => Array('_default', '_content'),
-),
-'img' => Array(
+'plain_content' => ['title', '_default'],
+'plain_link' => ['_default', '_content'],
+],
+'img' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => "DoImage",
 'class' => 'image',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 'end_tag' => BBCODE_REQUIRED,
 'content' => BBCODE_REQUIRED,
 'plain_start' => "[image]",
-'plain_content' => Array(),
-),
-'rule' => Array(
+'plain_content' => [],
+],
+'rule' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => "DoRule",
 'class' => 'block',
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'end_tag' => BBCODE_PROHIBIT,
 'content' => BBCODE_PROHIBIT,
 'before_tag' => "sns",
 'after_tag' => "sns",
 'plain_start' => "\n-----\n",
 'plain_end' => "",
-'plain_content' => Array(),
-),
-'br' => Array(
+'plain_content' => [],
+],
+'br' => [
 'mode' => BBCODE_MODE_SIMPLE,
 'simple_start' => "<br />\n",
 'simple_end' => "",
 'class' => 'inline',
-'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 'end_tag' => BBCODE_PROHIBIT,
 'content' => BBCODE_PROHIBIT,
 'before_tag' => "s",
 'after_tag' => "s",
 'plain_start' => "\n",
 'plain_end' => "",
-'plain_content' => Array(),
-),
-'left' => Array(
+'plain_content' => [],
+],
+'left' => [
 'simple_start' => "\n<div class=\"bbcode_left\" style=\"text-align:left\">\n",
 'simple_end' => "\n</div>\n",
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'before_tag' => "sns",
 'after_tag' => "sns",
 'before_endtag' => "sns",
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "\n",
-),
-'right' => Array(
+],
+'right' => [
 'simple_start' => "\n<div class=\"bbcode_right\" style=\"text-align:right\">\n",
 'simple_end' => "\n</div>\n",
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'before_tag' => "sns",
 'after_tag' => "sns",
 'before_endtag' => "sns",
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "\n",
-),
-'center' => Array(
+],
+'center' => [
 'simple_start' => "\n<div class=\"bbcode_center\" style=\"text-align:center\">\n",
 'simple_end' => "\n</div>\n",
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'before_tag' => "sns",
 'after_tag' => "sns",
 'before_endtag' => "sns",
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "\n",
-),
-'indent' => Array(
+],
+'indent' => [
 'simple_start' => "\n<div class=\"bbcode_indent\" style=\"margin-left:4em\">\n",
 'simple_end' => "\n</div>\n",
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'before_tag' => "sns",
 'after_tag' => "sns",
 'before_endtag' => "sns",
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "\n",
-),
-'columns' => Array(
+],
+'columns' => [
 'simple_start' => "\n<table class=\"bbcode_columns\"><tbody><tr><td class=\"bbcode_column bbcode_firstcolumn\">\n",
 'simple_end' => "\n</td></tr></tbody></table>\n",
 'class' => 'columns',
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'end_tag' => BBCODE_REQUIRED,
 'content' => BBCODE_REQUIRED,
 'before_tag' => "sns",
@@ -654,11 +654,11 @@ var $default_tag_rules = Array(
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "\n",
-),
-'nextcol' => Array(
+],
+'nextcol' => [
 'simple_start' => "\n</td><td class=\"bbcode_column\">\n",
 'class' => 'nextcol',
-'allow_in' => Array('columns'),
+'allow_in' => ['columns'],
 'end_tag' => BBCODE_PROHIBIT,
 'content' => BBCODE_PROHIBIT,
 'before_tag' => "sns",
@@ -667,12 +667,12 @@ var $default_tag_rules = Array(
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "",
-),
-'code' => Array(
+],
+'code' => [
 'mode' => BBCODE_MODE_ENHANCED,
 'template' => "\n<div class=\"bbcode_code\">\n<div class=\"bbcode_code_head\">Code:</div>\n<div class=\"bbcode_code_body\" style=\"white-space:pre\">{\$_content/v}</div>\n</div>\n",
 'class' => 'code',
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'content' => BBCODE_VERBATIM,
 'before_tag' => "sns",
 'after_tag' => "sn",
@@ -680,35 +680,35 @@ var $default_tag_rules = Array(
 'after_endtag' => "sns",
 'plain_start' => "\n<b>Code:</b>\n",
 'plain_end' => "\n",
-),
-'quote' => Array(
+],
+'quote' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => "DoQuote",
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'before_tag' => "sns",
 'after_tag' => "sns",
 'before_endtag' => "sns",
 'after_endtag' => "sns",
 'plain_start' => "\n<b>Quote:</b>\n",
 'plain_end' => "\n",
-),
-'list' => Array(
+],
+'list' => [
 'mode' => BBCODE_MODE_LIBRARY,
 'method' => 'DoList',
 'class' => 'list',
-'allow_in' => Array('listitem', 'block', 'columns'),
+'allow_in' => ['listitem', 'block', 'columns'],
 'before_tag' => "sns",
 'after_tag' => "sns",
 'before_endtag' => "sns",
 'after_endtag' => "sns",
 'plain_start' => "\n",
 'plain_end' => "\n",
-),
-'*' => Array(
+],
+'*' => [
 'simple_start' => "<li>",
 'simple_end' => "</li>\n",
 'class' => 'listitem',
-'allow_in' => Array('list'),
+'allow_in' => ['list'],
 'end_tag' => BBCODE_OPTIONAL,
 'before_tag' => "s",
 'after_tag' => "s",
@@ -716,8 +716,8 @@ var $default_tag_rules = Array(
 'after_endtag' => "sns",
 'plain_start' => "\n * ",
 'plain_end' => "\n",
-),
-);
+],
+];
 function DoURL($bbcode, $action, $name, $default, $params, $content) {
 if ($action == BBCODE_CHECK) return true;
 $url = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
@@ -758,7 +758,7 @@ return "<span style=\"font-size:$size\">$content</span>";
 function DoFont($bbcode, $action, $name, $default, $params, $content) {
 $fonts = explode(",", $default);
 $result = "";
-$special_fonts = Array(
+$special_fonts = [
 'serif' => 'serif',
 'sans-serif' => 'sans-serif',
 'sans serif' => 'sans-serif',
@@ -768,7 +768,7 @@ $special_fonts = Array(
 'fantasy' => 'fantasy',
 'monospace' => 'monospace',
 'mono' => 'monospace',
-);
+];
 foreach ($fonts as $font) {
 $font = trim($font);
 if (isset($special_fonts[$font])) {
@@ -839,27 +839,27 @@ return "\n<div class=\"bbcode_quote\">\n<div class=\"bbcode_quote_head\">"
 . $content . "</div>\n</div>\n";
 }
 function DoList($bbcode, $action, $name, $default, $params, $content) {
-$list_styles = Array(
+$list_styles = [
 '1' => 'decimal',
 '01' => 'decimal-leading-zero',
 'i' => 'lower-roman',
 'I' => 'upper-roman',
 'a' => 'lower-alpha',
 'A' => 'upper-alpha',
-);
-$ci_list_styles = Array(
+];
+$ci_list_styles = [
 'circle' => 'circle',
 'disc' => 'disc',
 'square' => 'square',
 'greek' => 'lower-greek',
 'armenian' => 'armenian',
 'georgian' => 'georgian',
-);
-$ul_types = Array(
+];
+$ul_types = [
 'circle' => 'circle',
 'disc' => 'disc',
 'square' => 'square',
-);
+];
 $default = trim($default);
 if ($action == BBCODE_CHECK) {
 if (!is_string($default) || strlen($default) == "") return true;
@@ -1026,8 +1026,8 @@ $this->rule_html = $this->GetDefaultRuleHTML();
 $this->pre_trim = "";
 $this->post_trim = "";
 $this->root_class = 'block';
-$this->lost_start_tags = Array();
-$this->start_tags = Array();
+$this->lost_start_tags = [];
+$this->start_tags = [];
 $this->tag_marker = '[';
 $this->allow_ampsersand = false;
 $this->current_class = $this->root_class;
@@ -1080,7 +1080,7 @@ function AddRule($name, $rule) { $this->tag_rules[$name] = $rule; }
 function RemoveRule($name) { unset($this->tag_rules[$name]); }
 function GetRule($name) { return isset($this->tag_rules[$name])
 ? $this->tag_rules[$name] : false; }
-function ClearRules() { $this->tag_rules = Array(); }
+function ClearRules() { $this->tag_rules = []; }
 function GetDefaultRule($name) { return isset($this->defaults->default_tag_rules[$name])
 ? $this->defaults->default_tag_rules[$name] : false; }
 function SetDefaultRule($name) { if (isset($this->defaults->default_tag_rules[$name]))
@@ -1104,7 +1104,7 @@ function AddSmiley($code, $image) { $this->smileys[$code] = $image; $this->smile
 function RemoveSmiley($code) { unset($this->smileys[$code]); $this->smiley_regex = false; }
 function GetSmiley($code) { return isset($this->smileys[$code])
 ? $this->smileys[$code] : false; }
-function ClearSmileys() { $this->smileys = Array(); $this->smiley_regex = false; }
+function ClearSmileys() { $this->smileys = []; $this->smiley_regex = false; }
 function GetDefaultSmiley($code) { return isset($this->defaults->default_smileys[$code])
 ? $this->defaults->default_smileys[$code] : false; }
 function SetDefaultSmiley($code) { $this->smileys[$code] = @$this->defaults->default_smileys[$code];
@@ -1208,8 +1208,8 @@ $/Dx", $string);
 function HTMLEncode($string) {
 if (!$this->allow_ampersand)
 return htmlspecialchars($string);
-else return str_replace(Array('<', '>'), //, '"'),
-Array('&lt;', '&gt;'), $string); //, '&quot;'), $string);
+else return str_replace(['<', '>'], //, '"'),
+['&lt;', '&gt;'], $string); //, '&quot;'), $string);
 }
 function FixupOutput($string) {
 if (!$this->detect_urls) {
@@ -1217,7 +1217,7 @@ $output = $this->Internal_ProcessSmileys($string);
 }
 else {
 $chunks = $this->Internal_AutoDetectURLs($string);
-$output = Array();
+$output = [];
 if (count($chunks)) {
 $is_a_url = false;
 foreach ($chunks as $index => $chunk) {
@@ -1271,7 +1271,7 @@ $is_a_smiley = !$is_a_smiley;
 return $output;
 }
 function Internal_RebuildSmileys() {
-$regex = Array("/(?<![\\w])(");
+$regex = ["/(?<![\\w])("];
 $first = true;
 foreach ($this->smileys as $code => $filename) {
 if (!$first) $regex[] = "|";
@@ -1345,7 +1345,7 @@ preg_match("/^([^\\/&?#]+)\\/*(.*)\$/", $token, $matches);
 $url = "http:/" . "/" . $matches[1] . "/" . $matches[2];
 }
 $params = @parse_url($url);
-if (!is_array($params)) $params = Array();
+if (!is_array($params)) $params = [];
 $params['url'] = $url;
 $params['link'] = $url;
 $params['text'] = $token;
@@ -1356,12 +1356,12 @@ $is_a_url = !$is_a_url;
 }
 return $output;
 }
-function FillTemplate($template, $insert_array, $default_array = Array()) {
+function FillTemplate($template, $insert_array, $default_array = []) {
 $pieces = preg_split('/(\{\$[a-zA-Z0-9_.:\/-]+\})/', $template,
 -1, PREG_SPLIT_DELIM_CAPTURE);
 if (count($pieces) <= 1)
 return $template;
-$result = Array();
+$result = [];
 $is_an_insert = false;
 foreach ($pieces as $piece) {
 if (!$is_an_insert) {
@@ -1394,7 +1394,7 @@ default: $value = ""; break;
 }
 if (strlen(@$matches[3]))
 $flags = array_flip(str_split($matches[3]));
-else $flags = Array();
+else $flags = [];
 if (!isset($flags['v'])) {
 if (isset($flags['w']))
 $value = preg_replace("/[\\x00-\\x09\\x0B-\x0C\x0E-\\x20]+/", " ", $value);
@@ -1429,7 +1429,7 @@ ob_end_clean();
 return $output;
 }
 function Internal_GenerateOutput($pos) {
-$output = Array();
+$output = [];
 while (count($this->stack) > $pos) {
 $token = array_pop($this->stack);
 if ($token[BBCODE_STACK_TOKEN] != BBCODE_TAG) {
@@ -1443,12 +1443,12 @@ if (!isset($rule['end_tag'])) $end_tag = BBCODE_REQUIRED;
 else $end_tag = $rule['end_tag'];
 array_pop($this->start_tags[$name]);
 if ($end_tag == BBCODE_PROHIBIT) {
-$output[] = Array(
+$output[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_TEXT => $token[BBCODE_STACK_TEXT],
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 else {
 if ($end_tag == BBCODE_REQUIRED)
@@ -1460,12 +1460,12 @@ $this->Internal_CleanupWSByPoppingStack(@$rule['before_tag'], $this->stack);
 $this->Internal_UpdateParamsForMissingEndTag(@$token[BBCODE_STACK_TAG]);
 $tag_output = $this->DoTag(BBCODE_OUTPUT, $name,
 @$token[BBCODE_STACK_TAG]['_default'], @$token[BBCODE_STACK_TAG], $tag_body);
-$output = Array(Array(
+$output = [[
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_TEXT => $tag_output,
 BBCODE_STACK_CLASS => $this->current_class
-));
+]];
 }
 }
 }
@@ -1626,12 +1626,12 @@ return $output;
 function Internal_DoLimit() {
 $this->Internal_CleanupWSByPoppingStack("a", $this->stack);
 if (strlen($this->limit_tail) > 0) {
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->limit_tail,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 $this->was_limited = true;
 }
@@ -1667,11 +1667,11 @@ case BBCODE_MODE_ENHANCED:
 $result = true;
 break;
 case BBCODE_MODE_INTERNAL:
-$result = @call_user_func(Array($this, @$tag_rule['method']), BBCODE_CHECK,
+$result = @call_user_func([$this, @$tag_rule['method']], BBCODE_CHECK,
 $tag_name, $default_value, $params, $contents);
 break;
 case BBCODE_MODE_LIBRARY:
-$result = @call_user_func(Array($this->defaults, @$tag_rule['method']), $this, BBCODE_CHECK,
+$result = @call_user_func([$this->defaults, @$tag_rule['method']], $this, BBCODE_CHECK,
 $tag_name, $default_value, $params, $contents);
 break;
 case BBCODE_MODE_CALLBACK:
@@ -1683,7 +1683,7 @@ return $result;
 case BBCODE_OUTPUT:
 if ($this->plain_mode) {
 if (!isset($tag_rule['plain_content']))
-$plain_content = Array('_content');
+$plain_content = ['_content'];
 else $plain_content = $tag_rule['plain_content'];
 $result = $possible_content = "";
 foreach ($plain_content as $possible_content) {
@@ -1715,7 +1715,7 @@ break;
 }
 }
 $params = @parse_url($link);
-if (!is_array($params)) $params = Array();
+if (!is_array($params)) $params = [];
 $params['link'] = $link;
 $params['url'] = $link;
 $start = $this->FillTemplate($start, $params);
@@ -1732,11 +1732,11 @@ case BBCODE_MODE_ENHANCED:
 $result = $this->Internal_DoEnhancedTag($tag_rule, $params, $contents);
 break;
 case BBCODE_MODE_INTERNAL:
-$result = @call_user_func(Array($this, @$tag_rule['method']), BBCODE_OUTPUT,
+$result = @call_user_func([$this, @$tag_rule['method']], BBCODE_OUTPUT,
 $tag_name, $default_value, $params, $contents);
 break;
 case BBCODE_MODE_LIBRARY:
-$result = @call_user_func(Array($this->defaults, @$tag_rule['method']), $this, BBCODE_OUTPUT,
+$result = @call_user_func([$this->defaults, @$tag_rule['method']], $this, BBCODE_OUTPUT,
 $tag_name, $default_value, $params, $contents);
 break;
 case BBCODE_MODE_CALLBACK:
@@ -1766,23 +1766,23 @@ $params['_endtag'] = $this->tag_marker . '/' . $params['_name'] . $tail_marker;
 }
 function Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule) {
 if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 return;
 }
 $this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
 $output = $this->DoTag(BBCODE_OUTPUT, $tag_name, @$tag_params['_default'], $tag_params, "");
 $this->Internal_CleanupWSByEatingInput(@$tag_rule['after_tag']);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $output,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 function Internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule) {
 $state = $this->lexer->SaveState();
@@ -1800,33 +1800,33 @@ $text = $this->Internal_LimitText($this->lexer->text,
 $this->output_limit - $this->text_length);
 if (strlen($text) > 0) {
 $this->text_length += strlen($text);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 $this->Internal_DoLimit();
 break;
 }
 $this->text_length += strlen($this->lexer->text);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => $token_type,
 BBCODE_STACK_TEXT => htmlspecialchars($this->lexer->text),
 BBCODE_STACK_TAG => $this->lexer->tag,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 $this->lexer->verbatim = false;
 if ($token_type == BBCODE_EOI) {
 $this->lexer->RestoreState($state);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 return;
 }
 $newstart = $this->Internal_CleanupWSByIteratingPointer(@$tag_rule['after_tag'], $start, $this->stack);
@@ -1840,36 +1840,36 @@ $tag_params['_endtag'] = $end_tag_params['_tag'];
 $tag_params['_hasend'] = true;
 $output = $this->DoTag(BBCODE_OUTPUT, $tag_name,
 @$tag_params['_default'], $tag_params, $content);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $output,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 function Internal_ParseStartTagToken() {
 $tag_params = $this->lexer->tag;
 $tag_name = @$tag_params['_name'];
 if (!isset($this->tag_rules[$tag_name])) {
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 return;
 }
 $tag_rule = $this->tag_rules[$tag_name];
 $allow_in = is_array($tag_rule['allow_in'])
-? $tag_rule['allow_in'] : Array($this->root_class);
+? $tag_rule['allow_in'] : [$this->root_class];
 if (!in_array($this->current_class, $allow_in)) {
 if (!$this->Internal_RewindToClass($allow_in)) {
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 return;
 }
 }
@@ -1879,12 +1879,12 @@ $this->Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule);
 return;
 }
 if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 return;
 }
 if (@$tag_rule['content'] == BBCODE_VERBATIM) {
@@ -1894,14 +1894,14 @@ return;
 if (isset($tag_rule['class']))
 $newclass = $tag_rule['class'];
 else $newclass = $this->root_class;
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => $this->lexer->token,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => $this->lexer->tag,
 BBCODE_STACK_CLASS => ($this->current_class = $newclass),
-);
+];
 if (!isset($this->start_tags[$tag_name]))
-$this->start_tags[$tag_name] = Array(count($this->stack)-1);
+$this->start_tags[$tag_name] = [count($this->stack)-1];
 else $this->start_tags[$tag_name][] = count($this->stack)-1;
 }
 function Internal_ParseEndTagToken() {
@@ -1913,12 +1913,12 @@ if (@$this->lost_start_tags[$tag_name] > 0) {
 $this->lost_start_tags[$tag_name]--;
 }
 else {
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 return;
 }
@@ -1931,12 +1931,12 @@ $start_tag_params['_hasend'] = true;
 $output = $this->DoTag(BBCODE_OUTPUT, $tag_name, @$start_tag_params['_default'],
 $start_tag_params, $contents);
 $this->Internal_CleanupWSByEatingInput(@$this->tag_rules[$tag_name]['after_endtag']);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $output,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 function Parse($string) {
 $this->lexer = new BBCodeLexer($string, $this->tag_marker);
@@ -1955,9 +1955,9 @@ else {
 }
 }
 }
-$this->stack = Array();
-$this->start_tags = Array();
-$this->lost_start_tags = Array();
+$this->stack = [];
+$this->start_tags = [];
+$this->lost_start_tags = [];
 $this->text_length = 0;
 $this->was_limited = false;
 if (strlen($this->pre_trim) > 0)
@@ -1975,23 +1975,23 @@ $text = $this->Internal_LimitText($this->lexer->text,
 $this->output_limit - $this->text_length);
 if (strlen($text) > 0) {
 $this->text_length += strlen($text);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 $this->Internal_DoLimit();
 break 2;
 }
 $this->text_length += strlen($this->lexer->text);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 break;
 case BBCODE_WS:
 if ($this->output_limit > 0
@@ -2000,12 +2000,12 @@ $this->Internal_DoLimit();
 break 2;
 }
 $this->text_length += strlen($this->lexer->text);
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_WS,
 BBCODE_STACK_TEXT => $this->lexer->text,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 break;
 case BBCODE_NL:
 if ($this->ignore_newlines) {
@@ -2015,12 +2015,12 @@ $this->Internal_DoLimit();
 break 2;
 }
 $this->text_length += 1;
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_WS,
 BBCODE_STACK_TEXT => "\n",
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 }
 else {
 $this->Internal_CleanupWSByPoppingStack("s", $this->stack);
@@ -2030,12 +2030,12 @@ $this->Internal_DoLimit();
 break 2;
 }
 $this->text_length += 1;
-$this->stack[] = Array(
+$this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_NL,
 BBCODE_STACK_TEXT => $newline,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
-);
+];
 $this->Internal_CleanupWSByEatingInput("s");
 }
 break;

--- a/plugins/NBBC/nbbc/src/nbbc_lex.php
+++ b/plugins/NBBC/nbbc/src/nbbc_lex.php
@@ -79,9 +79,9 @@
 			// We also separate out whitespace and newlines.
 			
 			// Choose a tag marker based on the possible tag markers.
-			$regex_beginmarkers = Array( '[' => '\[', '<' => '<', '{' => '\{', '(' => '\(' );
-			$regex_endmarkers   = Array( '[' => '\]', '<' => '>', '{' => '\}', '(' => '\)' );
-			$endmarkers         = Array( '[' =>  ']', '<' => '>', '{' =>  '}', '(' =>  ')' );
+			$regex_beginmarkers = [ '[' => '\[', '<' => '<', '{' => '\{', '(' => '\(' ];
+			$regex_endmarkers   = [ '[' => '\]', '<' => '>', '{' => '\}', '(' => '\)' ];
+			$endmarkers         = [ '[' =>  ']', '<' => '>', '{' =>  '}', '(' =>  ')' ];
 			if (!isset($regex_endmarkers[$tagmarker])) $tagmarker = '[';
 			$e = $regex_endmarkers[$tagmarker];
 			$b = $regex_beginmarkers[$tagmarker];
@@ -280,7 +280,7 @@
 					case 45:
 						// A rule made of hyphens; return it as a [rule] tag.
 						if (preg_match("/^-----/", $this->text)) {
-							$this->tag = Array('_name' => 'rule', '_endtag' => false, '_default' => '');
+							$this->tag = ['_name' => 'rule', '_endtag' => false, '_default' => ''];
 							$this->state = BBCODE_LEXSTATE_TEXT;
 							return $this->token = BBCODE_TAG;
 						}
@@ -317,8 +317,8 @@
 						
 						// See if this is a [[wiki link]]; if so, convert it into a [wiki="" title=""] tag.
 						if (preg_match($this->pat_wiki, $this->text, $matches)) {
-							$this->tag = Array('_name' => 'wiki', '_endtag' => false,
-								'_default' => @$matches[1], 'title' => @$matches[2]);
+							$this->tag = ['_name' => 'wiki', '_endtag' => false,
+								'_default' => @$matches[1], 'title' => @$matches[2]];
 							$this->state = BBCODE_LEXSTATE_TEXT;
 							return $this->token = BBCODE_TAG;
 						}
@@ -355,7 +355,7 @@
 		// references, the total cost of the returned state is relatively small, and
 		// the running time of this function (and RestoreState) is very fast.
 		function SaveState() {
-			return Array(
+			return [
 				'token' => $this->token,
 				'text' => $this->text,
 				'tag' => $this->tag,
@@ -364,7 +364,7 @@
 				'ptr' => $this->ptr,
 				'unget' => $this->unget,
 				'verbatim' => $this->verbatim
-			);
+			];
 		}
 		
 		// Restore the state of this lexer from a saved previous state.
@@ -414,8 +414,8 @@
 			}
 
 			// Create the initial result object.
-			$result = Array('_tag' => $tag, '_endtag' => '', '_name' => '',
-				'_hasend' => false, '_end' => false, '_default' => false);
+			$result = ['_tag' => $tag, '_endtag' => '', '_name' => '',
+				'_hasend' => false, '_end' => false, '_default' => false];
 
 			// Strip off the [brackets] around the tag, leaving just its content.
 			$tag = substr($tag, 1, strlen($tag)-2);
@@ -447,12 +447,12 @@
 			while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
 				$ptr++;
 
-			$params = Array();
+			$params = [];
 
 			// If the next piece is an equal sign, then the tag's default value follows.
 			if ($type != '=') {
 				$result['_default'] = false;
-				$params[] = Array('key' => '', 'value' => '');
+				$params[] = ['key' => '', 'value' => ''];
 			}
 			else {
 				$ptr++;
@@ -511,7 +511,7 @@
 				}
 
 				$result['_default'] = $value;
-				$params[] = Array('key' => '', 'value' => $value);
+				$params[] = ['key' => '', 'value' => $value];
 			}
 
 			// The rest of the tag is composed of either floating keys or key=value pairs, so walk through
@@ -568,7 +568,7 @@
 					$result[$key] = $value;
 
 				// Record this in the parameter list always.
-				$params[] = Array('key' => $key, 'value' => $value);
+				$params[] = ['key' => $key, 'value' => $value];
 			}
 
 			// Add the parameter list as a member of the associative array.

--- a/plugins/NBBC/nbbc/src/nbbc_lib.php
+++ b/plugins/NBBC/nbbc/src/nbbc_lib.php
@@ -62,7 +62,7 @@
 		//-----------------------------------------------------------------------------
 		// Standard library of smiley definitions.
 	
-		var $default_smileys = Array(
+		var $default_smileys = [
 			':)' => 'smile.gif',       ':-)' => 'smile.gif',
 			'=)' => 'smile.gif',       '=-)' => 'smile.gif',
 			':(' => 'frown.gif',       ':-(' => 'frown.gif',
@@ -116,215 +116,215 @@
 			':zzz:' => 'sleepy.gif',
 			'<3' => 'heart.gif',
 			':star:' => 'star.gif',
-		);
+		];
 
 		//-----------------------------------------------------------------------------
 		// Standard rules for what to do when a BBCode tag is encountered.
 
-		var $default_tag_rules = Array(
+		var $default_tag_rules = [
 		
-			'b' => Array(
+			'b' => [
 				'simple_start' => "<b>",
 				'simple_end' => "</b>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 				'plain_start' => "<b>",
 				'plain_end' => "</b>",
-			),
-			'i' => Array(
+			],
+			'i' => [
 				'simple_start' => "<i>",
 				'simple_end' => "</i>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 				'plain_start' => "<i>",
 				'plain_end' => "</i>",
-			),
-			'u' => Array(
+			],
+			'u' => [
 				'simple_start' => "<u>",
 				'simple_end' => "</u>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 				'plain_start' => "<u>",
 				'plain_end' => "</u>",
-			),
-			's' => Array(
+			],
+			's' => [
 				'simple_start' => "<strike>",
 				'simple_end' => "</strike>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 				'plain_start' => "<i>",
 				'plain_end' => "</i>",
-			),
+			],
 
-			'font' => Array(
+			'font' => [
 				'mode' => BBCODE_MODE_LIBRARY,
-				'allow' => Array('_default' => '/^[a-zA-Z0-9._ ,-]+$/'),
+				'allow' => ['_default' => '/^[a-zA-Z0-9._ ,-]+$/'],
 				'method' => 'DoFont',
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
-			'color' => Array(
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
+			'color' => [
 				'mode' => BBCODE_MODE_ENHANCED,
-				'allow' => Array('_default' => '/^#?[a-zA-Z0-9._ -]+$/'),
+				'allow' => ['_default' => '/^#?[a-zA-Z0-9._ -]+$/'],
 				'template' => '<span style="color:{$_default/tw}">{$_content/v}</span>',
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
-			'size' => Array(
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
+			'size' => [
 				'mode' => BBCODE_MODE_LIBRARY,
-				'allow' => Array('_default' => '/^[0-9.]+$/D'),
+				'allow' => ['_default' => '/^[0-9.]+$/D'],
 				'method' => 'DoSize',
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
-			'sup' => Array(
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
+			'sup' => [
 				'simple_start' => "<sup>",
 				'simple_end' => "</sup>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
-			'sub' => Array(
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
+			'sub' => [
 				'simple_start' => "<sub>",
 				'simple_end' => "</sub>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
-			'spoiler' => Array(
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
+			'spoiler' => [
 				'simple_start' => "<span class=\"bbcode_spoiler\">",
 				'simple_end' => "</span>",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
-			'acronym' => Array(
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
+			'acronym' => [
 				'mode' => BBCODE_MODE_ENHANCED,
 				'template' => '<span class="bbcode_acronym" title="{$_default/e}">{$_content/v}</span>',
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-			),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+			],
 
-			'url' => Array(
+			'url' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => 'DoURL',
 				'class' => 'link',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 				'content' => BBCODE_REQUIRED,
 				'plain_start' => "<a href=\"{\$link}\">",
 				'plain_end' => "</a>",
-				'plain_content' => Array('_content', '_default'),
-				'plain_link' => Array('_default', '_content'),
-			),
-			'email' => Array(
+				'plain_content' => ['_content', '_default'],
+				'plain_link' => ['_default', '_content'],
+			],
+			'email' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => 'DoEmail',
 				'class' => 'link',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 				'content' => BBCODE_REQUIRED,
 				'plain_start' => "<a href=\"mailto:{\$link}\">",
 				'plain_end' => "</a>",
-				'plain_content' => Array('_content', '_default'),
-				'plain_link' => Array('_default', '_content'),
-			),
-			'wiki' => Array(
+				'plain_content' => ['_content', '_default'],
+				'plain_link' => ['_default', '_content'],
+			],
+			'wiki' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => "DoWiki",
 				'class' => 'link',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline'],
 				'end_tag' => BBCODE_PROHIBIT,
 				'content' => BBCODE_PROHIBIT,
 				'plain_start' => "<b>[",
 				'plain_end' => "]</b>",
-				'plain_content' => Array('title', '_default'),
-				'plain_link' => Array('_default', '_content'),
-			),
+				'plain_content' => ['title', '_default'],
+				'plain_link' => ['_default', '_content'],
+			],
 
-			'img' => Array(
+			'img' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => "DoImage",
 				'class' => 'image',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 				'end_tag' => BBCODE_REQUIRED,
 				'content' => BBCODE_REQUIRED,
 				'plain_start' => "[image]",
-				'plain_content' => Array(),
-			),
-			'rule' => Array(
+				'plain_content' => [],
+			],
+			'rule' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => "DoRule",
 				'class' => 'block',
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'end_tag' => BBCODE_PROHIBIT,
 				'content' => BBCODE_PROHIBIT,
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'plain_start' => "\n-----\n",
 				'plain_end' => "",
-				'plain_content' => Array(),
-			),
-			'br' => Array(
+				'plain_content' => [],
+			],
+			'br' => [
 				'mode' => BBCODE_MODE_SIMPLE,
 				'simple_start' => "<br />\n",
 				'simple_end' => "",
 				'class' => 'inline',
-				'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
+				'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 				'end_tag' => BBCODE_PROHIBIT,
 				'content' => BBCODE_PROHIBIT,
 				'before_tag' => "s",
 				'after_tag' => "s",
 				'plain_start' => "\n",
 				'plain_end' => "",
-				'plain_content' => Array(),
-			),
+				'plain_content' => [],
+			],
 
-			'left' => Array(
+			'left' => [
 				'simple_start' => "\n<div class=\"bbcode_left\" style=\"text-align:left\">\n",
 				'simple_end' => "\n</div>\n",
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'before_endtag' => "sns",
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "\n",
-			),
-			'right' => Array(
+			],
+			'right' => [
 				'simple_start' => "\n<div class=\"bbcode_right\" style=\"text-align:right\">\n",
 				'simple_end' => "\n</div>\n",
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'before_endtag' => "sns",
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "\n",
-			),
-			'center' => Array(
+			],
+			'center' => [
 				'simple_start' => "\n<div class=\"bbcode_center\" style=\"text-align:center\">\n",
 				'simple_end' => "\n</div>\n",
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'before_endtag' => "sns",
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "\n",
-			),
-			'indent' => Array(
+			],
+			'indent' => [
 				'simple_start' => "\n<div class=\"bbcode_indent\" style=\"margin-left:4em\">\n",
 				'simple_end' => "\n</div>\n",
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'before_endtag' => "sns",
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "\n",
-			),
+			],
 
-			'columns' => Array(
+			'columns' => [
 				'simple_start' => "\n<table class=\"bbcode_columns\"><tbody><tr><td class=\"bbcode_column bbcode_firstcolumn\">\n",
 				'simple_end' => "\n</td></tr></tbody></table>\n",
 				'class' => 'columns',
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'end_tag' => BBCODE_REQUIRED,
 				'content' => BBCODE_REQUIRED,
 				'before_tag' => "sns",
@@ -333,11 +333,11 @@
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "\n",
-			),
-			'nextcol' => Array(
+			],
+			'nextcol' => [
 				'simple_start' => "\n</td><td class=\"bbcode_column\">\n",
 				'class' => 'nextcol',
-				'allow_in' => Array('columns'),
+				'allow_in' => ['columns'],
 				'end_tag' => BBCODE_PROHIBIT,
 				'content' => BBCODE_PROHIBIT,
 				'before_tag' => "sns",
@@ -346,13 +346,13 @@
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "",
-			),
+			],
 
-			'code' => Array(
+			'code' => [
 				'mode' => BBCODE_MODE_ENHANCED,
 				'template' => "\n<div class=\"bbcode_code\">\n<div class=\"bbcode_code_head\">Code:</div>\n<div class=\"bbcode_code_body\" style=\"white-space:pre\">{\$_content/v}</div>\n</div>\n",
 				'class' => 'code',
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'content' => BBCODE_VERBATIM,
 				'before_tag' => "sns",
 				'after_tag' => "sn",
@@ -360,36 +360,36 @@
 				'after_endtag' => "sns",
 				'plain_start' => "\n<b>Code:</b>\n",
 				'plain_end' => "\n",
-			),
-			'quote' => Array(
+			],
+			'quote' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => "DoQuote",
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'before_endtag' => "sns",
 				'after_endtag' => "sns",
 				'plain_start' => "\n<b>Quote:</b>\n",
 				'plain_end' => "\n",
-			),
+			],
 
-			'list' => Array(
+			'list' => [
 				'mode' => BBCODE_MODE_LIBRARY,
 				'method' => 'DoList',
 				'class' => 'list',
-				'allow_in' => Array('listitem', 'block', 'columns'),
+				'allow_in' => ['listitem', 'block', 'columns'],
 				'before_tag' => "sns",
 				'after_tag' => "sns",
 				'before_endtag' => "sns",
 				'after_endtag' => "sns",
 				'plain_start' => "\n",
 				'plain_end' => "\n",
-			),
-			'*' => Array(
+			],
+			'*' => [
 				'simple_start' => "<li>",
 				'simple_end' => "</li>\n",
 				'class' => 'listitem',
-				'allow_in' => Array('list'),
+				'allow_in' => ['list'],
 				'end_tag' => BBCODE_OPTIONAL,
 				'before_tag' => "s",
 				'after_tag' => "s",
@@ -397,8 +397,8 @@
 				'after_endtag' => "sns",
 				'plain_start' => "\n * ",
 				'plain_end' => "\n",
-			),
-		);
+			],
+		];
 
 		//-----------------------------------------------------------------------------
 		//  Standard library of BBCode formatting routines.
@@ -461,7 +461,7 @@
 		function DoFont($bbcode, $action, $name, $default, $params, $content) {
 			$fonts = explode(",", $default);
 			$result = "";
-			$special_fonts = Array(
+			$special_fonts = [
 				'serif' => 'serif',
 				'sans-serif' => 'sans-serif',
 				'sans serif' => 'sans-serif',
@@ -471,7 +471,7 @@
 				'fantasy' => 'fantasy',
 				'monospace' => 'monospace',
 				'mono' => 'monospace',
-			);
+			];
 			foreach ($fonts as $font) {
 				$font = trim($font);
 				if (isset($special_fonts[$font])) {
@@ -588,27 +588,27 @@
 
 			// Allowed list styles, striaght from the CSS 2.1 spec.  The only prohibited
 			// list style is that with image-based markers, which often slows down web sites.
-			$list_styles = Array(
+			$list_styles = [
 				'1' => 'decimal',
 				'01' => 'decimal-leading-zero',
 				'i' => 'lower-roman',
 				'I' => 'upper-roman',
 				'a' => 'lower-alpha',
 				'A' => 'upper-alpha',
-			);
-			$ci_list_styles = Array(
+			];
+			$ci_list_styles = [
 				'circle' => 'circle',
 				'disc' => 'disc',
 				'square' => 'square',
 				'greek' => 'lower-greek',
 				'armenian' => 'armenian',
 				'georgian' => 'georgian',
-			);
-			$ul_types = Array(
+			];
+			$ul_types = [
 				'circle' => 'circle',
 				'disc' => 'disc',
 				'square' => 'square',
-			);
+			];
 
 			$default = trim($default);
 

--- a/plugins/NBBC/nbbc/src/nbbc_main.php
+++ b/plugins/NBBC/nbbc/src/nbbc_main.php
@@ -93,7 +93,7 @@
 		var $start_time, $total_times;
 		
 		function BBCode_Profiler()
-			{ $start_time = Array(); $total_times = Array(); }
+			{ $start_time = []; $total_times = []; }
 
 		function Now()
 			{ list($usec, $sec) = explode(" ", microtime());

--- a/plugins/NBBC/nbbc/src/nbbc_parse.php
+++ b/plugins/NBBC/nbbc/src/nbbc_parse.php
@@ -140,8 +140,8 @@
 			$this->pre_trim = "";
 			$this->post_trim = "";
 			$this->root_class = 'block';
-			$this->lost_start_tags = Array();
-			$this->start_tags = Array();
+			$this->lost_start_tags = [];
+			$this->start_tags = [];
 			$this->tag_marker = '[';
 			$this->allow_ampsersand = false;
 			$this->current_class = $this->root_class;
@@ -212,7 +212,7 @@
 		function RemoveRule($name)     { unset($this->tag_rules[$name]); }
 		function GetRule($name)        { return isset($this->tag_rules[$name])
 		                                   ? $this->tag_rules[$name] : false; }
-		function ClearRules()          { $this->tag_rules = Array(); }
+		function ClearRules()          { $this->tag_rules = []; }
 		function GetDefaultRule($name) { return isset($this->defaults->default_tag_rules[$name])
 		                                   ? $this->defaults->default_tag_rules[$name] : false; }
 		function SetDefaultRule($name) { if (isset($this->defaults->default_tag_rules[$name]))
@@ -249,7 +249,7 @@
 		function RemoveSmiley($code)      { unset($this->smileys[$code]); $this->smiley_regex = false; }
 		function GetSmiley($code)         { return isset($this->smileys[$code])
 		                                      ? $this->smileys[$code] : false; }
-		function ClearSmileys()           { $this->smileys = Array(); $this->smiley_regex = false; }
+		function ClearSmileys()           { $this->smileys = []; $this->smiley_regex = false; }
 
 		function GetDefaultSmiley($code)  { return isset($this->defaults->default_smileys[$code])
 		                                      ? $this->defaults->default_smileys[$code] : false; }
@@ -415,8 +415,8 @@
 		function HTMLEncode($string) {
 			if (!$this->allow_ampersand)
 				return htmlspecialchars($string);
-			else return str_replace(Array('<', '>', '"'),
-					Array('&lt;', '&gt;', '&quot;'), $string);
+			else return str_replace(['<', '>', '"'],
+					['&lt;', '&gt;', '&quot;'], $string);
 		}
 
 		// Go through a string containing plain text and do three things on it:
@@ -447,7 +447,7 @@
 				// at them.  But then you didn't want a smiley named "foo.com" anyway,
 				// did you?)
 				$chunks = $this->Internal_AutoDetectURLs($string);
-				$output = Array();
+				$output = [];
 				if (count($chunks)) {
 					$is_a_url = false;
 					foreach ($chunks as $index => $chunk) {
@@ -541,7 +541,7 @@
 			// of the smileys.  This will save us a lot of computation time
 			// in $this->Parse() if multiple BBCode strings are being
 			// processed by the same script.
-			$regex = Array("/(?<![\\w])(");
+			$regex = ["/(?<![\\w])("];
 			$first = true;
 			foreach ($this->smileys as $code => $filename) {
 				if (!$first) $regex[] = "|";
@@ -655,7 +655,7 @@
 						// We have a full, complete, and properly-formatted URL, with protocol.
 						// Now we need to apply the $this->url_pattern template to turn it into HTML.
 						$params = @parse_url($url);
-						if (!is_array($params)) $params = Array();
+						if (!is_array($params)) $params = [];
 						$params['url'] = $url;
 						$params['link'] = $url;
 						$params['text'] = $token;
@@ -698,7 +698,7 @@
 		//
 		// Note that only one of the e, h, k, or u "formatting flags" may be specified;
 		// these flags are mutually-exclusive.
-		function FillTemplate($template, $insert_array, $default_array = Array()) {
+		function FillTemplate($template, $insert_array, $default_array = []) {
 			$pieces = preg_split('/(\{\$[a-zA-Z0-9_.:\/-]+\})/', $template,
 				-1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -706,7 +706,7 @@
 			if (count($pieces) <= 1)
 				return $template;
 
-			$result = Array();
+			$result = [];
 
 			$is_an_insert = false;
 			foreach ($pieces as $piece) {
@@ -758,7 +758,7 @@
 					// See if there are any flags.
 					if (strlen(@$matches[3]))
 						$flags = array_flip(str_split($matches[3]));
-					else $flags = Array();
+					else $flags = [];
 
 					// If there are flags, process the value according to them.
 					if (!isset($flags['v'])) {
@@ -839,7 +839,7 @@
 					. "<b>Internal_GenerateOutput:</b> Stack contents: <tt>"
 					. $this->Internal_DumpStack() . "</tt><br />\n";
 			}
-			$output = Array();
+			$output = [];
 			while (count($this->stack) > $pos) {
 				$token = array_pop($this->stack);
 				if ($token[BBCODE_STACK_TOKEN] != BBCODE_TAG) {
@@ -868,12 +868,12 @@
 					array_pop($this->start_tags[$name]);	// Remove the locator for this tag.
 					if ($end_tag == BBCODE_PROHIBIT) {
 						// Broken tag, so just push it to the output as HTML.
-						$output[] = Array(
+						$output[] = [
 							BBCODE_STACK_TOKEN => BBCODE_TEXT,
 							BBCODE_STACK_TAG => false,
 							BBCODE_STACK_TEXT => $token[BBCODE_STACK_TEXT],
 							BBCODE_STACK_CLASS => $this->current_class,
-						);
+						];
 						if ($this->debug) {
 							print "<b>Internal_GenerateOutput:</b> push broken tag: <tt>"
 								. htmlspecialchars($token['text']) . "</tt><br />\n";
@@ -917,12 +917,12 @@
 								. htmlspecialchars($tag_output) . "</tt><br />\n";
 						}
 
-						$output = Array(Array(
+						$output = [[
 							BBCODE_STACK_TOKEN => BBCODE_TEXT,
 							BBCODE_STACK_TAG => false,
 							BBCODE_STACK_TEXT => $tag_output,
 							BBCODE_STACK_CLASS => $this->current_class
-						));
+						]];
 					}
 				}
 			}
@@ -1268,12 +1268,12 @@
 			$this->Internal_CleanupWSByPoppingStack("a", $this->stack);
 
 			if (strlen($this->limit_tail) > 0) {
-				$this->stack[] = Array(
+				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
 					BBCODE_STACK_TEXT => $this->limit_tail,
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
-				);
+				];
 			}
 
 			$this->was_limited = true;
@@ -1356,12 +1356,12 @@
 					break;
 
 				case BBCODE_MODE_INTERNAL:
-					$result = @call_user_func(Array($this, @$tag_rule['method']), BBCODE_CHECK,
+					$result = @call_user_func([$this, @$tag_rule['method']], BBCODE_CHECK,
 						$tag_name, $default_value, $params, $contents);
 					break;
 
 				case BBCODE_MODE_LIBRARY:
-					$result = @call_user_func(Array($this->defaults, @$tag_rule['method']), $this, BBCODE_CHECK,
+					$result = @call_user_func([$this->defaults, @$tag_rule['method']], $this, BBCODE_CHECK,
 						$tag_name, $default_value, $params, $contents);
 					break;
 
@@ -1390,7 +1390,7 @@
 					// the 'plain_start' and 'plain_end' before the content specified in
 					// the 'plain_content' member.
 					if (!isset($tag_rule['plain_content']))
-						$plain_content = Array('_content');
+						$plain_content = ['_content'];
 					else $plain_content = $tag_rule['plain_content'];
 
 					// Find the requested content, in the order specified.
@@ -1436,7 +1436,7 @@
 							}
 						}
 						$params = @parse_url($link);
-						if (!is_array($params)) $params = Array();
+						if (!is_array($params)) $params = [];
 						$params['link'] = $link;
 						$params['url'] = $link;
 						$start = $this->FillTemplate($start, $params);
@@ -1459,12 +1459,12 @@
 					break;
 
 				case BBCODE_MODE_INTERNAL:
-					$result = @call_user_func(Array($this, @$tag_rule['method']), BBCODE_OUTPUT,
+					$result = @call_user_func([$this, @$tag_rule['method']], BBCODE_OUTPUT,
 						$tag_name, $default_value, $params, $contents);
 					break;
 
 				case BBCODE_MODE_LIBRARY:
-					$result = @call_user_func(Array($this->defaults, @$tag_rule['method']), $this, BBCODE_OUTPUT,
+					$result = @call_user_func([$this->defaults, @$tag_rule['method']], $this, BBCODE_OUTPUT,
 						$tag_name, $default_value, $params, $contents);
 					break;
 
@@ -1537,12 +1537,12 @@
 					print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars($tag_name)
 						. "]</tt> rejected its parameters; outputting as text after fixup.<br />\n";
 				}
-				$this->stack[] = Array(
+				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
 					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
-				);
+				];
 				return;
 			}
 
@@ -1555,12 +1555,12 @@
 					. "]</tt> is done; pushing its output: <tt>" . htmlspecialchars($output) . "</tt><br />\n";
 			}
 
-			$this->stack[] = Array(
+			$this->stack[] = [
 				BBCODE_STACK_TOKEN => BBCODE_TEXT,
 				BBCODE_STACK_TEXT => $output,
 				BBCODE_STACK_TAG => false,
 				BBCODE_STACK_CLASS => $this->current_class,
-			);
+			];
 		}
 
 		// Process a verbatim tag, a tag whose contents (body) must not be processed at all.
@@ -1602,24 +1602,24 @@
 						$this->output_limit - $this->text_length);
 					if (strlen($text) > 0) {
 						$this->text_length += strlen($text);
-						$this->stack[] = Array(
+						$this->stack[] = [
 							BBCODE_STACK_TOKEN => BBCODE_TEXT,
 							BBCODE_STACK_TEXT => $this->FixupOutput($text),
 							BBCODE_STACK_TAG => false,
 							BBCODE_STACK_CLASS => $this->current_class,
-						);
+						];
 					}
 					$this->Internal_DoLimit();
 					break;
 				}
 				$this->text_length += strlen($this->lexer->text);
 
-				$this->stack[] = Array(
+				$this->stack[] = [
 					BBCODE_STACK_TOKEN => $token_type,
 					BBCODE_STACK_TEXT => htmlspecialchars($this->lexer->text),
 					BBCODE_STACK_TAG => $this->lexer->tag,
 					BBCODE_STACK_CLASS => $this->current_class,
-				);
+				];
 			}
 			$this->lexer->verbatim = false;
 
@@ -1633,12 +1633,12 @@
 						. " and push start tag as text after fixup.<br />\n";
 				}
 				$this->lexer->RestoreState($state);
-				$this->stack[] = Array(
+				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
 					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
-				);
+				];
 				return;
 			}
 
@@ -1680,12 +1680,12 @@
 					. "</tt><br />\n";
 			}
 
-			$this->stack[] = Array(
+			$this->stack[] = [
 				BBCODE_STACK_TOKEN => BBCODE_TEXT,
 				BBCODE_STACK_TEXT => $output,
 				BBCODE_STACK_TAG => false,
 				BBCODE_STACK_CLASS => $this->current_class,
-			);
+			];
 		}
 
 		// Called when the parser has read a BBCODE_TAG token.
@@ -1709,12 +1709,12 @@
 				}
 				// If there is no such tag with this name, then just push the text as
 				// though it was plain text.
-				$this->stack[] = Array(
+				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
 					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
-				);
+				];
 				return;
 			}
 			$tag_rule = $this->tag_rules[$tag_name];
@@ -1723,7 +1723,7 @@
 			// it's legal to put an inline tag inside a block tag, but not legal to put a
 			// block tag inside an inline tag.
 			$allow_in = is_array($tag_rule['allow_in'])
-				? $tag_rule['allow_in'] : Array($this->root_class);
+				? $tag_rule['allow_in'] : [$this->root_class];
 			if (!in_array($this->current_class, $allow_in)) {
 				// Not allowed.  Rewind the stack backward until it is allowed.
 				if ($this->debug) {
@@ -1736,12 +1736,12 @@
 						print "<b>Internal_ParseStartTagToken:</b> no safe class exists; rejecting"
 							. " this tag as text after fixup.<br />\n";
 					}
-					$this->stack[] = Array(
+					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_TEXT,
 						BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
-					);
+					];
 					return;
 				}
 			}
@@ -1774,12 +1774,12 @@
 					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars($tag_name)
 						. "]</tt> rejected its parameters; outputting as text after fixup.<br />\n";
 				}
-				$this->stack[] = Array(
+				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
 					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
-				);
+				];
 				return;
 			}
 
@@ -1804,15 +1804,15 @@
 					. "</tt>.<br />\n";
 			}
 
-			$this->stack[] = Array(
+			$this->stack[] = [
 				BBCODE_STACK_TOKEN => $this->lexer->token,
 				BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 				BBCODE_STACK_TAG => $this->lexer->tag,
 				BBCODE_STACK_CLASS => ($this->current_class = $newclass),
-			);
+			];
 
 			if (!isset($this->start_tags[$tag_name]))
-				$this->start_tags[$tag_name] = Array(count($this->stack)-1);
+				$this->start_tags[$tag_name] = [count($this->stack)-1];
 			else $this->start_tags[$tag_name][] = count($this->stack)-1;
 		}
 
@@ -1843,12 +1843,12 @@
 					$this->lost_start_tags[$tag_name]--;
 				}
 				else {
-					$this->stack[] = Array(
+					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_TEXT,
 						BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
-					);
+					];
 				}
 				return;
 			}
@@ -1874,12 +1874,12 @@
 					. htmlspecialchars($output) . "</tt><br />\n";
 			}
 
-			$this->stack[] = Array(
+			$this->stack[] = [
 				BBCODE_STACK_TOKEN => BBCODE_TEXT,
 				BBCODE_STACK_TEXT => $output,
 				BBCODE_STACK_TAG => false,
 				BBCODE_STACK_CLASS => $this->current_class,
-			);
+			];
 		}
 
 		//-----------------------------------------------------------------------------
@@ -1945,13 +1945,13 @@
 			// The token stack is used to perform a document-tree walk without actually
 			// building the document tree, and is an essential component of our input-
 			// validation algorithm.
-			$this->stack = Array();
+			$this->stack = [];
 
 			// There are no start tags (yet).
-			$this->start_tags = Array();
+			$this->start_tags = [];
 
 			// There are no unmatched start tags (yet).
-			$this->lost_start_tags = Array();
+			$this->lost_start_tags = [];
 
 			// There is no text yet.
 			$this->text_length = 0;
@@ -1995,12 +1995,12 @@
 							$this->output_limit - $this->text_length);
 						if (strlen($text) > 0) {
 							$this->text_length += strlen($text);
-							$this->stack[] = Array(
+							$this->stack[] = [
 								BBCODE_STACK_TOKEN => BBCODE_TEXT,
 								BBCODE_STACK_TEXT => $this->FixupOutput($text),
 								BBCODE_STACK_TAG => false,
 								BBCODE_STACK_CLASS => $this->current_class,
-							);
+							];
 						}
 						$this->Internal_DoLimit();
 						break 2;
@@ -2008,12 +2008,12 @@
 					$this->text_length += strlen($this->lexer->text);
 
 					// Push this text token onto the stack.
-					$this->stack[] = Array(
+					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_TEXT,
 						BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
-					);
+					];
 					break;
 
 				case BBCODE_WS:
@@ -2031,12 +2031,12 @@
 					$this->text_length += strlen($this->lexer->text);
 
 					// Push this whitespace onto the stack.
-					$this->stack[] = Array(
+					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_WS,
 						BBCODE_STACK_TEXT => $this->lexer->text,
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
-					);
+					];
 					break;
 
 				case BBCODE_NL:
@@ -2063,12 +2063,12 @@
 						// input:  For example, a "\r\n" input will produce a "\n" output; but
 						// this should still be acceptable, since we're working with text, not
 						// binary data.
-						$this->stack[] = Array(
+						$this->stack[] = [
 							BBCODE_STACK_TOKEN => BBCODE_WS,
 							BBCODE_STACK_TEXT => "\n",
 							BBCODE_STACK_TAG => false,
 							BBCODE_STACK_CLASS => $this->current_class,
-						);
+						];
 					}
 					else {
 						// Any whitespace before a newline isn't worth outputting, so if there's
@@ -2088,12 +2088,12 @@
 						$this->text_length += 1;
 
 						// Add the newline to the stack.
-						$this->stack[] = Array(
+						$this->stack[] = [
 							BBCODE_STACK_TOKEN => BBCODE_NL,
 							BBCODE_STACK_TEXT => $newline,
 							BBCODE_STACK_TAG => false,
 							BBCODE_STACK_CLASS => $this->current_class,
-						);
+						];
 
 						// Any whitespace after a newline is meaningless, so if there's whitespace
 						// lingering on the input after this, remove it now.

--- a/plugins/NBBC/nbbc/test_nbbc.php
+++ b/plugins/NBBC/nbbc/test_nbbc.php
@@ -85,255 +85,255 @@ h1 { text-align: center; }
 	require_once("src/nbbc_main.php");		// Expanded version.
 	//require_once("nbbc.php");				// Condensed version.
 
-	$BBCodeTestSuite = Array(
+	$BBCodeTestSuite = [
 
 		//-----------------------------------------------------------------------------------------
 
 		"Input Validation Tests",
-		Array(
+		[
 			'descr' => "Unknown tags like [foo] get ignored.",
 			'bbcode' => "This is [foo]a tag[/foo].",
 			'html' => "This is [foo]a tag[/foo].",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken tags like [foo get ignored.",
 			'bbcode' => "This is [foo a tag.",
 			'html' => "This is [foo a tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken tags like [/foo get ignored.",
 			'bbcode' => "This is [/foo a tag.",
 			'html' => "This is [/foo a tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken tags like [] get ignored.",
 			'bbcode' => "This is [] a tag.",
 			'html' => "This is [] a tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken tags like [/  ] get ignored.",
 			'bbcode' => "This is [/  ] a tag.",
 			'html' => "This is [/  ] a tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken tags like [/ get ignored.",
 			'bbcode' => "This is [/ a tag.",
 			'html' => "This is [/ a tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken [ tags before [b]real tags[/b] don't break the real tags.",
 			'bbcode' => "Broken [ tags before [b]real tags[/b] don't break the real tags.",
 			'html' => "Broken [ tags before <b>real tags</b> don't break the real tags.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Broken [tags before [b]real tags[/b] don't break the real tags.",
 			'bbcode' => "Broken [tags before [b]real tags[/b] don't break the real tags.",
 			'html' => "Broken [tags before <b>real tags</b> don't break the real tags.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[i][b]Mis-ordered nesting[/i][/b] gets fixed.",
 			'bbcode' => "[i][b]Mis-ordered nesting[/i][/b] gets fixed.",
 			'html' => "<i><b>Mis-ordered nesting</b></i> gets fixed.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=][b]Mis-ordered nesting[/url][/b] gets fixed.",
 			'bbcode' => "[url=http://www.google.com][b]Mis-ordered nesting[/url][/b] gets fixed.",
 			'html' => "<a href=\"http://www.google.com\" class=\"bbcode_url\"><b>Mis-ordered nesting</b></a> gets fixed.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[i]Unended blocks are automatically ended.",
 			'bbcode' => "[i]Unended blocks are automatically ended.",
 			'html' => "<i>Unended blocks are automatically ended.</i>",
-		),
-		Array(
+		],
+		[
 			'descr' => "Unstarted blocks[/i] have their end tags ignored.",
 			'bbcode' => "Unstarted blocks[/i] have their end tags ignored.",
 			'html' => "Unstarted blocks[/i] have their end tags ignored.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[b]Mismatched tags[/i] are not matched to each other.",
 			'bbcode' => "[b]Mismatched tags[/i] are not matched to each other.",
 			'html' => "<b>Mismatched tags[/i] are not matched to each other.</b>",
-		),
-		Array(
+		],
+		[
 			'descr' => "[center]Inlines and [b]blocks get[/b] nested correctly[/center].",
 			'bbcode' => "[center]Inlines and [b]blocks get[/b] nested correctly[/center].",
 			'html' => "\n<div class=\"bbcode_center\" style=\"text-align:center\">\nInlines and <b>blocks get</b> nested correctly\n</div>\n.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[b]Inlines and [center]blocks get[/center] nested correctly[/b].",
 			'bbcode' => "[b]Inlines and [center]blocks get[/center] nested correctly[/b].",
 			'html' => "<b>Inlines and </b>\n<div class=\"bbcode_center\" style=\"text-align:center\">\nblocks get\n</div>\nnested correctly.",
-		),
-		Array(
+		],
+		[
 			'descr' => "BBCode is [B]case-insensitive[/b].",
 			'bbcode' => "[cEnTeR][b]This[/B] is a [I]test[/i].[/CeNteR]",
 			'html' => "\n<div class=\"bbcode_center\" style=\"text-align:center\">\n<b>This</b> is a <i>test</i>.\n</div>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "Plain text gets passed through unchanged.",
 			'bbcode' => "Plain text gets passed through unchanged.  b is not a tag and i is not a tag and neither is /i and neither is (b).",
 			'html' => "Plain text gets passed through unchanged.  b is not a tag and i is not a tag and neither is /i and neither is (b).",
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Special-Character Tests",
-		Array(
+		[
 			'descr' => "& and < and > and \" get replaced with HTML-safe equivalents.",
 			'bbcode' => "This <woo!> &\"yeah!\" 'sizzle'",
 			'html' => "This &lt;woo!&gt; &amp;&quot;yeah!&quot; 'sizzle'",
-		),
-		Array(
+		],
+		[
 			'descr' => ":-) produces a smiley <img> element.",
 			'bbcode' => "This is a test of the emergency broadcasting system :-)",
 			'regex' => "/This is a test of the emergency broadcasting system <img src=\\\"smileys\\/smile.gif\\\" width=\\\"[0-9]*\\\" height=\\\"[0-9]*\\\" alt=\\\":-\\)\\\" title=\\\":-\\)\\\" class=\\\"bbcode_smiley\\\" \\/>/",
-		),
-		Array(
+		],
+		[
 			'descr' => "--- does *not* produce a [rule] tag.",
 			'bbcode' => "This is a test of the --- emergency broadcasting system.",
 			'html' => "This is a test of the --- emergency broadcasting system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "---- does *not* produce a [rule] tag.",
 			'bbcode' => "This is a test of the ---- emergency broadcasting system.",
 			'html' => "This is a test of the ---- emergency broadcasting system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "----- produces a [rule] tag.",
 			'bbcode' => "This is a test of the ----- emergency broadcasting system.",
 			'html' => "This is a test of the\n<hr class=\"bbcode_rule\" />\nemergency broadcasting system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "--------- produces a [rule] tag.",
 			'bbcode' => "This is a test of the --------- emergency broadcasting system.",
 			'html' => "This is a test of the\n<hr class=\"bbcode_rule\" />\nemergency broadcasting system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[-] does *not* produce a comment.",
 			'bbcode' => "This is a test of the [- emergency broadcasting] system.",
 			'html' => "This is a test of the [- emergency broadcasting] system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[--] produces a comment.",
 			'bbcode' => "This is a test of the [-- emergency broadcasting] system.",
 			'html' => "This is a test of the  system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[----] produces a comment.",
 			'bbcode' => "This is a test of the [---- emergency broadcasting] system.",
 			'html' => "This is a test of the  system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[--] comments may contain - and [ and \" and ' characters.",
 			'bbcode' => "This is a test of the [-- emergency - [ \" ' broadcasting] system.",
 			'html' => "This is a test of the  system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[--] comments may *not* contain newlines.",
 			'bbcode' => "This is a test of the [-- emergency\n\rbroadcasting] system.",
 			'html' => "This is a test of the [-- emergency<br />\nbroadcasting] system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "['] produces a comment.",
 			'bbcode' => "This is a test of the ['emergency broadcasting] system.",
 			'html' => "This is a test of the  system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "['] comments may contain [ and \" and ' characters.",
 			'bbcode' => "This is a test of the ['emergency [ \" ' broadcasting] system.",
 			'html' => "This is a test of the  system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "['] comments may *not* contain newlines.",
 			'bbcode' => "This is a test of the [' emergency\n\rbroadcasting] system.",
 			'html' => "This is a test of the [' emergency<br />\nbroadcasting] system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[!-- --] produces a comment.",
 			'bbcode' => "This is a test of the [!-- emergency broadcasting --] system.",
 			'html' => "This is a test of the  system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[!-- ] does *not* produce a viable comment.",
 			'bbcode' => "This is a test of the [!-- emergency broadcasting ] system.",
 			'html' => "This is a test of the [!-- emergency broadcasting ] system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[!-- - -- ] [ --] produces a comment.",
 			'bbcode' => "This is a test of the [!-- emergency - broadcasting -- system ] thingy --].",
 			'html' => "This is a test of the .",
-		),
-		Array(
+		],
+		[
 			'descr' => "[!-- - -- ] [ --] --] produces a comment with a --] left over.",
 			'bbcode' => "This is a test of the [!-- emergency - broadcasting -- system ] thingy --] and other --] stuff.",
 			'html' => "This is a test of the  and other --] stuff.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[!-- --] does not break any following tags outside it.",
 			'bbcode' => "The [!-- quick brown --]fox jumps over the [b]lazy[/b] [i]dog[/i].",
 			'html' => "The fox jumps over the <b>lazy</b> <i>dog</i>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Tag marker mode '<' works correctly.",
 			'bbcode' => "This is <b>a <i>test</b></i>.",
 			'html' => "This is <b>a <i>test</i></b>.",
 			'tag_marker' => '<',
-		),
-		Array(
+		],
+		[
 			'descr' => "Tag marker mode '{' works correctly.",
 			'bbcode' => "This is {b}a {i}test{/b}{/i}.",
 			'html' => "This is <b>a <i>test</i></b>.",
 			'tag_marker' => '{',
-		),
-		Array(
+		],
+		[
 			'descr' => "Tag marker mode '(' works correctly.",
 			'bbcode' => "This is (b)a (i)test(/b)(/i).",
 			'html' => "This is <b>a <i>test</i></b>.",
 			'tag_marker' => '(',
-		),
-		Array(
+		],
+		[
 			'descr' => "Ampersand pass-through mode works correctly.",
 			'bbcode' => "This is <b>a <i>test</b></i> &amp; some junk.",
 			'html' => "This is <b>a <i>test</i></b> &amp; some junk.",
 			'tag_marker' => '<',
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Whitespace Tests",
-		Array(
+		[
 			'descr' => "Newlines get replaced with <br /> tags.",
 			'bbcode' => "This\nis\r\na\n\rtest.",
 			'html' => "This<br />\nis<br />\na<br />\ntest.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Newlines *don't* get replaced with <br /> tags in ignore-newline mode.",
 			'bbcode' => "This\nis\r\na\n\rtest.",
 			'html' => "This\nis\na\ntest.",
 			'newline_ignore' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Space before and after newlines gets removed.",
 			'bbcode' => "This \n \t is \na\n \x08test.",
 			'html' => "This<br />\nis<br />\na<br />\ntest.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Whitespace doesn't matter inside tags after the tag name.",
 			'bbcode' => "This [size = 4  ]is a test[/size ].",
 			'html' => "This <span style=\"font-size:1.17em\">is a test</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Whitespace does matter inside \"quotes\" in tags.",
 			'bbcode' => "This [wstest=\"  Courier   New  \"]is a test[/wstest].",
 			'html' => "This <span style=\"wstest:  Courier   New  \">is a test</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Whitespace does matter inside 'quotes' in tags.",
 			'bbcode' => "This [wstest='  Courier   New  ']is a test[/wstest].",
 			'html' => "This <span style=\"wstest:  Courier   New  \">is a test</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Whitespace is properly collapsed near block tags like [center].",
 			'bbcode' => "Not centered.    \n    \n    [center]    \n    \n    A bold stone gathers no italics.    \n    \n    [/center]    \n    \n    Not centered.",
 			'html' => "Not centered.<br />\n"
@@ -343,8 +343,8 @@ h1 { text-align: center; }
 				. "\n</div>\n"
 				. "<br />\n"
 				. "Not centered.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[code]...[/code] should strip whitespace outside it but not inside it.",
 			'bbcode' => "Not\ncode.\n"
 				. "[code]    \n\n    This is a test.    \n\n    [/code]\n"
@@ -355,322 +355,322 @@ h1 { text-align: center; }
 				. "<div class=\"bbcode_code_body\" style=\"white-space:pre\">\n    This is a test.    \n</div>\n"
 				. "</div>\n"
 				. "Also not code.<br />\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list] and [*] must consume correct quantities of whitespace.",
 			'bbcode' => "[list]\n\n\t[*] One Box\n\n\t[*] Two Boxes\n\t[*] \n Three Boxes\n\n[/list]\n",
 			'html' => "\n<ul class=\"bbcode_list\">\n<br />\n<li>One Box<br />\n</li>\n<li>Two Boxes</li>\n<li><br />\nThree Boxes<br />\n</li>\n</ul>\n",
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Inline Tag Conversion Tests",
-		Array(
+		[
 			'descr' => "[i] gets correctly converted.",
 			'bbcode' => "This is a test of the [i]emergency broadcasting system[/i].",
 			'html' => "This is a test of the <i>emergency broadcasting system</i>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[b] gets correctly converted.",
 			'bbcode' => "This is a test of the [b]emergency broadcasting system[/b].",
 			'html' => "This is a test of the <b>emergency broadcasting system</b>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[u] gets correctly converted.",
 			'bbcode' => "This is a test of the [u]emergency broadcasting system[/u].",
 			'html' => "This is a test of the <u>emergency broadcasting system</u>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[s] gets correctly converted.",
 			'bbcode' => "This is a test of the [s]emergency broadcasting system[/s].",
 			'html' => "This is a test of the <strike>emergency broadcasting system</strike>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[sup] gets correctly converted.",
 			'bbcode' => "This is a test of the [sup]emergency broadcasting system[/sup].",
 			'html' => "This is a test of the <sup>emergency broadcasting system</sup>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[sub] gets correctly converted.",
 			'bbcode' => "This is a test of the [sub]emergency broadcasting system[/sub].",
 			'html' => "This is a test of the <sub>emergency broadcasting system</sub>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[font=Arial] gets correctly converted (simple font name).",
 			'bbcode' => "This is a test of the [font=Arial]emergency broadcasting system[/font].",
 			'html' => "This is a test of the <span style=\"font-family:'Arial'\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[font=Times New Roman] gets correctly converted (unquoted default value).",
 			'bbcode' => "This is a test of the [font=Times New Roman]emergency broadcasting system[/font].",
 			'html' => "This is a test of the <span style=\"font-family:'Times New Roman'\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[font=Times New Roman size=1] gets converted (trailing parameter identified).",
 			'bbcode' => "This is a test of the [font=Times New Roman size=1]emergency broadcasting system[/font].",
 			'html' => "This is a test of the <span style=\"font-family:'Times New Roman'\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[font=\"Courier New\"] gets correctly converted (quoted default value).",
 			'bbcode' => "This is a test of the [font=\"Courier New\"]emergency broadcasting system[/font].",
 			'html' => "This is a test of the <span style=\"font-family:'Courier New'\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[font=\"Courier New\" blarg size=1] gets converted (floating parameter ignored).",
 			'bbcode' => "This is a test of the [font=\"Courier New\" blarg size=1]emergency broadcasting system[/font].",
 			'html' => "This is a test of the <span style=\"font-family:'Courier New'\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[size=6] gets correctly converted.",
 			'bbcode' => "This is a test of the [size=6]emergency broadcasting system[/size].",
 			'html' => "This is a test of the <span style=\"font-size:2.0em\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[size=10] gets correctly converted.",
 			'bbcode' => "This is a test of the [size=10]emergency broadcasting system[/size].",
 			'html' => "This is a test of the <span style=\"font-size:1.0em\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[size=blah] gets ignored.",
 			'bbcode' => "This is a test of the [size=blah]emergency broadcasting system[/size].",
 			'html' => "This is a test of the [size=blah]emergency broadcasting system[/size].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[color=red] gets correctly converted.",
 			'bbcode' => "This is a test of the [color=red]emergency broadcasting system[/color].",
 			'html' => "This is a test of the <span style=\"color:red\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[color=gronk] gets correctly converted.",
 			'bbcode' => "This is a test of the [color=gronk]emergency broadcasting system[/color].",
 			'html' => "This is a test of the <span style=\"color:gronk\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[color=#FFF] gets correctly converted.",
 			'bbcode' => "This is a test of the [color=#FFF]emergency broadcasting system[/color].",
 			'html' => "This is a test of the <span style=\"color:#FFF\">emergency broadcasting system</span>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[color=*#\$] is prohibited.",
 			'bbcode' => "This is a test of the [color=*#\$]emergency broadcasting system[/color].",
 			'html' => "This is a test of the [color=*#\$]emergency broadcasting system[/color].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[spoiler] gets converted.",
 			'bbcode' => "Ssh, don't tell, but [spoiler]Darth is Luke's father[/spoiler]!",
 			'html' => "Ssh, don't tell, but <span class=\"bbcode_spoiler\">Darth is Luke's father</span>!",
-		),
-		Array(
+		],
+		[
 			'descr' => "[acronym] gets converted.",
 			'bbcode' => "The [acronym=\"British Broadcasting Company\"]BBC[/acronym] airs [i]Doctor Who[/i] on Saturdays.",
 			'html' => "The <span class=\"bbcode_acronym\" title=\"British Broadcasting Company\">BBC</span> airs <i>Doctor Who</i> on Saturdays.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[acronym] safely encodes its content.",
 			'bbcode' => "The [acronym=_\"><script>alert(/XSS/.source)</script><x]Foo[/acronym] is safe.",
 			'html' => "The <span class=\"bbcode_acronym\" title=\"_&quot;&gt;&lt;script&gt;alert(/XSS/.source)&lt;/script&gt;&lt;x\">Foo</span> is safe.",
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"URL Tests",
-		Array(
+		[
 			'descr' => "[url=...] (with no protocol given) gets converted.",
 			'bbcode' => "This is a test of the [url=fleeb.html]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"fleeb.html\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=http:...] gets converted.",
 			'bbcode' => "This is a test of the [url=http://www.google.com]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"http://www.google.com\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=http:...] gets converted correctly in plain mode.",
 			'bbcode' => "This is a test of the [url=http://www.google.com]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"http://www.google.com\">emergency broadcasting system</a>.",
 			'plainmode' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Unquoted [url=http:...] with parameters gets converted.",
 			'bbcode' => "This is a test of the [url=http://www.google.com?q=broadcasting&y=foo&x=bar]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"http://www.google.com?q=broadcasting&amp;y=foo&amp;x=bar\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=https:...] gets converted.",
 			'bbcode' => "This is a test of the [url=https://www.google.com]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"https://www.google.com\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=ftp:...] gets converted.",
 			'bbcode' => "This is a test of the [url=ftp://www.google.com]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"ftp://www.google.com\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=mailto:...] gets converted.",
 			'bbcode' => "This is a test of the [url=mailto:john@example.com]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"mailto:john@example.com\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=javascript:...] is prohibited.",
 			'bbcode' => "This is a test of the [url=javascript:alert()]emergency broadcasting system[/url].",
 			'html' => "This is a test of the [url=javascript:alert()]emergency broadcasting system[/url].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=(unknown protocol):...] is prohibited.",
 			'bbcode' => "This is a test of the [url=flooble:blarble]emergency broadcasting system[/url].",
 			'html' => "This is a test of the [url=flooble:blarble]emergency broadcasting system[/url].",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [url]http://...[/url] form works correctly.",
 			'bbcode' => "The [url]http://www.google.com[/url] form works correctly.",
 			'html' => "The <a href=\"http://www.google.com\" class=\"bbcode_url\">http://www.google.com</a> form works correctly.",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [url]http://...[/url] form works correctly in plain mode.",
 			'bbcode' => "The [url]http://www.google.com[/url] form works correctly.",
 			'html' => "The <a href=\"http://www.google.com\">http://www.google.com</a> form works correctly.",
 			'plainmode' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "The [url]malformed...url...[/url] form is fully unprocessed.",
 			'bbcode' => "The [url]a.imagehost.org/view/egdgdo[/url] form is fully unprocessed.",
 			'html' => "The <a href=\"a.imagehost.org/view/egdgdo\" class=\"bbcode_url\">a.imagehost.org/view/egdgdo</a> form is fully unprocessed.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=\"...=...\"] contains an embedded equal sign (quotes work correctly).",
 			'bbcode' => "The [url=\"http://www.google.com/?foo=bar&baz=frob\" bar=foo]link[/url] works correctly.",
 			'html' => "The <a href=\"http://www.google.com/?foo=bar&amp;baz=frob\" class=\"bbcode_url\">link</a> works correctly.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=\"...=...\"] contains an embedded equal sign (test #2).",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\"]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\">Opinion</a> is funny.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=\"...\" target=\"...\"] has its target ignored by default.",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\" target=_blank]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\">Opinion</a> is funny.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=\"...\" target=\"...\"] has its target used when URL targeting is enabled.",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\" target=_blank]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\" target=\"_blank\">Opinion</a> is funny.",
 			'urltarget' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "[url] has a target applied when forced URL targeting is enabled.",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\"]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\" target=\"somewhere\">Opinion</a> is funny.",
 			'urlforcetarget' => "somewhere",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url target=\"...\"] has its target ignored when forced URL targeting is enabled.",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\" target=\"_blank\"]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\" target=\"somewhere\">Opinion</a> is funny.",
 			'urlforcetarget' => "somewhere",
-		),
-		Array(
+		],
+		[
 			'descr' => "[url] has a target applied even with URL target overriding.",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\"]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\" target=\"somewhere\">Opinion</a> is funny.",
 			'urlforcetarget' => "somewhere",
 			'urltarget' => 'override',
-		),
-		Array(
+		],
+		[
 			'descr' => "[url target=\"...\"] has its target applied with URL target overriding.",
 			'bbcode' => "The [url=\"http://www.demourl.com/opinion.php?idopinion=234\" target=\"_blank\"]Opinion[/url] is funny.",
 			'html' => "The <a href=\"http://www.demourl.com/opinion.php?idopinion=234\" class=\"bbcode_url\" target=\"_blank\">Opinion</a> is funny.",
 			'urlforcetarget' => "somewhere",
 			'urltarget' => 'override',
-		),
-		Array(
+		],
+		[
 			'descr' => "[url=(includes a smiley)] is not converted into a smiley.",
 			'bbcode' => "This is a test of the [url=http://www.google.com/foo:-P]emergency broadcasting system[/url].",
 			'html' => "This is a test of the <a href=\"http://www.google.com/foo:-P\" class=\"bbcode_url\">emergency broadcasting system</a>.",
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Embedded URL Tests",
-		Array(
+		[
 			'descr' => "Embedded URLs get detected and converted.",
 			'bbcode' => "Go to http://www.google.com for your search needs!",
 			'html' => "Go to <a href=\"http://www.google.com/\">http://www.google.com</a> for your search needs!",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded HTTPS URLs get detected and converted.",
 			'bbcode' => "Go to https://www.google.com for your search needs!",
 			'html' => "Go to <a href=\"https://www.google.com/\">https://www.google.com</a> for your search needs!",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded FTP URLs get detected and converted.",
 			'bbcode' => "Go to ftp://www.google.com for your search needs!",
 			'html' => "Go to <a href=\"ftp://www.google.com/\">ftp://www.google.com</a> for your search needs!",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded Javascript URLs are properly ignored.",
 			'bbcode' => "Go to javascript:foo.com;alert(); for your search needs!",
 			'html' => "Go to javascript:<a href=\"http://foo.com/\">foo.com</a>;alert(); for your search needs!",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded domain names get detected and converted.",
 			'bbcode' => "Go to www.google.com for your search needs!",
 			'html' => "Go to <a href=\"http://www.google.com/\">www.google.com</a> for your search needs!",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded IPs get detected and converted.",
 			'bbcode' => "Go to 127.0.0.1:667/flarb for your own computer!",
 			'html' => "Go to <a href=\"http://127.0.0.1:667/flarb\">127.0.0.1:667/flarb</a> for your own computer!",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded addresses are smart about being inside parentheses.",
 			'bbcode' => "I love Google! (google.com)",
 			'html' => "I love Google! (<a href=\"http://google.com/\">google.com</a>)",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded-URL detector disallows junk that only seems like a URL.",
 			'bbcode' => "I browse alt.net.screw-you:80/flarb all the time.",
 			'html' => "I browse alt.net.screw-you:80/flarb all the time.",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded-URL detector also detects e-mail addresses.",
 			'bbcode' => "Send complaints to complaints@whitehouse.gov .",
 			'html' => "Send complaints to <a href=\"mailto:complaints@whitehouse.gov\">complaints@whitehouse.gov</a> .",
 			'detect_urls' => true,
-		),
-		Array(
+		],
+		[
 			'descr' => "Embedded-URL detector takes precedence over the smiley detector.",
 			'bbcode' => "This is a good dictionary:  http://www.amazon.com/Oxford-Dictionary-American-Usage-Style/dp/0195135083/ref=pd_bbs_sr_1?ie=UTF8&s=books&qid=1217890161&sr=8-1&x=p",
 			'html' => "This is a good dictionary:  <a href=\"http://www.amazon.com/Oxford-Dictionary-American-Usage-Style/dp/0195135083/ref=pd_bbs_sr_1?ie=UTF8&amp;s=books&amp;qid=1217890161&amp;sr=8-1&amp;x=p\">http://www.amazon.com/Oxford-Dictionary-American-Usage-Style/dp/0195135083/ref=pd_bbs_sr_1?ie=UTF8&amp;s=books&amp;qid=1217890161&amp;sr=8-1&amp;x=p</a>",
 			'detect_urls' => true,
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Special URL-Like-Tag Tests",
-		Array(
+		[
 			'descr' => "[email] gets converted.",
 			'bbcode' => "Send complaints to [email]john@example.com[/email].",
 			'html' => "Send complaints to <a href=\"mailto:john@example.com\" class=\"bbcode_email\">john@example.com</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[email] supports both forms.",
 			'bbcode' => "Send complaints to [email=john@example.com]John Smith[/email].",
 			'html' => "Send complaints to <a href=\"mailto:john@example.com\" class=\"bbcode_email\">John Smith</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Bad addresses in [email] are ignored.",
 			'bbcode' => "Send complaints to [email]jo\"hn@@@exa:mple.com[/email].",
 			'html' => "Send complaints to [email]jo&quot;hn@@@exa:mple.com[/email].",
-		),
+		],
 /*
 		Array(
 			'descr' => "[video=youtube] gets converted.",
@@ -698,100 +698,100 @@ h1 { text-align: center; }
 			'html' => "Watch this cute doggy!!! <object width=\"320\" height=\"240\"><param name=\"movie\" value=\"http://www.youtube.com/v/dQw4w9WgXcQ&hl=en_US&fs=1&\"></param><param name=\"allowFullScreen\" value=\"true\"></param><param name=\"allowscriptaccess\" value=\"always\"></param><embed src=\"http://www.youtube.com/v/dQw4w9WgXcQ&hl=en_US&fs=1&\" type=\"application/x-shockwave-flash\" allowscriptaccess=\"always\" allowfullscreen=\"true\" width=\"320\" height=\"240\"></embed></object>",
 		),
 */
-		Array(
+		[
 			'descr' => "The [[wiki]] special tag produces a wiki link.",
 			'bbcode' => "This is a test of the [[wiki]] tag.",
 			'html' => "This is a test of the <a href=\"/?page=wiki\" class=\"bbcode_wiki\">wiki</a> tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [[wiki]] special tag does not convert [a-zA-Z0-9'\".:_-].",
 			'bbcode' => "This is a test of the [[\"Ab1cd'Ef2gh_Ij3kl.,Mn4op:Qr9st-Uv0wx\"]] tag.",
 			'html' => "This is a test of the <a href=\"/?page=%22Ab1cd%27Ef2gh_Ij3kl.%2CMn4op%3AQr9st_Uv0wx%22\" class=\"bbcode_wiki\">&quot;Ab1cd'Ef2gh_Ij3kl.,Mn4op:Qr9st-Uv0wx&quot;</a> tag.",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [[wiki]] special tag can contain spaces.",
 			'bbcode' => "This is a test of the [[northwestern salmon]].",
 			'html' => "This is a test of the <a href=\"/?page=northwestern_salmon\" class=\"bbcode_wiki\">northwestern salmon</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [[wiki]] special tag cannot contain newlines.",
 			'bbcode' => "This is a test of the [[northwestern\nsalmon]].",
 			'html' => "This is a test of the [[northwestern<br />\nsalmon]].",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [[wiki]] special tag can contain a title after a | character.",
 			'bbcode' => "This is a test of the [[northwestern salmon|Northwestern salmon are yummy!]].",
 			'html' => "This is a test of the <a href=\"/?page=northwestern_salmon\" class=\"bbcode_wiki\">Northwestern salmon are yummy!</a>.",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [[wiki]] special tag doesn't damage anything outside it.",
 			'bbcode' => "I really loved reading [[arc 1|the first story arc]] because it was more entertaining than [[arc 2|the second story arc]] was.",
 			'html' => "I really loved reading <a href=\"/?page=arc_1\" class=\"bbcode_wiki\">the first story arc</a> because it was more entertaining than <a href=\"/?page=arc_2\" class=\"bbcode_wiki\">the second story arc</a> was.",
-		),
-		Array(
+		],
+		[
 			'descr' => "The [[wiki]] special tag condenses and trims internal whitespace.",
 			'bbcode' => "This is a test of the [[  northwestern \t salmon   |   Northwestern   salmon are   yummy!  ]].",
 			'html' => "This is a test of the <a href=\"/?page=northwestern_salmon\" class=\"bbcode_wiki\">Northwestern   salmon are   yummy!</a>.",
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Images and Replaced-Tag Conversion Tests",
-		Array(
+		[
 			'descr' => "[img] produces an image.",
 			'bbcode' => "This is Google's logo: [img]http://www.google.com/intl/en_ALL/images/logo.gif[/img].",
 			'html' => "This is Google's logo: <img src=\"http://www.google.com/intl/en_ALL/images/logo.gif\" alt=\"logo.gif\" class=\"bbcode_img\" />.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] disallows a javascript: URL.",
 			'bbcode' => "This is Google's logo: [img]javascript:alert()[/img].",
 			'html' => "This is Google's logo: [img]javascript:alert()[/img].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] disallows a URL with an unknown protocol type.",
 			'bbcode' => "This is Google's logo: [img]foobar:bar.jpg[/img].",
 			'html' => "This is Google's logo: [img]foobar:bar.jpg[/img].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] disallows HTML content.",
 			'bbcode' => "This is Google's logo: [img]<a href='javascript:alert(\"foo\")'>click me</a>[/img].",
 			'html' => "This is Google's logo: [img]&lt;a href='javascript:alert(&quot;foo&quot;)'&gt;click me&lt;/a&gt;[/img].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] can produce a local image.",
 			'bbcode' => "This is a smiley: [img]smile.gif[/img].",
 			'html' => "This is a smiley: <img src=\"smileys/smile.gif\" alt=\"smile.gif\" width=\"16\" height=\"16\" class=\"bbcode_img\" />.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] can produce a local rooted URL.",
 			'bbcode' => "This is a smiley: [img]/smile.gif[/img].",
 			'html' => "This is a smiley: <img src=\"/smile.gif\" alt=\"smile.gif\" class=\"bbcode_img\" />.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] can produce a local relative URL.",
 			'bbcode' => "This is a smiley: [img]../smile.gif[/img].",
 			'html' => "This is a smiley: <img src=\"../smile.gif\" alt=\"smile.gif\" class=\"bbcode_img\" />.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[img] will skip nonexistent local images.",
 			'bbcode' => "This is a smiley: [img]flarb.gif[/img].",
 			'html' => "This is a smiley: [img]flarb.gif[/img].",
-		),
-		Array(
+		],
+		[
 			'descr' => "[rule] produces a horizontal rule.",
 			'bbcode' => "This is a test of the [rule] emergency broadcasting system.",
 			'html' => "This is a test of the\n<hr class=\"bbcode_rule\" />\nemergency broadcasting system.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[br] is equivalent to a newline.",
 			'bbcode' => "This is a newline.    [br]    And here we are!    \n  And more!",
 			'html' => "This is a newline.<br />\nAnd here we are!<br />\nAnd more!",
-		),
+		],
 
 		//-----------------------------------------------------------------------------------------
 
 		"Block Tag Conversion Tests",
-		Array(
+		[
 			'descr' => "[center]...[/center] should produce centered alignment.",
 			'bbcode' => "Not centered.[center]A [b]bold[/b] stone gathers no italics.[/center]Not centered.",
 			'html' => "Not centered.\n"
@@ -799,8 +799,8 @@ h1 { text-align: center; }
 				. "A <b>bold</b> stone gathers no italics.\n"
 				. "</div>\n"
 				. "Not centered.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[left]...[/left] should produce left alignment.",
 			'bbcode' => "Not left.[left]A [b]bold[/b] stone gathers no italics.[/left]Not left.",
 			'html' => "Not left.\n"
@@ -808,8 +808,8 @@ h1 { text-align: center; }
 				. "A <b>bold</b> stone gathers no italics.\n"
 				. "</div>\n"
 				. "Not left.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[right]...[/right] should produce right alignment.",
 			'bbcode' => "Not right.[right]A [b]bold[/b] stone gathers no italics.[/right]Not right.",
 			'html' => "Not right.\n"
@@ -817,8 +817,8 @@ h1 { text-align: center; }
 				. "A <b>bold</b> stone gathers no italics.\n"
 				. "</div>\n"
 				. "Not right.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[indent]...[/indent] should produce indented content.",
 			'bbcode' => "Not indented.[indent]A [b]bold[/b] stone gathers no italics.[/indent]Not indented.",
 			'html' => "Not indented.\n"
@@ -826,8 +826,8 @@ h1 { text-align: center; }
 				. "A <b>bold</b> stone gathers no italics.\n"
 				. "</div>\n"
 				. "Not indented.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[code]...[/code] should reproduce its contents exactly as they're given.",
 			'bbcode' => "Not code."
 				. "[code]A [b]and[/b] & <woo>!\n\tAnd a ['hey'] and a [/nonny] and a ho ho ho![/code]"
@@ -839,8 +839,8 @@ h1 { text-align: center; }
 					. "\tAnd a ['hey'] and a [/nonny] and a ho ho ho!</div>\n"
 				. "</div>\n"
 				. "Also not code.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[code]...[/code] should reproduce PHP source code undamaged.",
 			'bbcode' => "Not code.\n"
 				. "[code]\n"
@@ -855,8 +855,8 @@ h1 { text-align: center; }
 					. "if (\$foo[&quot;bar&quot;] &lt; 42) \$foo[] = 0;</div>\n"
 				. "</div>\n"
 				. "Also not code.<br />\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "<code>...</code> should not misbehave in '<' tag marker mode.",
 			'bbcode' => "Not code."
 				. "<code>A <b>and</b> & <woo>!\n\tAnd a [hey] and a [/nonny] and a ho ho ho!</code>"
@@ -869,8 +869,8 @@ h1 { text-align: center; }
 				. "</div>\n"
 				. "Also not code.",
 			'tag_marker' => '<',
-		),
-		Array(
+		],
+		[
 			'descr' => "[quote]...[/quote] should produce a plain quote.",
 			'bbcode' => "Outside the quote."
 				. "[quote]A [b]and[/b] & <woo>!\n\tAnd a [hey] and a [/nonny] and a ho ho ho![/quote]"
@@ -882,8 +882,8 @@ h1 { text-align: center; }
 					. "And a [hey] and a [/nonny] and a ho ho ho!</div>\n"
 				. "</div>\n"
 				. "Also outside the quote.",
-		),
-		Array(
+		],
+		[
 			'descr' => "Multiple nested [quote]...[/quote] tags should produce nested quotes.",
 			'bbcode' => "text0\n[quote]\n[quote]\n[quote]text1[/quote]\ntext2[/quote]\ntext3[/quote]\ntext4",
 			'html' => "text0"
@@ -906,8 +906,8 @@ h1 { text-align: center; }
 				. "</div>\n"
 				. "</div>\n"
 				. "text4",
-		),
-		Array(
+		],
+		[
 			'descr' => "Multiple nested [quote]...[/quote] tags should produce nested quotes.",
 			'bbcode' => "[quote]\n[quote]\n[quote]text1[/quote]\ntext2[/quote]\ntext3[/quote]\ntext4 :) text5 :o text6 :o",
 			'html' => "\n<div class=\"bbcode_quote\">\n"
@@ -929,8 +929,8 @@ h1 { text-align: center; }
 				. "</div>\n"
 				. "</div>\n"
 				. "text4 <img src=\"smileys/smile.gif\" width=\"16\" height=\"16\" alt=\":)\" title=\":)\" class=\"bbcode_smiley\" /> text5 :o text6 :o",
-		),
-		Array(
+		],
+		[
 			'descr' => "[quote=John]...[/quote] should produce a quote from John.",
 			'bbcode' => "Outside the quote."
 				. "[quote=John]A [b]and[/b] & <woo>!\n\tAnd a [hey] and a [/nonny] and a ho ho ho![/quote]"
@@ -942,8 +942,8 @@ h1 { text-align: center; }
 					. "And a [hey] and a [/nonny] and a ho ho ho!</div>\n"
 				. "</div>\n"
 				. "Also outside the quote.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[quote=\"John Smith\"]...[/quote] should produce a quote from John Smith.",
 			'bbcode' => "Outside the quote."
 				. "[quote=\"John Smith\"]A [b]and[/b] & <woo>!\n\tAnd a [hey] and a [/nonny] and a ho ho ho![/quote]"
@@ -955,8 +955,8 @@ h1 { text-align: center; }
 					. "And a [hey] and a [/nonny] and a ho ho ho!</div>\n"
 				. "</div>\n"
 				. "Also outside the quote.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[quote name= date= url=]...[/quote] should produce a detailed quote.",
 			'bbcode' => "Outside the quote."
 				. "[quote name=\"John Smith\" date=\"July 4, 1776\" url=\"http://www.constitution.gov\"]We hold these truths to be self-evident...[/quote]"
@@ -967,8 +967,8 @@ h1 { text-align: center; }
 				. "<div class=\"bbcode_quote_body\">We hold these truths to be self-evident...</div>\n"
 				. "</div>\n"
 				. "Also outside the quote.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[quote name= date= url=]...[/quote] should disallow bad URLs.",
 			'bbcode' => "Outside the quote."
 				. "[quote name=\"John Smith\" date=\"July 4, 1776\" url=\"javascript:alert()\"]We hold these truths to be self-evident...[/quote]"
@@ -979,8 +979,8 @@ h1 { text-align: center; }
 				. "<div class=\"bbcode_quote_body\">We hold these truths to be self-evident...</div>\n"
 				. "</div>\n"
 				. "Also outside the quote.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[quote=\"<script>javascript:alert()</script>\"] should not produce Javascript.",
 			'bbcode' => "Outside the quote."
 				. "[quote=\"<script>javascript:alert()</script>\"]A [b]and[/b] & <woo>!\n\tAnd a [hey] and a [/nonny] and a ho ho ho![/quote]"
@@ -992,8 +992,8 @@ h1 { text-align: center; }
 					. "And a [hey] and a [/nonny] and a ho ho ho!</div>\n"
 				. "</div>\n"
 				. "Also outside the quote.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[columns] should produce columns.",
 			'bbcode' => "Before the columns."
 				. "[columns]This is a test.[nextcol]This is [b]beside[/b] it.[nextcol]This is [i]also[/i] beside it.[/columns]"
@@ -1007,13 +1007,13 @@ h1 { text-align: center; }
 				. "This is <i>also</i> beside it."
 				. "\n</td></tr></tbody></table>\n"
 				. "After the columns.",
-		),
-		Array(
+		],
+		[
 			'descr' => "[nextcol] doesn't do anything outside a [columns] block.",
 			'bbcode' => "Here's some text.[nextcol]\nHere's some more.\n",
 			'html' => "Here's some text.[nextcol]<br />\nHere's some more.<br />\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "Bad column misuse doesn't break layouts.",
 			'bbcode' => "[center][columns]This is a test.[nextcol]This is also a [b]test[/b].[/center][/columns]",
 			'html' => "\n<div class=\"bbcode_center\" style=\"text-align:center\">\n"
@@ -1023,75 +1023,75 @@ h1 { text-align: center; }
 				. "This is also a <b>test</b>."
 				. "\n</td></tr></tbody></table>\n"
 				. "\n</div>\n",
-		),
+		],
 		
 		"Lists and List Items",
-		Array(
+		[
 			'descr' => "[list] and [*] should produce an unordered list.",
 			'bbcode' => "[list][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ul class=\"bbcode_list\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ul>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list] and [*] should produce an unordered list even without [/list].",
 			'bbcode' => "[list][*]One Box[*]Two Boxes[*]Three Boxes",
 			'html' => "\n<ul class=\"bbcode_list\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ul>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=circle] should produce an unordered list.",
 			'bbcode' => "[list=circle][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ul class=\"bbcode_list\" style=\"list-style-type:circle\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ul>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=disc] should produce an unordered list.",
 			'bbcode' => "[list=disc][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ul class=\"bbcode_list\" style=\"list-style-type:disc\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ul>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=square] should produce an unordered list.",
 			'bbcode' => "[list=square][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ul class=\"bbcode_list\" style=\"list-style-type:square\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ul>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=1] should produce an ordered list.",
 			'bbcode' => "[list=1][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=A] should produce an ordered list.",
 			'bbcode' => "[list=A][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:upper-alpha\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=a] should produce an ordered list.",
 			'bbcode' => "[list=a][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:lower-alpha\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=I] should produce an ordered list.",
 			'bbcode' => "[list=I][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:upper-roman\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=i] should produce an ordered list.",
 			'bbcode' => "[list=i][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:lower-roman\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=greek] should produce an ordered list.",
 			'bbcode' => "[list=greek][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:lower-greek\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=georgian] should produce an ordered list.",
 			'bbcode' => "[list=georgian][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:georgian\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-		Array(
+		],
+		[
 			'descr' => "[list=armenian] should produce an ordered list.",
 			'bbcode' => "[list=armenian][*]One Box[*]Two Boxes[*]Three Boxes[/list]",
 			'html' => "\n<ol class=\"bbcode_list\" style=\"list-style-type:armenian\">\n<li>One Box</li>\n<li>Two Boxes</li>\n<li>Three Boxes</li>\n</ol>\n",
-		),
-	);
+		],
+	];
 
 	function MicroNow() {
 		list($usec, $sec) = explode(" ", microtime());
@@ -1104,13 +1104,13 @@ h1 { text-align: center; }
 
 	$bbcode = new BBCode;
 
-	$bbcode->AddRule('wstest', Array(
+	$bbcode->AddRule('wstest', [
 		'mode' => BBCODE_MODE_ENHANCED,
-		'allow' => Array('_default' => '/^[a-zA-Z0-9._ -]+$/'),
+		'allow' => ['_default' => '/^[a-zA-Z0-9._ -]+$/'],
 		'template' => '<span style="wstest:{$_default}">{$_content}</span>',
 		'class' => 'inline',
-		'allow_in' => Array('listitem', 'block', 'columns', 'inline', 'link'),
-	));	
+		'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
+	]);	
 	$bbcode->SetLocalImgDir("smileys");
 	$bbcode->SetLocalImgURL("smileys");
 

--- a/plugins/NBBC/nbbc/tools/collect_smileys.php
+++ b/plugins/NBBC/nbbc/tools/collect_smileys.php
@@ -46,7 +46,7 @@
 	}
 
 	$dir = opendir("../smileys");
-	$files = Array();
+	$files = [];
 	while (($file = readdir($dir)) !== false) {
 		if (!preg_match("/\\.(?:gif|jpg|jpe|jpeg|png)$/", $file))
 			continue;

--- a/plugins/NoBump/class.nobump.plugin.php
+++ b/plugins/NoBump/class.nobump.plugin.php
@@ -6,7 +6,7 @@ class NoBumpPlugin extends Gdn_Plugin {
     */
    public function DiscussionController_AfterBodyField_Handler($Sender) {
       if (Gdn::Session()->CheckPermission('Garden.Moderation.Manage'))
-         echo $Sender->Form->CheckBox('NoBump', T('No Bump'), array('value' => '1'));
+         echo $Sender->Form->CheckBox('NoBump', T('No Bump'), ['value' => '1']);
    }
 
    /**

--- a/plugins/NoIndex/class.noindex.plugin.php
+++ b/plugins/NoIndex/class.noindex.plugin.php
@@ -12,7 +12,7 @@ class NoIndexPlugin extends Gdn_Plugin {
     * Allow mods to add/remove NoIndex via discussion options.
     */
    public function Base_DiscussionOptions_Handler($Sender, $Args) {
-      if (CheckPermission(array('Garden.Moderation.Manage', 'Garden.Curation.Manage'), FALSE)) {
+      if (CheckPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE)) {
          $Discussion = $Args['Discussion'];
          $Label = (GetValue('NoIndex', $Discussion)) ? T('Remove NoIndex') : T('Add NoIndex');
          $Url = "/discussion/noindex?discussionid={$Discussion->DiscussionID}";
@@ -21,11 +21,11 @@ class NoIndexPlugin extends Gdn_Plugin {
             $Sender->Options .= Wrap(Anchor($Label, $Url, 'NoIndex'), 'li');
          }
          else {
-            $Args['DiscussionOptions']['Bump'] = array(
+            $Args['DiscussionOptions']['Bump'] = [
                'Label' => $Label,
                'Url' => $Url,
                'Class' => 'NoIndex'
-            );
+            ];
          }
       }
    }
@@ -34,7 +34,7 @@ class NoIndexPlugin extends Gdn_Plugin {
     * Handle discussion option menu NoIndex action (simple toggle).
     */
    public function DiscussionController_NoIndex_Create($Sender, $Args) {
-      $Sender->Permission(array('Garden.Moderation.Manage', 'Garden.Curation.Manage'), FALSE);
+      $Sender->Permission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE);
 
       // Get discussion
       $DiscussionID = $Sender->Request->Get('discussionid');
@@ -55,11 +55,11 @@ class NoIndexPlugin extends Gdn_Plugin {
      * Add a mod message to NoIndex discussions.
      */
     public function DiscussionController_BeforeDiscussionDisplay_Handler($Sender, $Args) {
-        if (!CheckPermission(array('Garden.Moderation.Manage', 'Garden.Curation.Manage'), FALSE))
+        if (!CheckPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE))
             return;
 
         if (GetValue('NoIndex', $Sender->Data('Discussion'))) {
-            echo Wrap(T('Discussion marked as noindex'), 'div', array('class' => 'Warning'));
+            echo Wrap(T('Discussion marked as noindex'), 'div', ['class' => 'Warning']);
         }
     }
 
@@ -68,7 +68,7 @@ class NoIndexPlugin extends Gdn_Plugin {
      */
     public function DiscussionController_Render_Before($Sender, $Args) {
         if ($Sender->Head && GetValue('NoIndex', $Sender->Data('Discussion'))) {
-            $Sender->Head->AddTag('meta', array('name' => 'robots', 'content' => 'noindex,noarchive'));
+            $Sender->Head->AddTag('meta', ['name' => 'robots', 'content' => 'noindex,noarchive']);
         }
     }
 
@@ -77,7 +77,7 @@ class NoIndexPlugin extends Gdn_Plugin {
      */
     public function Base_BeforeDiscussionMeta_Handler($Sender, $Args) {
         $NoIndex = GetValue('NoIndex', GetValue('Discussion', $Args));
-        if (CheckPermission(array('Garden.Moderation.Manage', 'Garden.Curation.Manage'), FALSE) && $NoIndex) {
+        if (CheckPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE) && $NoIndex) {
             echo ' <span class="Tag Tag-NoIndex">'.T('NoIndex').'</span> ';
         }
     }

--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -10,24 +10,24 @@
 class PocketsPlugin extends Gdn_Plugin {
 
     /** @var array Counters for the various locations. */
-    protected $_Counters = array();
+    protected $_Counters = [];
 
     /** @var array  */
-    public $Locations = array(
-        'Content' => array('Name' => 'Content'),
-        'Panel' => array('Name' => 'Panel'),
-        'BetweenDiscussions' => array('Name' => 'Between Discussions', 'Wrap' => array('<li>', '</li>')),
-        'BetweenComments' => array('Name' => 'Between Comments', 'Wrap' => array('<li>', '</li>')),
-        'Head' => array('Name' => 'Head'),
-        'Foot' => array('Name' => 'Foot'),
-        'Custom' => array('Name' => 'Custom')
-    );
+    public $Locations = [
+        'Content' => ['Name' => 'Content'],
+        'Panel' => ['Name' => 'Panel'],
+        'BetweenDiscussions' => ['Name' => 'Between Discussions', 'Wrap' => ['<li>', '</li>']],
+        'BetweenComments' => ['Name' => 'Between Comments', 'Wrap' => ['<li>', '</li>']],
+        'Head' => ['Name' => 'Head'],
+        'Foot' => ['Name' => 'Foot'],
+        'Custom' => ['Name' => 'Custom']
+    ];
 
     /** @var array All of the pockets indexed by location. */
-    protected $_Pockets = array();
+    protected $_Pockets = [];
 
     /** @var array  */
-    protected $_PocketNames = array();
+    protected $_PocketNames = [];
 
     /** @var bool  */
     protected $StateLoaded = false;
@@ -137,7 +137,7 @@ class PocketsPlugin extends Gdn_Plugin {
      * @param array $Args
      * @return mixed
      */
-    public function settingsController_pockets_create($Sender, $Args = array()) {
+    public function settingsController_pockets_create($Sender, $Args = []) {
         $Sender->permission('Plugins.Pockets.Manage');
         $Sender->setHighlightRoute('settings/pockets');
         $Sender->addJsFile('pockets.js', 'plugins/Pockets');
@@ -247,7 +247,7 @@ class PocketsPlugin extends Gdn_Plugin {
                 saveToConfig('Plugins.Pockets.ShowLocations', true);
                 break;
             case 'hidelocations':
-                saveToConfig('Plugins.Pockets.ShowLocations', false, array('RemoveEmpty' => true));
+                saveToConfig('Plugins.Pockets.ShowLocations', false, ['RemoveEmpty' => true]);
                 break;
         }
 
@@ -395,7 +395,7 @@ class PocketsPlugin extends Gdn_Plugin {
         } else {
             if ($PocketID !== false) {
                 // Load the pocket.
-                $Pocket = $PocketModel->getWhere(array('PocketID' => $PocketID))->firstRow(DATASET_TYPE_ARRAY);
+                $Pocket = $PocketModel->getWhere(['PocketID' => $PocketID])->firstRow(DATASET_TYPE_ARRAY);
                 if (!$Pocket) {
                     return Gdn::dispatcher()->dispatch('Default404');
                 }
@@ -423,7 +423,7 @@ class PocketsPlugin extends Gdn_Plugin {
 
         $Sender->setData('Locations', $this->Locations);
         $Sender->setData('LocationsArray', $this->getLocationsArray());
-        $Sender->setData('Pages', array('' => '('.T('All').')', 'activity' => 'activity', 'comments' => 'comments', 'dashboard' => 'dashboard', 'discussions' => 'discussions', 'inbox' => 'inbox', 'profile' => 'profile'));
+        $Sender->setData('Pages', ['' => '('.T('All').')', 'activity' => 'activity', 'comments' => 'comments', 'dashboard' => 'dashboard', 'discussions' => 'discussions', 'inbox' => 'inbox', 'profile' => 'profile']);
 
         return $Sender->render('AddEdit', '', 'plugins/Pockets');
     }
@@ -453,7 +453,7 @@ class PocketsPlugin extends Gdn_Plugin {
 
         $Form = new Gdn_Form();
         if ($Form->authenticatedPostBack()) {
-            Gdn::sql()->delete('Pocket', array('PocketID' => $PocketID));
+            Gdn::sql()->delete('Pocket', ['PocketID' => $PocketID]);
             $Sender->StatusMessage = sprintf(T('The %s has been deleted.'), strtolower(t('Pocket')));
             $Sender->setRedirectTo('settings/pockets');
         }
@@ -470,7 +470,7 @@ class PocketsPlugin extends Gdn_Plugin {
      */
     public function addPocket($Pocket) {
         if (!isset($this->_Pockets[$Pocket->Location])) {
-            $this->_Pockets[$Pocket->Location] = array();
+            $this->_Pockets[$Pocket->Location] = [];
         }
 
         $this->_Pockets[$Pocket->Location][] = $Pocket;
@@ -483,7 +483,7 @@ class PocketsPlugin extends Gdn_Plugin {
      * @return array
      */
     public function getLocationsArray() {
-        $Result = array();
+        $Result = [];
         foreach ($this->Locations as $Key => $Value) {
             $Result[$Key] = val('Name', $Value, $Key);
         }
@@ -498,7 +498,7 @@ class PocketsPlugin extends Gdn_Plugin {
      */
     public function getPockets($Name) {
         $this->_loadState();
-        return val($Name, $this->_PocketNames, array());
+        return val($Name, $this->_PocketNames, []);
     }
 
     /**
@@ -540,7 +540,7 @@ class PocketsPlugin extends Gdn_Plugin {
         $this->_loadState();
 
         // Build up the data for filtering.
-        $Data = array();
+        $Data = [];
         $Data['Request'] = Gdn::request();
 
         // Increment the counter.
@@ -556,7 +556,7 @@ class PocketsPlugin extends Gdn_Plugin {
         $Data['Count'] = $Count;
         $Data['PageName'] = Pocket::pageName($Sender);
 
-        $LocationOptions = val($Location, $this->Locations, array());
+        $LocationOptions = val($Location, $this->Locations, []);
 
         if ($this->ShowPocketLocations && array_key_exists($Location, $this->Locations) && checkPermission('Plugins.Pockets.Manage') && $Sender->MasterView != 'admin') {
             $LocationName = val("Name", $this->Locations, $Location);
@@ -576,7 +576,7 @@ class PocketsPlugin extends Gdn_Plugin {
                 /** @var Pocket $Pocket */
 
                 if ($Pocket->canRender($Data)) {
-                    $Wrap = val('Wrap', $LocationOptions, array());
+                    $Wrap = val('Wrap', $LocationOptions, []);
 
                     echo val(0, $Wrap, '');
                     $Pocket->render($Data);
@@ -601,7 +601,7 @@ class PocketsPlugin extends Gdn_Plugin {
         $Pockets = $Inst->getPockets($Name);
 
         if (val('random', $Data)) {
-            $Pockets = array(array_rand($Pockets));
+            $Pockets = [array_rand($Pockets)];
         }
 
         $Result = '';
@@ -622,7 +622,7 @@ class PocketsPlugin extends Gdn_Plugin {
             $Data = array_change_key_case($Data);
 
             self::pocketStringCb($Data, true);
-            $Result = preg_replace_callback('`{{(\w+)}}`', array('PocketsPlugin', 'PocketStringCb'), $Result);
+            $Result = preg_replace_callback('`{{(\w+)}}`', ['PocketsPlugin', 'PocketStringCb'], $Result);
         }
 
         return $Result;
@@ -689,13 +689,13 @@ class PocketsPlugin extends Gdn_Plugin {
             ->column('EmbeddedNever', 'tinyint', '0')
             ->column('ShowInDashboard', 'tinyint', '0')
             ->column('TestMode', 'tinyint', '0')
-            ->column('Type', array(Pocket::TYPE_DEFAULT, Pocket::TYPE_AD), Pocket::TYPE_DEFAULT)
+            ->column('Type', [Pocket::TYPE_DEFAULT, Pocket::TYPE_AD], Pocket::TYPE_DEFAULT)
             ->set();
 
         $PermissionModel = Gdn::permissionModel();
-        $PermissionModel->define(array(
+        $PermissionModel->define([
             'Garden.NoAds.Allow' => 0
-        ));
+        ]);
     }
 
     /**
@@ -759,9 +759,9 @@ if (!function_exists('renderPocketToggle')) {
         $enabled = val('Disabled', $pocket) !== Pocket::DISABLED;
         $return = '<span id="pockets-toggle-'.val('PocketID', $pocket).'">';
         if ($enabled) {
-            $return .= wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/disable/'.val('PocketID', $pocket), 'Hijack'), 'span', array('class' => "toggle-wrap toggle-wrap-on"));
+            $return .= wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/disable/'.val('PocketID', $pocket), 'Hijack'), 'span', ['class' => "toggle-wrap toggle-wrap-on"]);
         } else {
-            $return .= wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/enable/'.val('PocketID', $pocket), 'Hijack'), 'span', array('class' => "toggle-wrap toggle-wrap-off"));
+            $return .= wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/enable/'.val('PocketID', $pocket), 'Hijack'), 'span', ['class' => "toggle-wrap toggle-wrap-off"]);
         }
         $return .= '</span>';
         return $return;

--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -44,7 +44,7 @@ class Pocket {
     public $RepeatType = Pocket::REPEAT_INDEX;
 
     /** $var array The repeat frequency. */
-    public $RepeatFrequency = array(1);
+    public $RepeatFrequency = [1];
 
     /** $var array The repeat frequency. */
     public $MobileOnly = false;
@@ -65,7 +65,7 @@ class Pocket {
     public $ShowInDashboard = false;
 
     /** @var array */
-    public static $NameTranslations = array('conversations' => 'inbox', 'messages' => 'inbox', 'categories' => 'discussions', 'discussion' => 'comments');
+    public static $NameTranslations = ['conversations' => 'inbox', 'messages' => 'inbox', 'categories' => 'discussions', 'discussion' => 'comments'];
 
     /**
      * Pocket constructor.
@@ -239,10 +239,10 @@ class Pocket {
             $Frequency = explode(',', $Frequency);
             $Frequency = array_map('trim', $Frequency);
         } else {
-            $Frequency = array();
+            $Frequency = [];
         }
 
-        return array($RepeatType, $Frequency);
+        return [$RepeatType, $Frequency];
     }
 
     /**
@@ -297,10 +297,10 @@ class Pocket {
      */
     public static function touch($Name, $Value) {
         $Model = new Gdn_Model('Pocket');
-        $Pockets = $Model->getWhere(array('Name' => $Name))->resultArray();
+        $Pockets = $Model->getWhere(['Name' => $Name])->resultArray();
 
         if (empty($Pockets)) {
-            $Pocket = array(
+            $Pocket = [
                 'Name' => $Name,
                 'Location' => 'Content',
                 'Sort' => 0,
@@ -313,7 +313,7 @@ class Pocket {
                 'EmbeddedNever' => 0,
                 'ShowInDashboard' => 0,
                 'Type' => 'default'
-                );
+                ];
             $Model->save($Pocket);
         }
     }

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -51,17 +51,17 @@ echo $Form->errors();
             echo '<div class="info">', t('Select the location of the pocket.', 'Select the location of the pocket.'), '</div>'; ?>
         </div>
         <div class="input-wrap">
-        <?php echo $Form->dropdown('Location', array_merge(array('' => '('.sprintf(T('Select a %s'), t('Location')).')'), $this->data('LocationsArray'))); ?>
+        <?php echo $Form->dropdown('Location', array_merge(['' => '('.sprintf(T('Select a %s'), t('Location')).')'], $this->data('LocationsArray'))); ?>
         </div>
     </li>
     <li class="js-repeat form-group">
         <?php echo $Form->labelWrap('Repeat', 'RepeatType'); ?>
         <div class="input-wrap">
         <?php
-            echo '<div>', $Form->radio('RepeatType', 'Before', array('Value' => Pocket::REPEAT_BEFORE, 'Default' => true)), '</div>';
-            echo '<div>', $Form->radio('RepeatType', 'After', array('Value' => Pocket::REPEAT_AFTER)), '</div>';
-            echo '<div>', $Form->radio('RepeatType', 'Repeat Every', array('Value' => Pocket::REPEAT_EVERY)), '</div>';
-            echo '<div>', $Form->radio('RepeatType', 'Given Indexes', array('Value' => Pocket::REPEAT_INDEX)), '</div>';
+            echo '<div>', $Form->radio('RepeatType', 'Before', ['Value' => Pocket::REPEAT_BEFORE, 'Default' => true]), '</div>';
+            echo '<div>', $Form->radio('RepeatType', 'After', ['Value' => Pocket::REPEAT_AFTER]), '</div>';
+            echo '<div>', $Form->radio('RepeatType', 'Repeat Every', ['Value' => Pocket::REPEAT_EVERY]), '</div>';
+            echo '<div>', $Form->radio('RepeatType', 'Given Indexes', ['Value' => Pocket::REPEAT_INDEX]), '</div>';
 
             // Options for repeat every.
             echo '<div class="RepeatOptions RepeatEveryOptions padded-top">',

--- a/plugins/Pockets/views/index.php
+++ b/plugins/Pockets/views/index.php
@@ -13,9 +13,9 @@ echo heading($this->data('Title'), sprintf(t('Add %s'), t('Pocket')), 'settings/
         <span id="pocket-locations-toggle">
             <?php
             if (!c('Plugins.Pockets.ShowLocations')) {
-                echo wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/showlocations'), 'span', array('class' => "toggle-wrap toggle-wrap-off"));
+                echo wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/showlocations'), 'span', ['class' => "toggle-wrap toggle-wrap-off"]);
             } else {
-                echo wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/hidelocations'), 'span', array('class' => "toggle-wrap toggle-wrap-on"));
+                echo wrap(anchor('<div class="toggle-well"></div><div class="toggle-slider"></div>', '/settings/pockets/hidelocations'), 'span', ['class' => "toggle-wrap toggle-wrap-on"]);
             }
             ?>
         </span>

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -80,11 +80,11 @@ class QnAPlugin extends Gdn_Plugin {
         $sender->Form = new Gdn_Form();
         $validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
-        $configurationModel->setField(array(
+        $configurationModel->setField([
             'QnA.Points.Enabled' => c('QnA.Points.Enabled', false),
             'QnA.Points.Answer' => c('QnA.Points.Answer', 1),
             'QnA.Points.AcceptedAnswer' => c('QnA.Points.AcceptedAnswer', 1),
-        ));
+        ]);
         $sender->Form->setModel($configurationModel);
 
         // If seeing the form for the first time...
@@ -169,12 +169,12 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function base_discussionTypes_handler($sender, $args) {
         if (!C('Plugins.QnA.UseBigButtons')) {
-            $args['Types']['Question'] = array(
+            $args['Types']['Question'] = [
                 'Singular' => 'Question',
                 'Plural' => 'Questions',
                 'AddUrl' => '/post/question',
                 'AddText' => 'Ask a Question'
-            );
+            ];
         }
     }
 
@@ -218,7 +218,7 @@ class QnAPlugin extends Gdn_Plugin {
             return;
         }
 
-        $args['CommentOptions']['QnA'] = array('Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?commentid='.$Comment->CommentID, 'Class' => 'Popup');
+        $args['CommentOptions']['QnA'] = ['Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?commentid='.$Comment->CommentID, 'Class' => 'Popup'];
     }
 
     /**
@@ -234,7 +234,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         if (isset($args['DiscussionOptions'])) {
-            $args['DiscussionOptions']['QnA'] = array('Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Class' => 'Popup');
+            $args['DiscussionOptions']['QnA'] = ['Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Class' => 'Popup'];
         } elseif (isset($sender->Options)) {
             $sender->Options .= '<li>'.anchor(t('Q&A').'...', '/discussion/qnaoptions?discussionid='.$Discussion->DiscussionID, 'Popup QnAOptions') . '</li>';
         }
@@ -264,7 +264,7 @@ class QnAPlugin extends Gdn_Plugin {
 
         $HeadlineFormat = t('HeadlineFormat.Answer', '{ActivityUserID,user} answered your question: <a href="{Url,html}">{Data.Name,text}</a>');
 
-        $Activity = array(
+        $Activity = [
             'ActivityType' => 'Comment',
             'ActivityUserID' => $Comment['InsertUserID'],
             'NotifyUserID' => $Discussion['InsertUserID'],
@@ -272,10 +272,10 @@ class QnAPlugin extends Gdn_Plugin {
             'RecordType' => 'Comment',
             'RecordID' => $CommentID,
             'Route' => "/discussion/comment/$CommentID#Comment_$CommentID",
-            'Data' => array(
+            'Data' => [
                 'Name' => val('Name', $Discussion)
-            )
-        );
+            ]
+        ];
 
         $ActivityModel->queue($Activity, 'DiscussionComment');
     }
@@ -290,7 +290,7 @@ class QnAPlugin extends Gdn_Plugin {
         $Discussion =& $args['Discussion'];
 
         // Mark the question as answered.
-        if (strtolower($Discussion['Type']) == 'question' && !$Discussion['Sink'] && !in_array($Discussion['QnA'], array('Answered', 'Accepted'))) {
+        if (strtolower($Discussion['Type']) == 'question' && !$Discussion['Sink'] && !in_array($Discussion['QnA'], ['Answered', 'Accepted'])) {
             if($args['Counts']['CountComments'] > 0) {
                 $sender->SQL->set('QnA', 'Answered');
             } else {
@@ -316,7 +316,7 @@ class QnAPlugin extends Gdn_Plugin {
 
         // Find the accepted answer(s) to the question.
         $CommentModel = new CommentModel();
-        $Answers = $CommentModel->getWhere(array('DiscussionID' => $sender->data('Discussion.DiscussionID'), 'Qna' => 'Accepted'))->result();
+        $Answers = $CommentModel->getWhere(['DiscussionID' => $sender->data('Discussion.DiscussionID'), 'Qna' => 'Accepted'])->result();
 
         if (class_exists('ReplyModel')) {
             $ReplyModel = new ReplyModel();
@@ -387,7 +387,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
 
-        $Query = http_build_query(array('commentid' => $CommentID, 'tkey' => Gdn::session()->transientKey()));
+        $Query = http_build_query(['commentid' => $CommentID, 'tkey' => Gdn::session()->transientKey()]);
 
         echo '<div class="ActionBlock QnA-Feedback">';
 
@@ -395,9 +395,9 @@ class QnAPlugin extends Gdn_Plugin {
 
         echo '<span class="QnA-YesNo">';
 
-        echo anchor(t('Yes'), '/discussion/qna/accept?'.$Query, array('class' => 'React QnA-Yes', 'title' => t('Accept this answer.')));
+        echo anchor(t('Yes'), '/discussion/qna/accept?'.$Query, ['class' => 'React QnA-Yes', 'title' => t('Accept this answer.')]);
         echo ' '.bullet().' ';
-        echo anchor(t('No'), '/discussion/qna/reject?'.$Query, array('class' => 'React QnA-No', 'title' => t('Reject this answer.')));
+        echo anchor(t('No'), '/discussion/qna/reject?'.$Query, ['class' => 'React QnA-No', 'title' => t('Reject this answer.')]);
 
         echo '</span>';
 
@@ -425,12 +425,12 @@ class QnAPlugin extends Gdn_Plugin {
      * @throws notFoundException
      */
     public function discussionController_QnA_create($sender, $args) {
-        $Comment = Gdn::SQL()->getWhere('Comment', array('CommentID' => $sender->Request->get('commentid')))->firstRow(DATASET_TYPE_ARRAY);
+        $Comment = Gdn::SQL()->getWhere('Comment', ['CommentID' => $sender->Request->get('commentid')])->firstRow(DATASET_TYPE_ARRAY);
         if (!$Comment) {
             throw notFoundException('Comment');
         }
 
-        $Discussion = Gdn::SQL()->getWhere('Discussion', array('DiscussionID' => $Comment['DiscussionID']))->firstRow(DATASET_TYPE_ARRAY);
+        $Discussion = Gdn::SQL()->getWhere('Discussion', ['DiscussionID' => $Comment['DiscussionID']])->firstRow(DATASET_TYPE_ARRAY);
 
         // Check for permission.
         if (!(Gdn::session()->UserID == val('InsertUserID', $Discussion) || Gdn::session()->checkPermission('Garden.Moderation.Manage'))) {
@@ -450,8 +450,8 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         if (isset($QnA)) {
-            $DiscussionSet = array('QnA' => $QnA);
-            $CommentSet = array('QnA' => $QnA);
+            $DiscussionSet = ['QnA' => $QnA];
+            $CommentSet = ['QnA' => $QnA];
 
             if ($QnA == 'Accepted') {
                 $CommentSet['DateAccepted'] = Gdn_Format::toDateTime();
@@ -464,14 +464,14 @@ class QnAPlugin extends Gdn_Plugin {
             }
 
             // Update the comment.
-            Gdn::SQL()->put('Comment', $CommentSet, array('CommentID' => $Comment['CommentID']));
+            Gdn::SQL()->put('Comment', $CommentSet, ['CommentID' => $Comment['CommentID']]);
 
             // Update the discussion.
-            if ($Discussion['QnA'] != $QnA && (!$Discussion['QnA'] || in_array($Discussion['QnA'], array('Unanswered', 'Answered', 'Rejected')))) {
+            if ($Discussion['QnA'] != $QnA && (!$Discussion['QnA'] || in_array($Discussion['QnA'], ['Unanswered', 'Answered', 'Rejected']))) {
                 Gdn::SQL()->put(
                     'Discussion',
                     $DiscussionSet,
-                    array('DiscussionID' => $Comment['DiscussionID']));
+                    ['DiscussionID' => $Comment['DiscussionID']]);
             }
 
             // Determine QnA change
@@ -527,7 +527,7 @@ class QnAPlugin extends Gdn_Plugin {
 
             // Record the activity.
             if ($QnA == 'Accepted') {
-                $Activity = array(
+                $Activity = [
                     'ActivityType' => 'AnswerAccepted',
                     'NotifyUserID' => $Comment['InsertUserID'],
                     'HeadlineFormat' => $headlineFormat,
@@ -536,10 +536,10 @@ class QnAPlugin extends Gdn_Plugin {
                     'Route' => commentUrl($Comment, '/'),
                     'Emailed' => ActivityModel::SENT_PENDING,
                     'Notified' => ActivityModel::SENT_PENDING,
-                    'Data' => array(
+                    'Data' => [
                         'Name' => val('Name', $Discussion)
-                    )
-                );
+                    ]
+                ];
 
                 $ActivityModel = new ActivityModel();
                 $ActivityModel->save($Activity);
@@ -572,10 +572,10 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function recalculateDiscussionQnA($discussion) {
         // Find comments in this discussion with a QnA value.
-        $Set = array();
+        $Set = [];
 
         $Row = Gdn::SQL()->getWhere('Comment',
-            array('DiscussionID' => val('DiscussionID', $discussion), 'QnA is not null' => ''), 'QnA, DateAccepted', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
+            ['DiscussionID' => val('DiscussionID', $discussion), 'QnA is not null' => ''], 'QnA, DateAccepted', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
 
         if (!$Row) {
             if (val('CountComments', $discussion) > 0) {
@@ -605,7 +605,7 @@ class QnAPlugin extends Gdn_Plugin {
      * @param string|int $userID User identifier
      */
     public function recalculateUserQnA($userID) {
-        $CountAcceptedAnswers = Gdn::SQL()->getCount('Comment', array('InsertUserID' => $userID, 'QnA' => 'Accepted'));
+        $CountAcceptedAnswers = Gdn::SQL()->getCount('Comment', ['InsertUserID' => $userID, 'QnA' => 'Accepted']);
         Gdn::userModel()->setField($userID, 'CountAcceptedAnswers', $CountAcceptedAnswers);
     }
 
@@ -639,7 +639,7 @@ class QnAPlugin extends Gdn_Plugin {
             $CurrentQnA = val('QnA', $Comment);
 
             if ($CurrentQnA != $newQnA) {
-                $Set = array('QnA' => $newQnA);
+                $Set = ['QnA' => $newQnA];
 
                 if ($newQnA == 'Accepted') {
                     $Set['DateAccepted'] = Gdn_Format::toDateTime();
@@ -712,7 +712,7 @@ class QnAPlugin extends Gdn_Plugin {
 
         $sender->setData('Comment', $Comment);
         $sender->setData('Discussion', $Discussion);
-        $sender->setData('_QnAs', array('Accepted' => t('Yes'), 'Rejected' => t('No'), '' => t("Don't know")));
+        $sender->setData('_QnAs', ['Accepted' => t('Yes'), 'Rejected' => t('No'), '' => t("Don't know")]);
         $sender->setData('Title', t('Q&A Options'));
         $sender->render('CommentOptions', '', 'plugins/QnA');
     }
@@ -765,7 +765,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         $sender->setData('Discussion', $Discussion);
-        $sender->setData('_Types', array('Question' => '@'.t('Question Type', 'Question'), 'Discussion' => '@'.t('Discussion Type', 'Discussion')));
+        $sender->setData('_Types', ['Question' => '@'.t('Question Type', 'Question'), 'Discussion' => '@'.t('Discussion Type', 'Discussion')]);
         $sender->setData('Title', t('Q&A Options'));
         $sender->render('DiscussionOptions', '', 'plugins/QnA');
     }
@@ -784,7 +784,7 @@ class QnAPlugin extends Gdn_Plugin {
                 $args['Wheres']['Type'] = 'Question';
                 $sender->SQL->beginWhereGroup()
                     ->where('d.QnA', null)
-                    ->orWhereIn('d.QnA', array('Unanswered', 'Rejected'))
+                    ->orWhereIn('d.QnA', ['Unanswered', 'Rejected'])
                     ->endWhereGroup();
                 Gdn::controller()->title(t('Unanswered Questions'));
             } elseif ($QnA = Gdn::request()->get('qna')) {
@@ -893,11 +893,11 @@ class QnAPlugin extends Gdn_Plugin {
             $questionCount = Gdn::sql()
                 ->beginWhereGroup()
                 ->where('QnA', null)
-                ->orWhereIn('QnA', array('Unanswered', 'Rejected'))
+                ->orWhereIn('QnA', ['Unanswered', 'Rejected'])
                 ->endWhereGroup()
-                ->getCount('Discussion', array('Type' => 'Question'));
+                ->getCount('Discussion', ['Type' => 'Question']);
 
-            Gdn::cache()->store($cacheKey, $questionCount, array(Gdn_Cache::FEATURE_EXPIRY => 15 * 60));
+            Gdn::cache()->store($cacheKey, $questionCount, [Gdn_Cache::FEATURE_EXPIRY => 15 * 60]);
         }
 
         // Check to see if another plugin can handle this.
@@ -925,7 +925,7 @@ class QnAPlugin extends Gdn_Plugin {
         // Remove announcements that aren't questions...
         if (is_a($sender->data('Announcements'), 'Gdn_DataSet')) {
             $sender->data('Announcements')->result();
-            $Announcements = array();
+            $Announcements = [];
             foreach ($sender->data('Announcements') as $i => $Row) {
                 if (val('Type', $Row) == 'Question') {
                     $Announcements[] = $Row;
@@ -1005,7 +1005,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         // Check to see if the user has answered questions.
-        $Count = Gdn::SQL()->getCount('Discussion', array('Type' => 'Question', 'InsertUserID' => Gdn::session()->UserID, 'QnA' => 'Answered'));
+        $Count = Gdn::SQL()->getCount('Discussion', ['Type' => 'Question', 'InsertUserID' => Gdn::session()->UserID, 'QnA' => 'Answered']);
         if ($Count > 0) {
             $sender->informMessage(formatString(t("You've asked questions that have now been answered", "<a href=\"{/discussions/mine?qna=Answered,url}\">You've asked questions that now have answers</a>. Make sure you accept/reject the answers.")), 'Dismissable');
         }
@@ -1046,7 +1046,7 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function postController_afterForms_handler($sender) {
         $Forms = $sender->data('Forms');
-        $Forms[] = array('Name' => 'Question', 'Label' => sprite('SpQuestion').t('Ask a Question'), 'Url' => 'post/question');
+        $Forms[] = ['Name' => 'Question', 'Label' => sprite('SpQuestion').t('Ask a Question'), 'Url' => 'post/question'];
         $sender->setData('Forms', $Forms);
     }
 
@@ -1072,7 +1072,7 @@ class QnAPlugin extends Gdn_Plugin {
         if ($sender->RequestMethod == 'question') {
             $sender->Form->addHidden('Type', 'Question');
             $sender->title(t('Ask a Question'));
-            $sender->setData('Breadcrumbs', array(array('Name' => $sender->data('Title'), 'Url' => '/post/question')));
+            $sender->setData('Breadcrumbs', [['Name' => $sender->data('Title'), 'Url' => '/post/question']]);
         }
     }
 

--- a/plugins/QnA/structure.php
+++ b/plugins/QnA/structure.php
@@ -6,14 +6,14 @@ $QnAExists = Gdn::structure()->columnExists('QnA');
 $DateAcceptedExists = Gdn::structure()->columnExists('DateAccepted');
 
 Gdn::structure()
-    ->column('QnA', array('Unanswered', 'Answered', 'Accepted', 'Rejected'), null, 'index')
+    ->column('QnA', ['Unanswered', 'Answered', 'Accepted', 'Rejected'], null, 'index')
     ->column('DateAccepted', 'datetime', true) // The
     ->column('DateOfAnswer', 'datetime', true) // The time to answer an accepted question.
     ->set();
 
 Gdn::structure()
     ->table('Comment')
-    ->column('QnA', array('Accepted', 'Rejected'), null)
+    ->column('QnA', ['Accepted', 'Rejected'], null)
     ->column('DateAccepted', 'datetime', true)
     ->column('AcceptedUserID', 'int', true)
     ->set();
@@ -25,12 +25,12 @@ Gdn::structure()
 
 Gdn::SQL()->replace(
     'ActivityType',
-    array('AllowComments' => '0', 'RouteCode' => 'question', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''),
-    array('Name' => 'QuestionAnswer'), true);
+    ['AllowComments' => '0', 'RouteCode' => 'question', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''],
+    ['Name' => 'QuestionAnswer'], true);
 Gdn::SQL()->replace(
     'ActivityType',
-    array('AllowComments' => '0', 'RouteCode' => 'answer', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''),
-    array('Name' => 'AnswerAccepted'), true);
+    ['AllowComments' => '0', 'RouteCode' => 'answer', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''],
+    ['Name' => 'AnswerAccepted'], true);
 
 if ($QnAExists && !$DateAcceptedExists) {
     // Default the date accepted to the accepted answer's date.
@@ -61,84 +61,84 @@ if ($this->Badges && class_exists('BadgeModel')) {
     $BadgeModel = new BadgeModel();
 
     // Answer Counts
-    $BadgeModel->define(array(
+    $BadgeModel->define([
         'Name' => 'First Answer',
         'Slug' => 'answer',
         'Type' => 'UserCount',
         'Body' => 'Answering questions is a great way to show your support for a community!',
         'Photo' => 'http://badges.vni.la/100/answer.png',
         'Points' => 2,
-        'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+        'Attributes' => ['Column' => 'CountAcceptedAnswers'],
         'Threshold' => 1,
         'Class' => 'Answerer',
         'Level' => 1,
         'CanDelete' => 0
-    ));
-    $BadgeModel->define(array(
+    ]);
+    $BadgeModel->define([
         'Name' => '5 Answers',
         'Slug' => 'answer-5',
         'Type' => 'UserCount',
         'Body' => 'Your willingness to share knowledge has definitely been noticed.',
         'Photo' => 'http://badges.vni.la/100/answer-2.png',
         'Points' => 3,
-        'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+        'Attributes' => ['Column' => 'CountAcceptedAnswers'],
         'Threshold' => 5,
         'Class' => 'Answerer',
         'Level' => 2,
         'CanDelete' => 0
-    ));
-    $BadgeModel->define(array(
+    ]);
+    $BadgeModel->define([
         'Name' => '25 Answers',
         'Slug' => 'answer-25',
         'Type' => 'UserCount',
         'Body' => 'Looks like you&rsquo;re starting to make a name for yourself as someone who knows the score!',
         'Photo' => 'http://badges.vni.la/100/answer-3.png',
         'Points' => 5,
-        'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+        'Attributes' => ['Column' => 'CountAcceptedAnswers'],
         'Threshold' => 25,
         'Class' => 'Answerer',
         'Level' => 3,
         'CanDelete' => 0
-    ));
-    $BadgeModel->define(array(
+    ]);
+    $BadgeModel->define([
         'Name' => '50 Answers',
         'Slug' => 'answer-50',
         'Type' => 'UserCount',
         'Body' => 'Why use Google when we could just ask you?',
         'Photo' => 'http://badges.vni.la/100/answer-4.png',
         'Points' => 10,
-        'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+        'Attributes' => ['Column' => 'CountAcceptedAnswers'],
         'Threshold' => 50,
         'Class' => 'Answerer',
         'Level' => 4,
         'CanDelete' => 0
-    ));
-    $BadgeModel->define(array(
+    ]);
+    $BadgeModel->define([
         'Name' => '100 Answers',
         'Slug' => 'answer-100',
         'Type' => 'UserCount',
         'Body' => 'Admit it, you read Wikipedia in your spare time.',
         'Photo' => 'http://badges.vni.la/100/answer-5.png',
         'Points' => 15,
-        'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+        'Attributes' => ['Column' => 'CountAcceptedAnswers'],
         'Threshold' => 100,
         'Class' => 'Answerer',
         'Level' => 5,
         'CanDelete' => 0
-    ));
-    $BadgeModel->define(array(
+    ]);
+    $BadgeModel->define([
         'Name' => '250 Answers',
         'Slug' => 'answer-250',
         'Type' => 'UserCount',
         'Body' => 'Is there *anything* you don&rsquo;t know?',
         'Photo' => 'http://badges.vni.la/100/answer-6.png',
         'Points' => 20,
-        'Attributes' => array('Column' => 'CountAcceptedAnswers'),
+        'Attributes' => ['Column' => 'CountAcceptedAnswers'],
         'Threshold' => 250,
         'Class' => 'Answerer',
         'Level' => 6,
         'CanDelete' => 0
-    ));
+    ]);
 }
 
 // Define 'Accept' reaction

--- a/plugins/QnA/views/commentoptions.php
+++ b/plugins/QnA/views/commentoptions.php
@@ -10,14 +10,14 @@ echo $this->Form->errors();
     <?php
     echo '<i>'.t('Did this answer the question?').'</i>';
     echo $this->Form->getFormValue('QnA');
-    echo $this->Form->radioList('QnA', $this->data('_QnAs'), array('list' => true));
+    echo $this->Form->radioList('QnA', $this->data('_QnAs'), ['list' => true]);
     ?>
 </div>
 
 <?php
 echo '<div class="Buttons Buttons-Confirm">',
     $this->Form->button(t('OK')), ' ',
-    $this->Form->button(t('Cancel'), array('type' => 'button', 'class' => 'Button Close')),
+    $this->Form->button(t('Cancel'), ['type' => 'button', 'class' => 'Button Close']),
     '</div>';
 echo $this->Form->close();
 ?>

--- a/plugins/QnA/views/configuration.php
+++ b/plugins/QnA/views/configuration.php
@@ -6,10 +6,10 @@
 echo $this->Form->open();
 echo $this->Form->errors();
 $pointsAwardEnabled = c('QnA.Points.Enabled');
-$textBoxAttributes = array();
-$checkBoxAttributes = array(
+$textBoxAttributes = [];
+$checkBoxAttributes = [
     'id' => 'IsPointsAwardEnabled',
-);
+];
 if ($pointsAwardEnabled) {
     $checkBoxAttributes['checked'] = true;
 } else {

--- a/plugins/QnA/views/discussionoptions.php
+++ b/plugins/QnA/views/discussionoptions.php
@@ -9,14 +9,14 @@ echo $this->Form->errors();
 <div class="P">
     <?php
 //   echo $this->Form->Label();
-    echo $this->Form->radioList('Type', $this->data('_Types'), array('list' => true));
+    echo $this->Form->radioList('Type', $this->data('_Types'), ['list' => true]);
     ?>
 </div>
 
 <?php
 echo '<div class="Buttons Buttons-Confirm">',
     $this->Form->button(t('OK')), ' ',
-    $this->Form->button(t('Cancel'), array('type' => 'button', 'class' => 'Button Close')),
+    $this->Form->button(t('Cancel'), ['type' => 'button', 'class' => 'Button Close']),
     '</div>';
 echo $this->Form->close();
 ?>

--- a/plugins/QnA/views/post.php
+++ b/plugins/QnA/views/post.php
@@ -9,7 +9,7 @@ if (c('Vanilla.Categories.Use') && is_object($this->Category)) {
 <div id="DiscussionForm" class="FormTitleWrapper DiscussionForm">
    <?php
 		if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-		    echo wrap($this->data('Title'), 'h1', array('class' => 'H'));
+		    echo wrap($this->data('Title'), 'h1', ['class' => 'H']);
 		}
 
         echo '<div class="FormWrapper">';
@@ -21,7 +21,7 @@ if (c('Vanilla.Categories.Use') && is_object($this->Category)) {
             $options = [
                 'Value' => val('CategoryID', $this->Category),
                 'IncludeNull' => true,
-                'PermFilter' => array('AllowedDiscussionTypes' => 'Question'),
+                'PermFilter' => ['AllowedDiscussionTypes' => 'Question'],
             ];
             echo '<div class="P">';
                 echo '<div class="Category">';
@@ -33,23 +33,23 @@ if (c('Vanilla.Categories.Use') && is_object($this->Category)) {
 
         echo '<div class="P">';
             echo $this->Form->label('Question', 'Name');
-            echo wrap($this->Form->textBox('Name', array('maxlength' => 100, 'class' => 'InputBox BigInput')), 'div', array('class' => 'TextBoxWrapper'));
+            echo wrap($this->Form->textBox('Name', ['maxlength' => 100, 'class' => 'InputBox BigInput']), 'div', ['class' => 'TextBoxWrapper']);
         echo '</div>';
 
         $this->fireEvent('BeforeBodyInput');
         echo '<div class="P">';
-         echo $this->Form->bodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true));
+         echo $this->Form->bodyBox('Body', ['Table' => 'Discussion', 'FileUpload' => true]);
         echo '</div>';
 
         $this->fireEvent('AfterDiscussionFormOptions');
 
         echo '<div class="Buttons">';
         $this->fireEvent('BeforeFormButtons');
-        echo $this->Form->button((property_exists($this, 'Discussion')) ? 'Save' : 'Ask Question', array('class' => 'Button Primary DiscussionButton'));
+        echo $this->Form->button((property_exists($this, 'Discussion')) ? 'Save' : 'Ask Question', ['class' => 'Button Primary DiscussionButton']);
         if (!property_exists($this, 'Discussion') || !is_object($this->Discussion) || (property_exists($this, 'Draft') && is_object($this->Draft))) {
-            echo ' '.$this->Form->button('Save Draft', array('class' => 'Button Warning DraftButton'));
+            echo ' '.$this->Form->button('Save Draft', ['class' => 'Button Warning DraftButton']);
         }
-        echo ' '.$this->Form->button('Preview', array('class' => 'Button Warning PreviewButton'));
+        echo ' '.$this->Form->button('Preview', ['class' => 'Button Warning PreviewButton']);
         echo ' '.anchor(t('Edit'), '#', 'Button WriteButton Hidden')."\n";
         $this->fireEvent('AfterFormButtons');
         echo ' '.anchor(t('Cancel'), $CancelUrl, 'Button Cancel');

--- a/plugins/QnA/views/qnapost.php
+++ b/plugins/QnA/views/qnapost.php
@@ -7,7 +7,7 @@
     <style>.NoScript { display: block; } .YesScript { display: none; }</style>
 </noscript>
 <div class="P NoScript">
-    <?php echo $Form->radioList('Type', array('Question' => t('Ask a Question'), 'Discussion' => t('Start a New Discussion'))); ?>
+    <?php echo $Form->radioList('Type', ['Question' => t('Ask a Question'), 'Discussion' => t('Start a New Discussion')]); ?>
 </div>
 <div class="YesScript">
     <div class="Tabs">

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -209,7 +209,7 @@ class RedirectorPlugin extends Gdn_Plugin {
         trace($Get, 'New Get');
 
         // Translate all of the get parameters into new parameters.
-        $Vars = array();
+        $Vars = [];
         foreach ($Get as $Key => $Value) {
             if (!isset($Row[$Key]))
                 continue;
@@ -499,9 +499,9 @@ class RedirectorPlugin extends Gdn_Plugin {
     public static function showpostFilter(&$Get) {
         self::vbFriendlyUrlID($Get, 'p');
 
-        return array(
+        return [
             'p' => 'CommentID'
-        );
+        ];
 
     }
 
@@ -513,7 +513,7 @@ class RedirectorPlugin extends Gdn_Plugin {
      * @return array Mapping of vB parameters
      */
     public static function showthreadFilter(&$Get) {
-        $data = array(
+        $data = [
             'p' => 'CommentID',
             'page' => 'Page',
             '_arg0' => [
@@ -524,7 +524,7 @@ class RedirectorPlugin extends Gdn_Plugin {
                 'Page',
                 'Filter' => [__CLASS__, 'getNumber']
             ]
-        );
+        ];
 
         if (isset($Get['t'])) {
             $data['t'] = [

--- a/plugins/Reporting/class.reporting.plugin.php
+++ b/plugins/Reporting/class.reporting.plugin.php
@@ -51,7 +51,7 @@ class ReportingPlugin extends Gdn_Plugin {
       $Command = GetValue('2', $Sender->RequestArgs);
       $TransientKey = Gdn::request()->get('TransientKey');
       if (Gdn::Session()->ValidateTransientKey($TransientKey)) {
-         if (in_array($Feature, array('awesome', 'report'))) {
+         if (in_array($Feature, ['awesome', 'report'])) {
             SaveToConfig(
                'Plugins.Reporting.'.ucfirst($Feature).'Enabled',
                $Command == 'disable' ? FALSE : TRUE
@@ -62,10 +62,10 @@ class ReportingPlugin extends Gdn_Plugin {
       }
 
       $CategoryModel = new CategoryModel();
-      $Sender->SetData('Plugins.Reporting.Data', array(
+      $Sender->SetData('Plugins.Reporting.Data', [
          'ReportEnabled'   => $this->ReportEnabled,
          'AwesomeEnabled'  => $this->AwesomeEnabled
-      ));
+      ]);
 
       $Sender->Render($this->GetView('settings.php'));
    }
@@ -118,7 +118,7 @@ class ReportingPlugin extends Gdn_Plugin {
       $RegardingAction = C('Plugins.Reporting.ReportAction', FALSE);
       $RegardingActionSupplement = C('Plugins.Reporting.ReportActionSupplement', FALSE);
 
-      $ReportingData = array(
+      $ReportingData = [
          'Type'            => 'report',
          'Context'         => $Context,
          'Element'         => $ReportElement,
@@ -131,7 +131,7 @@ class ReportingPlugin extends Gdn_Plugin {
          'UserName'        => $UserName,
          'Action'          => $RegardingAction,
          'Supplement'      => $RegardingActionSupplement
-      );
+      ];
 
       if ($Sender->Form->AuthenticatedPostBack()) {
          $RegardingTitle = sprintf(T("Reported: '{RegardingTitle}' by %s"), $ElementAuthorName);
@@ -203,7 +203,7 @@ class ReportingPlugin extends Gdn_Plugin {
       $ElementAuthor = Gdn::UserModel()->GetID($ElementAuthorID);
       $ElementAuthorName = GetValue('Name', $ElementAuthor);
 
-      $ReportingData = array(
+      $ReportingData = [
          'Context'         => $Context,
          'ElementID'       => $ElementID,
          'ElementTitle'    => $ElementTitle,
@@ -212,7 +212,7 @@ class ReportingPlugin extends Gdn_Plugin {
          'URL'             => $URL,
          'UserID'          => $UserID,
          'UserName'        => $UserName
-      );
+      ];
 
       $RegardingAction = C('Plugins.Reporting.AwesomeAction', FALSE);
       $RegardingActionSupplement = C('Plugins.Reporting.AwesomeActionSupplement', FALSE);
@@ -249,7 +249,7 @@ class ReportingPlugin extends Gdn_Plugin {
    public function DiscussionController_AfterReactions_Handler($Sender) {
       $Context = $Sender->EventArguments['Type'];
       $Text = FALSE;
-      $Style = array();
+      $Style = [];
 
       $Context = strtolower($Sender->EventArguments['Type']);
 
@@ -312,20 +312,20 @@ class ReportingPlugin extends Gdn_Plugin {
     */
 
    public function Gdn_Regarding_RegardingDisplay_Handler($Sender) {
-      $Event = $Sender->MatchEvent(array('report', 'awesome'), '*');
+      $Event = $Sender->MatchEvent(['report', 'awesome'], '*');
       if ($Event === FALSE)
          return;
 
       $Entity = GetValue('Entity', $Event);
       $RegardingData = GetValue('RegardingData', $Event);
       $RegardingType = GetValue('Type', $RegardingData);
-      $ReportInfo = array(
+      $ReportInfo = [
          'ReportingUser'         => Gdn::UserModel()->GetID(GetValue('InsertUserID', $RegardingData)),
          'EntityType'            => T(ucfirst(GetValue('ForeignType', $RegardingData))),
          'ReportedUser'          => Gdn::UserModel()->GetID(GetValue('InsertUserID', $Entity)),
          'ReportedTime'          => GetValue('DateInserted', $RegardingData),
          'EntityURL'             => GetValue('ForeignURL', $RegardingData, NULL)
-      );
+      ];
 
       if (!is_null($ReportedReason = GetValue('Comment', $RegardingData, NULL)))
          $ReportInfo['ReportedReason'] = $ReportedReason;

--- a/plugins/Reporting/views/awesome-regarding.php
+++ b/plugins/Reporting/views/awesome-regarding.php
@@ -1,10 +1,10 @@
 <div class="RegardingEvent">
    <span class="InformSprite Heart"/>&nbsp;</span> <?php 
-      echo FormatString(T("{ReportingUser} likes this {EntityType} written by {ReportedUser}"), array(
+      echo FormatString(T("{ReportingUser} likes this {EntityType} written by {ReportedUser}"), [
          'ReportingUser'      => UserAnchor(GetValue('ReportingUser', $this->Data('ReportInfo')), 'ReportingUser'),
          'EntityType'         => GetValue('EntityType', $this->Data('ReportInfo')),
          'ReportedUser'       => UserAnchor(GetValue('ReportedUser', $this->Data('ReportInfo')), 'ReportedUser')
-      ));
+      ]);
    ?>
    <div class="RegardingTime"><?php 
       $ReportedDate = GetValue('ReportedTime', $this->Data('ReportInfo'));

--- a/plugins/Reporting/views/awesome.php
+++ b/plugins/Reporting/views/awesome.php
@@ -31,7 +31,7 @@ echo $this->Form->Errors();
       <li>
          <?php
             echo $this->Form->Label('Reason', 'Plugin.Reporting.Reason');
-            echo Wrap($this->Form->TextBox('Plugin.Reporting.Reason', array('MultiLine' => TRUE)), 'div', array('class' => 'TextBoxWrapper'));
+            echo Wrap($this->Form->TextBox('Plugin.Reporting.Reason', ['MultiLine' => TRUE]), 'div', ['class' => 'TextBoxWrapper']);
          ?>
       </li>
       <?php

--- a/plugins/Reporting/views/report-regarding.php
+++ b/plugins/Reporting/views/report-regarding.php
@@ -1,10 +1,10 @@
 <div class="RegardingEvent">
    <span class="InformSprite Skull"/>&nbsp;</span> <?php 
-      echo FormatString(T("{ReportingUser} reported this {EntityType} written by {ReportedUser}"), array(
+      echo FormatString(T("{ReportingUser} reported this {EntityType} written by {ReportedUser}"), [
          'ReportingUser'      => UserAnchor(GetValue('ReportingUser', $this->Data('ReportInfo')), 'ReportingUser'),
          'EntityType'         => GetValue('EntityType', $this->Data('ReportInfo')),
          'ReportedUser'       => UserAnchor(GetValue('ReportedUser', $this->Data('ReportInfo')), 'ReportedUser')
-      ));
+      ]);
    ?>
    <div class="RegardingTime"><?php 
       $ReportedDate = GetValue('ReportedTime', $this->Data('ReportInfo'));

--- a/plugins/Reporting/views/report.php
+++ b/plugins/Reporting/views/report.php
@@ -31,7 +31,7 @@ echo $this->Form->Errors();
       <li>
          <?php
             echo $this->Form->Label('Reason', 'Plugin.Reporting.Reason');
-            echo Wrap($this->Form->TextBox('Plugin.Reporting.Reason', array('MultiLine' => TRUE)), 'div', array('class' => 'TextBoxWrapper'));
+            echo Wrap($this->Form->TextBox('Plugin.Reporting.Reason', ['MultiLine' => TRUE]), 'div', ['class' => 'TextBoxWrapper']);
          ?>
       </li>
       <?php

--- a/plugins/Reporting/views/settings.php
+++ b/plugins/Reporting/views/settings.php
@@ -9,10 +9,10 @@ $CategoryData = GetValue('CategoryData', $this->Data);
 <?php
    // Settings
 
-   $Features = array(
-      'report'    => array('Reporting Bad Content', "reports bad", "Find out who is posting objectionable content, where they're they're posting it, and take action."),
-      'awesome'   => array('Tagging Good Content', "tags awesome", "Get notified when people post great threads. Reward these people, and use their content to promote your site.")
-   );
+   $Features = [
+      'report'    => ['Reporting Bad Content', "reports bad", "Find out who is posting objectionable content, where they're they're posting it, and take action."],
+      'awesome'   => ['Tagging Good Content', "tags awesome", "Get notified when people post great threads. Reward these people, and use their content to promote your site."]
+   ];
 ?>
 <?php
 

--- a/plugins/Resolved/class.resolved.plugin.php
+++ b/plugins/Resolved/class.resolved.plugin.php
@@ -45,11 +45,11 @@ class ResolvedPlugin extends Gdn_Plugin {
      * @return void
      */
     public function resolve(&$discussion, $resolve) {
-        $resolution = array(
+        $resolution = [
             'Resolved' => $resolve,
             'DateResolved' => $resolve ? Gdn_Format::toDateTime() : null,
             'ResolvedUserID' => $resolve ? Gdn::session()->UserID : null
-        );
+        ];
 
         $discussionID = val('DiscussionID', $discussion);
         self::discussionModel()->setField($discussionID, $resolution);
@@ -64,7 +64,7 @@ class ResolvedPlugin extends Gdn_Plugin {
     public function base_afterBodyField_handler($sender, $args) {
         if (checkPermission('Plugins.Resolved.Manage')) {
             echo '<span class="ResolvedCheckbox">' .
-            $sender->Form->checkBox('Resolved', T('Resolved'), array('value' => '1')) . '</span>';
+            $sender->Form->checkBox('Resolved', T('Resolved'), ['value' => '1']) . '</span>';
         }
     }
 
@@ -84,11 +84,11 @@ class ResolvedPlugin extends Gdn_Plugin {
             if (isset($sender->Options)) {
                 $sender->Options .= wrap(anchor($label, $url, 'ResolveDiscussion Hijack'), 'li');
             } else {
-                $args['DiscussionOptions']['ResolveDiscussion'] = array(
+                $args['DiscussionOptions']['ResolveDiscussion'] = [
                     'Label' => $label,
                     'Url' => $url,
                     'Class' => 'ResolveDiscussion Hijack'
-                );
+                ];
             }
         }
     }
@@ -169,9 +169,9 @@ class ResolvedPlugin extends Gdn_Plugin {
     public function commentModel_afterSaveComment_handler($sender, $args) {
         $resolved = valr('FormPostValues.Resolved', $args);
         $discussionID = val('DiscussionID', $args['FormPostValues']);
-        $discussion = array(
+        $discussion = [
             'DiscussionID' => $discussionID
-        );
+        ];
         if (!checkPermission('Plugins.Resolved.Manage')) {
             // Unset Resolved flag
             $this->resolve($discussion, 0);
@@ -224,7 +224,7 @@ class ResolvedPlugin extends Gdn_Plugin {
             ->from('Discussion d')
             ->where('d.Resolved', 0)
             ->beginWhereGroup()
-            ->whereNotIn('d.Type', array('page', 'Report', 'poll', 'SimplePage'))
+            ->whereNotIn('d.Type', ['page', 'Report', 'poll', 'SimplePage'])
             ->orWhere('d.Type is null')
             ->endWhereGroup()
             ->get()
@@ -252,11 +252,11 @@ class ResolvedPlugin extends Gdn_Plugin {
         }
 
         $discussionModel = new DiscussionModel();
-        $wheres = array('d.Resolved' => '0');
+        $wheres = ['d.Resolved' => '0'];
 
         // Hack in our wheregroup.
         Gdn::sql()->beginWhereGroup()
-            ->whereNotIn('d.Type', array('page', 'Report', 'poll', 'SimplePage'))
+            ->whereNotIn('d.Type', ['page', 'Report', 'poll', 'SimplePage'])
             ->orWhere('d.Type is null')
             ->endWhereGroup();
 
@@ -299,7 +299,7 @@ class ResolvedPlugin extends Gdn_Plugin {
 
         // Render default view
         $sender->setData('Title', T('Unresolved'));
-        $sender->setData('Breadcrumbs', array(array('Name' => T('Unresolved'), 'Url' => '/discussions/unresolved')));
+        $sender->setData('Breadcrumbs', [['Name' => T('Unresolved'), 'Url' => '/discussions/unresolved']]);
         $sender->render('index');
     }
 

--- a/plugins/RightToLeft/class.righttoleft.plugin.php
+++ b/plugins/RightToLeft/class.righttoleft.plugin.php
@@ -15,7 +15,7 @@ class RightToLeftPlugin extends Gdn_Plugin {
     /**
     * @var array $rtlLocales List the locales that are rtl.
     */
-    protected $rtlLocales = array('ar', 'fa', 'he', 'ku', 'ps', 'sd', 'ug', 'ur', 'yi');
+    protected $rtlLocales = ['ar', 'fa', 'he', 'ku', 'ps', 'sd', 'ug', 'ur', 'yi'];
 
    /**
     * Add the rtl stylesheets to the page.

--- a/plugins/SMFCompatibility/class.smfcompatibility.plugin.php
+++ b/plugins/SMFCompatibility/class.smfcompatibility.plugin.php
@@ -48,9 +48,9 @@ class SMFCompatibilityPlugin extends Gdn_Plugin {
       $OldFormat = C('Garden.InputFormatter');
 
       if ($OldFormat != 'BBCode') {
-         SaveToConfig(array(
+         SaveToConfig([
             'Garden.InputFormatter' => 'BBCode',
-            'Garden.InputFormatterBak' => $OldFormat));
+            'Garden.InputFormatterBak' => $OldFormat]);
       }
 
       // Setup the default routes.

--- a/plugins/SMFCompatibility/functions.smf.php
+++ b/plugins/SMFCompatibility/functions.smf.php
@@ -27,14 +27,14 @@ define('WIRELESS', FALSE);
 function smf_setglobals() {
    global $modSettings, $context, $txt;
 
-   $modSettings = array();
+   $modSettings = [];
    $modSettings['enableBBC'] = TRUE;
    $modSettings['smileys_url'] = '';
    $modSettings['enableEmbeddedFlash'] = TRUE;
    $modSettings['lang_character_set'] = 'UTF-8';
    $modSettings['global_character_set'] = 'UTF-8';
 
-   $context = array();
+   $context = [];
    $context['browser']['is_gecko'] = FALSE;
    $context['browser']['is_mac_ie'] = FALSE;
    $context['browser']['is_ie'] = FALSE;
@@ -44,7 +44,7 @@ function smf_setglobals() {
    $context['browser']['is_ie7'] = FALSE;
    $context['server']['complex_preg_chars'] = FALSE;
 
-   $txt = array();
+   $txt = [];
    $txt['lang_character_set'] = 'utf8';
    $txt['smf238'] = T('Code');
    $txt['smf239'] = T('Quote from');
@@ -77,7 +77,7 @@ function highlight_php_code($code)
 	global $context;
 
 	// Remove special characters.
-	$code = un_htmlspecialchars(strtr($code, array('<br />' => "\n", "\t" => 'SMF_TAB();', '&#91;' => '[')));
+	$code = un_htmlspecialchars(strtr($code, ['<br />' => "\n", "\t" => 'SMF_TAB();', '&#91;' => '[']));
 
 	$oldlevel = error_reporting(0);
 
@@ -86,25 +86,25 @@ function highlight_php_code($code)
 	{
 		ob_start();
 		@highlight_string($code);
-		$buffer = str_replace(array("\n", "\r"), '', ob_get_contents());
+		$buffer = str_replace(["\n", "\r"], '', ob_get_contents());
 		ob_end_clean();
 	}
 	else
-		$buffer = str_replace(array("\n", "\r"), '', @highlight_string($code, true));
+		$buffer = str_replace(["\n", "\r"], '', @highlight_string($code, true));
 
 	error_reporting($oldlevel);
 
 	// Yes, I know this is kludging it, but this is the best way to preserve tabs from PHP :P.
 	$buffer = preg_replace('~SMF_TAB(</(font|span)><(font color|span style)="[^"]*?">)?\(\);~', "<pre style=\"display: inline;\">\t</pre>", $buffer);
 
-	return strtr($buffer, array('\'' => '&#039;', '<code>' => '', '</code>' => ''));
+	return strtr($buffer, ['\'' => '&#039;', '<code>' => '', '</code>' => '']);
 }
 
 // Parse bulletin board code in a string, as well as smileys optionally.
 function parse_bbc($message, $smileys = true, $cache_id = '')
 {
 	global $txt, $scripturl, $context, $modSettings, $user_info;
-	static $bbc_codes = array(), $itemcodes = array(), $no_autolink_tags = array();
+	static $bbc_codes = [], $itemcodes = [], $no_autolink_tags = [];
 	static $disabled;
 
 	// Never show smileys for wireless clients.  More bytes, can't see it anyway :P.
@@ -222,51 +222,51 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			  parsed inside the tag.
 		*/
 
-		$codes = array(
-			array(
+		$codes = [
+			[
 				'tag' => 'abbr',
 				'type' => 'unparsed_equals',
 				'before' => '<abbr title="$1">',
 				'after' => '</abbr>',
 				'quoted' => 'optional',
 				'disabled_after' => ' ($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'acronym',
 				'type' => 'unparsed_equals',
 				'before' => '<acronym title="$1">',
 				'after' => '</acronym>',
 				'quoted' => 'optional',
 				'disabled_after' => ' ($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'anchor',
 				'type' => 'unparsed_equals',
 				'test' => '[#]?([A-Za-z][A-Za-z0-9_\-]*)\]',
 				'before' => '<span id="post_$1" />',
 				'after' => '',
-			),
-			array(
+			],
+			[
 				'tag' => 'b',
 				'before' => '<b>',
 				'after' => '</b>',
-			),
-			array(
+			],
+			[
 				'tag' => 'black',
 				'before' => '<span style="color: black;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'blue',
 				'before' => '<span style="color: blue;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'br',
 				'type' => 'closed',
 				'content' => '<br />',
-			),
-			array(
+			],
+			[
 				'tag' => 'code',
 				'type' => 'unparsed_content',
 				'content' => '<div class="codeheader">' . $txt['smf238'] . ':</div><div class="code">' . ($context['browser']['is_gecko'] ? '<pre style="margin-top: 0; display: inline;">$1</pre>' : '$1') . '</div>',
@@ -303,8 +303,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 							$data = str_replace("\t", "<span style=\"white-space: pre;\">\t</span>", $data);
 					}'),
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'code',
 				'type' => 'unparsed_equals_content',
 				'content' => '<div class="codeheader">' . $txt['smf238'] . ': ($2)</div><div class="code">' . ($context['browser']['is_gecko'] ? '<pre style="margin-top: 0; display: inline;">$1</pre>' : '$1') . '</div>',
@@ -341,37 +341,37 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 							$data = str_replace("\t", "<span style=\"white-space: pre;\">\t</span>", $data);
 					}'),
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'center',
 				'before' => '<div align="center">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'color',
 				'type' => 'unparsed_equals',
 				'test' => '(#[\da-fA-F]{3}|#[\da-fA-F]{6}|[A-Za-z]{1,12})\]',
 				'before' => '<span style="color: $1;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'email',
 				'type' => 'unparsed_content',
 				'content' => '<a href="mailto:$1">$1</a>',
 				// !!! Should this respect guest_hideContacts?
 				'validate' => create_function('&$tag, &$data, $disabled', '$data = strtr($data, array(\'<br />\' => \'\'));'),
-			),
-			array(
+			],
+			[
 				'tag' => 'email',
 				'type' => 'unparsed_equals',
 				'before' => '<a href="mailto:$1">',
 				'after' => '</a>',
 				// !!! Should this respect guest_hideContacts?
-				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
+				'disallow_children' => ['email', 'ftp', 'url', 'iurl'],
 				'disabled_after' => ' ($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'ftp',
 				'type' => 'unparsed_content',
 				'content' => '<a href="$1" target="_blank">$1</a>',
@@ -380,8 +380,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					if (strpos($data, \'ftp://\') !== 0 && strpos($data, \'ftps://\') !== 0)
 						$data = \'ftp://\' . $data;
 				'),
-			),
-			array(
+			],
+			[
 				'tag' => 'ftp',
 				'type' => 'unparsed_equals',
 				'before' => '<a href="$1" target="_blank">',
@@ -390,17 +390,17 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					if (strpos($data, \'ftp://\') !== 0 && strpos($data, \'ftps://\') !== 0)
 						$data = \'ftp://\' . $data;
 				'),
-				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
+				'disallow_children' => ['email', 'ftp', 'url', 'iurl'],
 				'disabled_after' => ' ($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'font',
 				'type' => 'unparsed_equals',
 				'test' => '[A-Za-z0-9_,\-\s]+?\]',
 				'before' => '<span style="font-family: $1;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'flash',
 				'type' => 'unparsed_commas_content',
 				'test' => '\d+,\d+\]',
@@ -412,40 +412,40 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 						$data[0] = \'http://\' . $data[0];
 				'),
 				'disabled_content' => '<a href="$1" target="_blank">$1</a>',
-			),
-			array(
+			],
+			[
 				'tag' => 'green',
 				'before' => '<span style="color: green;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'glow',
 				'type' => 'unparsed_commas',
 				'test' => '[#0-9a-zA-Z\-]{3,12},([012]\d{1,2}|\d{1,2})(,[^]]+)?\]',
 				'before' => $context['browser']['is_ie'] ? '<table border="0" cellpadding="0" cellspacing="0" style="display: inline; vertical-align: middle; font: inherit;"><tr><td style="filter: Glow(color=$1, strength=$2); font: inherit;">' : '<span style="background-color: $1;">',
 				'after' => $context['browser']['is_ie'] ? '</td></tr></table> ' : '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'hr',
 				'type' => 'closed',
 				'content' => '<hr />',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'html',
 				'type' => 'unparsed_content',
 				'content' => '$1',
 				'block_level' => true,
 				'disabled_content' => '$1',
-			),
-			array(
+			],
+			[
 				'tag' => 'img',
 				'type' => 'unparsed_content',
-				'parameters' => array(
-					'alt' => array('optional' => true),
-					'width' => array('optional' => true, 'value' => ' width="$1"', 'match' => '(\d+)'),
-					'height' => array('optional' => true, 'value' => ' height="$1"', 'match' => '(\d+)'),
-				),
+				'parameters' => [
+					'alt' => ['optional' => true],
+					'width' => ['optional' => true, 'value' => ' width="$1"', 'match' => '(\d+)'],
+					'height' => ['optional' => true, 'value' => ' height="$1"', 'match' => '(\d+)'],
+				],
 				'content' => '<img src="$1" alt="{alt}"{width}{height} border="0" />',
 				'validate' => create_function('&$tag, &$data, $disabled', '
 					$data = strtr($data, array(\'<br />\' => \'\'));
@@ -453,8 +453,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 						$data = \'http://\' . $data;
 				'),
 				'disabled_content' => '($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'img',
 				'type' => 'unparsed_content',
 				'content' => '<img src="$1" alt="" border="0" />',
@@ -464,13 +464,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 						$data = \'http://\' . $data;
 				'),
 				'disabled_content' => '($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'i',
 				'before' => '<i>',
 				'after' => '</i>',
-			),
-			array(
+			],
+			[
 				'tag' => 'iurl',
 				'type' => 'unparsed_content',
 				'content' => '<a href="$1">$1</a>',
@@ -479,8 +479,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					if (strpos($data, \'http://\') !== 0 && strpos($data, \'https://\') !== 0)
 						$data = \'http://\' . $data;
 				'),
-			),
-			array(
+			],
+			[
 				'tag' => 'iurl',
 				'type' => 'unparsed_equals',
 				'before' => '<a href="$1">',
@@ -491,51 +491,51 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					elseif (strpos($data, \'http://\') !== 0 && strpos($data, \'https://\') !== 0)
 						$data = \'http://\' . $data;
 				'),
-				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
+				'disallow_children' => ['email', 'ftp', 'url', 'iurl'],
 				'disabled_after' => ' ($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'li',
 				'before' => '<li>',
 				'after' => '</li>',
 				'trim' => 'outside',
-				'require_parents' => array('list'),
+				'require_parents' => ['list'],
 				'block_level' => true,
 				'disabled_before' => '',
 				'disabled_after' => '<br />',
-			),
-			array(
+			],
+			[
 				'tag' => 'list',
 				'before' => '<ul style="margin-top: 0; margin-bottom: 0;">',
 				'after' => '</ul>',
 				'trim' => 'inside',
-				'require_children' => array('li'),
+				'require_children' => ['li'],
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'list',
-				'parameters' => array(
-					'type' => array('match' => '(none|disc|circle|square|decimal|decimal-leading-zero|lower-roman|upper-roman|lower-alpha|upper-alpha|lower-greek|lower-latin|upper-latin|hebrew|armenian|georgian|cjk-ideographic|hiragana|katakana|hiragana-iroha|katakana-iroha)'),
-				),
+				'parameters' => [
+					'type' => ['match' => '(none|disc|circle|square|decimal|decimal-leading-zero|lower-roman|upper-roman|lower-alpha|upper-alpha|lower-greek|lower-latin|upper-latin|hebrew|armenian|georgian|cjk-ideographic|hiragana|katakana|hiragana-iroha|katakana-iroha)'],
+				],
 				'before' => '<ul style="margin-top: 0; margin-bottom: 0; list-style-type: {type};">',
 				'after' => '</ul>',
 				'trim' => 'inside',
-				'require_children' => array('li'),
+				'require_children' => ['li'],
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'left',
 				'before' => '<div style="text-align: left;">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'ltr',
 				'before' => '<div dir="ltr">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'me',
 				'type' => 'unparsed_equals',
 				'before' => '<div class="meaction">* $1 ',
@@ -544,24 +544,24 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				'block_level' => true,
 				'disabled_before' => '/me ',
 				'disabled_after' => '<br />',
-			),
-			array(
+			],
+			[
 				'tag' => 'move',
 				'before' => '<marquee>',
 				'after' => '</marquee>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'nobbc',
 				'type' => 'unparsed_content',
 				'content' => '$1',
-			),
-			array(
+			],
+			[
 				'tag' => 'pre',
 				'before' => '<pre>',
 				'after' => '</pre>',
-			),
-			array(
+			],
+			[
 				'tag' => 'php',
 				'type' => 'unparsed_content',
 				'content' => '<div class="phpcode">$1</div>',
@@ -575,99 +575,99 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					}'),
 				'block_level' => true,
 				'disabled_content' => '$1',
-			),
-			array(
+			],
+			[
 				'tag' => 'quote',
 				'before' => '<div class="quoteheader">' . $txt['smf240'] . '</div><div class="quote">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'quote',
-				'parameters' => array(
-					'author' => array('match' => '(.{1,192}?)', 'quoted' => true, 'validate' => 'parse_bbc'),
-				),
+				'parameters' => [
+					'author' => ['match' => '(.{1,192}?)', 'quoted' => true, 'validate' => 'parse_bbc'],
+				],
 				'before' => '<div class="quoteheader">' . $txt['smf239'] . ': {author}</div><div class="quote">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'quote',
 				'type' => 'parsed_equals',
 				'before' => '<div class="quoteheader">' . $txt['smf239'] . ': $1</div><div class="quote">',
 				'after' => '</div>',
 				'quoted' => 'optional',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'quote',
-				'parameters' => array(
-					'author' => array('match' => '([^<>]{1,192}?)'),
-					'link' => array('match' => '(?:board=\d+;)?((?:topic|threadid)=[\dmsg#\./]{1,40}(?:;start=[\dmsg#\./]{1,40})?|action=profile;u=\d+)'),
-					'date' => array('match' => '(\d+)', 'validate' => 'timeformat'),
-				),
+				'parameters' => [
+					'author' => ['match' => '([^<>]{1,192}?)'],
+					'link' => ['match' => '(?:board=\d+;)?((?:topic|threadid)=[\dmsg#\./]{1,40}(?:;start=[\dmsg#\./]{1,40})?|action=profile;u=\d+)'],
+					'date' => ['match' => '(\d+)', 'validate' => 'timeformat'],
+				],
 				'before' => '<div class="quoteheader"><a href="' . $scripturl . '?{link}">' . $txt['smf239'] . ': {author} ' . $txt[176] . ' {date}</a></div><div class="quote">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'quote',
-				'parameters' => array(
-					'author' => array('match' => '(.{1,192}?)', 'validate' => 'parse_bbc'),
-				),
+				'parameters' => [
+					'author' => ['match' => '(.{1,192}?)', 'validate' => 'parse_bbc'],
+				],
 				'before' => '<div class="quoteheader">' . $txt['smf239'] . ': {author}</div><div class="quote">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'right',
 				'before' => '<div style="text-align: right;">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'red',
 				'before' => '<span style="color: red;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'rtl',
 				'before' => '<div dir="rtl">',
 				'after' => '</div>',
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 's',
 				'before' => '<del>',
 				'after' => '</del>',
-			),
-			array(
+			],
+			[
 				'tag' => 'size',
 				'type' => 'unparsed_equals',
 				'test' => '([1-9][\d]?p[xt]|(?:x-)?small(?:er)?|(?:x-)?large[r]?)\]',
 				// !!! line-height
 				'before' => '<span style="font-size: $1; line-height: 1.3em;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'size',
 				'type' => 'unparsed_equals',
 				'test' => '[1-9]\]',
 				// !!! line-height
 				'before' => '<font size="$1" style="line-height: 1.3em;">',
 				'after' => '</font>',
-			),
-			array(
+			],
+			[
 				'tag' => 'sub',
 				'before' => '<sub>',
 				'after' => '</sub>',
-			),
-			array(
+			],
+			[
 				'tag' => 'sup',
 				'before' => '<sup>',
 				'after' => '</sup>',
-			),
-			array(
+			],
+			[
 				'tag' => 'shadow',
 				'type' => 'unparsed_commas',
 				'test' => '[#0-9a-zA-Z\-]{3,12},(left|right|top|bottom|[0123]\d{0,2})\]',
@@ -694,8 +694,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 						return \'-2px 0\';
 					else
 						return \'0 0\';'),
-			),
-			array(
+			],
+			[
 				'tag' => 'time',
 				'type' => 'unparsed_content',
 				'content' => '$1',
@@ -704,42 +704,42 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 						$data = timeformat($data);
 					else
 						$tag[\'content\'] = \'[time]$1[/time]\';'),
-			),
-			array(
+			],
+			[
 				'tag' => 'tt',
 				'before' => '<tt>',
 				'after' => '</tt>',
-			),
-			array(
+			],
+			[
 				'tag' => 'table',
 				'before' => '<table style="font: inherit; color: inherit;">',
 				'after' => '</table>',
 				'trim' => 'inside',
-				'require_children' => array('tr'),
+				'require_children' => ['tr'],
 				'block_level' => true,
-			),
-			array(
+			],
+			[
 				'tag' => 'tr',
 				'before' => '<tr>',
 				'after' => '</tr>',
-				'require_parents' => array('table'),
-				'require_children' => array('td'),
+				'require_parents' => ['table'],
+				'require_children' => ['td'],
 				'trim' => 'both',
 				'block_level' => true,
 				'disabled_before' => '',
 				'disabled_after' => '',
-			),
-			array(
+			],
+			[
 				'tag' => 'td',
 				'before' => '<td valign="top" style="font: inherit; color: inherit;">',
 				'after' => '</td>',
-				'require_parents' => array('tr'),
+				'require_parents' => ['tr'],
 				'trim' => 'outside',
 				'block_level' => true,
 				'disabled_before' => '',
 				'disabled_after' => '',
-			),
-			array(
+			],
+			[
 				'tag' => 'url',
 				'type' => 'unparsed_content',
 				'content' => '<a href="$1" target="_blank">$1</a>',
@@ -748,8 +748,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					if (strpos($data, \'http://\') !== 0 && strpos($data, \'https://\') !== 0)
 						$data = \'http://\' . $data;
 				'),
-			),
-			array(
+			],
+			[
 				'tag' => 'url',
 				'type' => 'unparsed_equals',
 				'before' => '<a href="$1" target="_blank">',
@@ -758,27 +758,27 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					if (strpos($data, \'http://\') !== 0 && strpos($data, \'https://\') !== 0)
 						$data = \'http://\' . $data;
 				'),
-				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
+				'disallow_children' => ['email', 'ftp', 'url', 'iurl'],
 				'disabled_after' => ' ($1)',
-			),
-			array(
+			],
+			[
 				'tag' => 'u',
 				'before' => '<span style="text-decoration: underline;">',
 				'after' => '</span>',
-			),
-			array(
+			],
+			[
 				'tag' => 'white',
 				'before' => '<span style="color: white;">',
 				'after' => '</span>',
-			),
-		);
+			],
+		];
 
 		// This is mainly for the bbc manager, so it's easy to add tags above.  Custom BBC should be added above this line.
 		if ($message === false)
 			return $codes;
 
 		// So the parser won't skip them.
-		$itemcodes = array(
+		$itemcodes = [
 			'*' => '',
 			'@' => 'disc',
 			'+' => 'square',
@@ -787,34 +787,34 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			'o' => 'circle',
 			'O' => 'circle',
 			'0' => 'circle',
-		);
+		];
 		if (!isset($disabled['li']) && !isset($disabled['list']))
 		{
 			foreach ($itemcodes as $c => $dummy)
-				$bbc_codes[$c] = array();
+				$bbc_codes[$c] = [];
 		}
 
 		// Inside these tags autolink is not recommendable.
-		$no_autolink_tags = array(
+		$no_autolink_tags = [
 			'url',
 			'iurl',
 			'ftp',
 			'email',
-		);
+		];
 
 		// Shhhh!
 		if (!isset($disabled['color']))
 		{
-			$codes[] = array(
+			$codes[] = [
 				'tag' => 'chrissy',
 				'before' => '<span style="color: #CC0099;">',
 				'after' => ' :-*</span>',
-			);
-			$codes[] = array(
+			];
+			$codes[] = [
 				'tag' => 'kissy',
 				'before' => '<span style="color: #CC0099;">',
 				'after' => ' :-*</span>',
-			);
+			];
 		}
 
 		foreach ($codes as $c)
@@ -867,8 +867,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 		// !!! Interface/setting to add more?
 	}
 
-	$open_tags = array();
-	$message = strtr($message, array("\n" => '<br />'));
+	$open_tags = [];
+	$message = strtr($message, ["\n" => '<br />']);
 
 	// The non-breaking-space looks a bit different each time.
 	$non_breaking_space = $context['utf8'] ? ($context['server']['complex_preg_chars'] ? '\x{C2A0}' : chr(0xC2) . chr(0xA0)) : '\xA0';
@@ -897,16 +897,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				$data = preg_replace('~&lt;/a&gt;~i', '[/url]', $data);
 
 				// <br /> should be empty.
-				$empty_tags = array('br', 'hr');
+				$empty_tags = ['br', 'hr'];
 				foreach ($empty_tags as $tag)
-					$data = str_replace(array('&lt;' . $tag . '&gt;', '&lt;' . $tag . '/&gt;', '&lt;' . $tag . ' /&gt;'), '[' . $tag . ' /]', $data);
+					$data = str_replace(['&lt;' . $tag . '&gt;', '&lt;' . $tag . '/&gt;', '&lt;' . $tag . ' /&gt;'], '[' . $tag . ' /]', $data);
 
 				// b, u, i, s, pre... basic tags.
-				$closable_tags = array('b', 'u', 'i', 's', 'em', 'ins', 'del', 'pre', 'blockquote');
+				$closable_tags = ['b', 'u', 'i', 's', 'em', 'ins', 'del', 'pre', 'blockquote'];
 				foreach ($closable_tags as $tag)
 				{
 					$diff = substr_count($data, '&lt;' . $tag . '&gt;') - substr_count($data, '&lt;/' . $tag . '&gt;');
-					$data = strtr($data, array('&lt;' . $tag . '&gt;' => '<' . $tag . '>', '&lt;/' . $tag . '&gt;' => '</' . $tag . '>'));
+					$data = strtr($data, ['&lt;' . $tag . '&gt;' => '<' . $tag . '>', '&lt;/' . $tag . '&gt;' => '</' . $tag . '>']);
 
 					if ($diff > 0)
 						$data .= str_repeat('</' . $tag . '>', $diff);
@@ -916,7 +916,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				preg_match_all('~&lt;img\s+src=((?:&quot;)?)((?:https?://|ftps?://)\S+?)\\1(?:\s+alt=(&quot;.*?&quot;|\S*?))?(?:\s?/)?&gt;~i', $data, $matches, PREG_PATTERN_ORDER);
 				if (!empty($matches[0]))
 				{
-					$replaces = array();
+					$replaces = [];
 					foreach ($matches[2] as $match => $imgtag)
 					{
 						$alt = empty($matches[3][$match]) ? '' : ' alt=' . preg_replace('~^&quot;|&quot;$~', '', $matches[3][$match]);
@@ -977,19 +977,19 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 					if (!isset($disabled['url']) && (strpos($data, '://') !== false || strpos($data, 'www.') !== false))
 					{
 						// Switch out quotes really quick because they can cause problems.
-						$data = strtr($data, array('&#039;' => '\'', '&nbsp;' => $context['utf8'] ? "\xC2\xA0" : "\xA0", '&quot;' => '>">', '"' => '<"<', '&lt;' => '<lt<'));
+						$data = strtr($data, ['&#039;' => '\'', '&nbsp;' => $context['utf8'] ? "\xC2\xA0" : "\xA0", '&quot;' => '>">', '"' => '<"<', '&lt;' => '<lt<']);
 
 						// Only do this if the preg survives.
-						if (is_string($result = preg_replace(array(
+						if (is_string($result = preg_replace([
 							'~(?<=[\s>\.(;\'"]|^)((?:http|https|ftp|ftps)://[\w\-_%@:|]+(?:\.[\w\-_%]+)*(?::\d+)?(?:/[\w\-_\~%\.@,\?&;=#(){}+:\'\\\\]*)*[/\w\-_\~%@\?;=#}\\\\])~i',
 							'~(?<=[\s>(\'<]|^)(www(?:\.[\w\-_]+)+(?::\d+)?(?:/[\w\-_\~%\.@,\?&;=#(){}+:\'\\\\]*)*[/\w\-_\~%@\?;=#}\\\\])~i'
-						), array(
+						], [
 							'[url]$1[/url]',
 							'[url=http://$1]$1[/url]'
-						), $data)))
+						], $data)))
 							$data = $result;
 
-						$data = strtr($data, array('\'' => '&#039;', $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;', '>">' => '&quot;', '<"<' => '"', '<lt<' => '&lt;'));
+						$data = strtr($data, ['\'' => '&#039;', $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;', '>">' => '&quot;', '<"<' => '"', '<lt<' => '&lt;']);
 					}
 
 					// Next, emails...
@@ -1001,7 +1001,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				}
 			}
 
-			$data = strtr($data, array("\t" => '&nbsp;&nbsp;&nbsp;'));
+			$data = strtr($data, ["\t" => '&nbsp;&nbsp;&nbsp;']);
 
 			if (!empty($modSettings['fixLongWords']) && $modSettings['fixLongWords'] > 5)
 			{
@@ -1022,12 +1022,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				if (strlen($data) > $modSettings['fixLongWords'])
 				{
 					// This is done in a roundabout way because $breaker has "long words" :P.
-					$data = strtr($data, array($breaker => '< >', '&nbsp;' => $context['utf8'] ? "\xC2\xA0" : "\xA0"));
+					$data = strtr($data, [$breaker => '< >', '&nbsp;' => $context['utf8'] ? "\xC2\xA0" : "\xA0"]);
 					$data = preg_replace(
 						'~(?<=[>;:!? ' . $non_breaking_space . '\]()]|^)([\w\.]{' . $modSettings['fixLongWords'] . ',})~e' . ($context['utf8'] ? 'u' : ''),
 						"preg_replace('/(.{" . ($modSettings['fixLongWords'] - 1) . '})/' . ($context['utf8'] ? 'u' : '') . "', '\\\$1< >', '\$1')",
 						$data);
-					$data = strtr($data, array('< >' => $breaker, $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;'));
+					$data = strtr($data, ['< >' => $breaker, $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;']);
 				}
 			}
 
@@ -1060,7 +1060,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				continue;
 			$look_for = strtolower(substr($message, $pos + 2, $pos2 - $pos - 2));
 
-			$to_close = array();
+			$to_close = [];
 			$block_level = null;
 			do
 			{
@@ -1142,7 +1142,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 
 			if (!empty($to_close))
 			{
-				$to_close = array();
+				$to_close = [];
 				$pos--;
 			}
 
@@ -1175,7 +1175,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			elseif (isset($possible['type']))
 			{
 				// Do we need an equal sign?
-				if (in_array($possible['type'], array('unparsed_equals', 'unparsed_commas', 'unparsed_commas_content', 'unparsed_equals_content', 'parsed_equals')) && $next_c != '=')
+				if (in_array($possible['type'], ['unparsed_equals', 'unparsed_commas', 'unparsed_commas_content', 'unparsed_equals_content', 'parsed_equals']) && $next_c != '=')
 					continue;
 				// Maybe we just want a /...
 				if ($possible['type'] == 'closed' && $next_c != ']' && substr($message, $pos + 1 + strlen($possible['tag']), 2) != '/]' && substr($message, $pos + 1 + strlen($possible['tag']), 3) != ' /]')
@@ -1202,7 +1202,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			// This is long, but it makes things much easier and cleaner.
 			if (!empty($possible['parameters']))
 			{
-				$preg = array();
+				$preg = [];
 				foreach ($possible['parameters'] as $p => $info)
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
 
@@ -1220,19 +1220,19 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				if (!$match)
 					continue;
 
-				$params = array();
+				$params = [];
 				for ($i = 1, $n = count($matches); $i < $n; $i += 2)
 				{
 					$key = strtok(ltrim($matches[$i]), '=');
 					if (isset($possible['parameters'][$key]['value']))
-						$params['{' . $key . '}'] = strtr($possible['parameters'][$key]['value'], array('$1' => $matches[$i + 1]));
+						$params['{' . $key . '}'] = strtr($possible['parameters'][$key]['value'], ['$1' => $matches[$i + 1]]);
 					elseif (isset($possible['parameters'][$key]['validate']))
 						$params['{' . $key . '}'] = $possible['parameters'][$key]['validate']($matches[$i + 1]);
 					else
 						$params['{' . $key . '}'] = $matches[$i + 1];
 
 					// Just to make sure: replace any $ or { so they can't interpolate wrongly.
-					$params['{' . $key . '}'] = strtr($params['{' . $key . '}'], array('$' => '&#036;', '{' => '&#123;'));
+					$params['{' . $key . '}'] = strtr($params['{' . $key . '}'], ['$' => '&#036;', '{' => '&#123;']);
 				}
 
 				foreach ($possible['parameters'] as $p => $info)
@@ -1261,20 +1261,20 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 		// Item codes are complicated buggers... they are implicit [li]s and can make [list]s!
 		if ($smileys !== false && $tag === null && isset($itemcodes[substr($message, $pos + 1, 1)]) && substr($message, $pos + 2, 1) == ']' && !isset($disabled['list']) && !isset($disabled['li']))
 		{
-			if (substr($message, $pos + 1, 1) == '0' && !in_array(substr($message, $pos - 1, 1), array(';', ' ', "\t", '>')))
+			if (substr($message, $pos + 1, 1) == '0' && !in_array(substr($message, $pos - 1, 1), [';', ' ', "\t", '>']))
 				continue;
 			$tag = $itemcodes[substr($message, $pos + 1, 1)];
 
 			// First let's set up the tree: it needs to be in a list, or after an li.
 			if ($inside === null || ($inside['tag'] != 'list' && $inside['tag'] != 'li'))
 			{
-				$open_tags[] = array(
+				$open_tags[] = [
 					'tag' => 'list',
 					'after' => '</ul>',
 					'block_level' => true,
-					'require_children' => array('li'),
+					'require_children' => ['li'],
 					'disallow_children' => isset($inside['disallow_children']) ? $inside['disallow_children'] : null,
-				);
+				];
 				$code = '<ul style="margin-top: 0; margin-bottom: 0;">';
 			}
 			// We're in a list item already: another itemcode?  Close it first.
@@ -1287,13 +1287,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 				$code = '';
 
 			// Now we open a new tag.
-			$open_tags[] = array(
+			$open_tags[] = [
 				'tag' => 'li',
 				'after' => '</li>',
 				'trim' => 'outside',
 				'block_level' => true,
 				'disallow_children' => isset($inside['disallow_children']) ? $inside['disallow_children'] : null,
-			);
+			];
 
 			// First, open the tag...
 			$code .= '<li' . ($tag == '' ? '' : ' type="' . $tag . '"') . '>';
@@ -1403,7 +1403,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			if (isset($tag['validate']))
 				$tag['validate']($tag, $data, $disabled);
 
-			$code = strtr($tag['content'], array('$1' => $data));
+			$code = strtr($tag['content'], ['$1' => $data]);
 			$message = substr($message, 0, $pos) . $code . substr($message, $pos2 + 3 + strlen($tag['tag']));
 			$pos += strlen($code) - 1;
 		}
@@ -1430,10 +1430,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			if ($pos3 === false)
 				continue;
 
-			$data = array(
+			$data = [
 				substr($message, $pos2 + ($quoted == false ? 1 : 7), $pos3 - ($pos2 + ($quoted == false ? 1 : 7))),
 				substr($message, $pos1, $pos2 - $pos1)
-			);
+			];
 
 			if (!empty($tag['block_level']) && substr($data[0], 0, 6) == '<br />')
 				$data[0] = substr($data[0], 6);
@@ -1442,7 +1442,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			if (isset($tag['validate']))
 				$tag['validate']($tag, $data, $disabled);
 
-			$code = strtr($tag['content'], array('$1' => $data[0], '$2' => $data[1]));
+			$code = strtr($tag['content'], ['$1' => $data[0], '$2' => $data[1]]);
 			$message = substr($message, 0, $pos) . $code . substr($message, $pos3 + 3 + strlen($tag['tag']));
 			$pos += strlen($code) - 1;
 		}
@@ -1472,7 +1472,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 
 			$code = $tag['content'];
 			foreach ($data as $k => $d)
-				$code = strtr($code, array('$' . ($k + 1) => trim($d)));
+				$code = strtr($code, ['$' . ($k + 1) => trim($d)]);
 			$message = substr($message, 0, $pos) . $code . substr($message, $pos3 + 3 + strlen($tag['tag']));
 			$pos += strlen($code) - 1;
 		}
@@ -1490,14 +1490,14 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 
 			// Fix after, for disabled code mainly.
 			foreach ($data as $k => $d)
-				$tag['after'] = strtr($tag['after'], array('$' . ($k + 1) => trim($d)));
+				$tag['after'] = strtr($tag['after'], ['$' . ($k + 1) => trim($d)]);
 
 			$open_tags[] = $tag;
 
 			// Replace them out, $1, $2, $3, $4, etc.
 			$code = $tag['before'];
 			foreach ($data as $k => $d)
-				$code = strtr($code, array('$' . ($k + 1) => trim($d)));
+				$code = strtr($code, ['$' . ($k + 1) => trim($d)]);
 			$message = substr($message, 0, $pos) . $code . substr($message, $pos2 + 1);
 			$pos += strlen($code) - 1;
 		}
@@ -1531,11 +1531,11 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 			if ($tag['type'] != 'unparsed_equals')
 				$data = parse_bbc($data);
 
-			$tag['after'] = strtr($tag['after'], array('$1' => $data));
+			$tag['after'] = strtr($tag['after'], ['$1' => $data]);
 
 			$open_tags[] = $tag;
 
-			$code = strtr($tag['before'], array('$1' => $data));
+			$code = strtr($tag['before'], ['$1' => $data]);
 			$message = substr($message, 0, $pos) . $code . substr($message, $pos2 + ($quoted == false ? 1 : 7));
 			$pos += strlen($code) - 1;
 		}
@@ -1557,7 +1557,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 		$message = '&nbsp;' . substr($message, 1);
 
 	// Cleanup whitespace.
-	$message = strtr($message, array('  ' => ' &nbsp;', "\r" => '', "\n" => '<br />', '<br /> ' => '<br />&nbsp;', '&#13;' => "\n"));
+	$message = strtr($message, ['  ' => ' &nbsp;', "\r" => '', "\n" => '<br />', '<br /> ' => '<br />&nbsp;', '&#13;' => "\n"]);
 
 	// Cache the output if it took some time...
 	if (isset($cache_key, $cache_t) && array_sum(explode(' ', microtime())) - array_sum(explode(' ', $cache_t)) > 0.05)
@@ -1570,7 +1570,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '')
 function parsesmileys(&$message)
 {
 	global $modSettings, $db_prefix, $txt, $user_info, $context;
-	static $smileyfromcache = array(), $smileytocache = array();
+	static $smileyfromcache = [], $smileytocache = [];
 
 	// No smiley set at all?!
 	if ($user_info['smiley_set'] == 'none')
@@ -1582,9 +1582,9 @@ function parsesmileys(&$message)
 		// Use the default smileys if it is disabled. (better for "portability" of smileys.)
 		if (empty($modSettings['smiley_enable']))
 		{
-			$smileysfrom = array('>:D', ':D', '::)', '>:(', ':)', ';)', ';D', ':(', ':o', '8)', ':P', '???', ':-[', ':-X', ':-*', ':\'(', ':-\\', '^-^', 'O0', 'C:-)', '0:)');
-			$smileysto = array('evil.gif', 'cheesy.gif', 'rolleyes.gif', 'angry.gif', 'smiley.gif', 'wink.gif', 'grin.gif', 'sad.gif', 'shocked.gif', 'cool.gif', 'tongue.gif', 'huh.gif', 'embarrassed.gif', 'lipsrsealed.gif', 'kiss.gif', 'cry.gif', 'undecided.gif', 'azn.gif', 'afro.gif', 'police.gif', 'angel.gif');
-			$smileysdescs = array('', $txt[289], $txt[450], $txt[288], $txt[287], $txt[292], $txt[293], $txt[291], $txt[294], $txt[295], $txt[451], $txt[296], $txt[526], $txt[527], $txt[529], $txt[530], $txt[528], '', '', '', '');
+			$smileysfrom = ['>:D', ':D', '::)', '>:(', ':)', ';)', ';D', ':(', ':o', '8)', ':P', '???', ':-[', ':-X', ':-*', ':\'(', ':-\\', '^-^', 'O0', 'C:-)', '0:)'];
+			$smileysto = ['evil.gif', 'cheesy.gif', 'rolleyes.gif', 'angry.gif', 'smiley.gif', 'wink.gif', 'grin.gif', 'sad.gif', 'shocked.gif', 'cool.gif', 'tongue.gif', 'huh.gif', 'embarrassed.gif', 'lipsrsealed.gif', 'kiss.gif', 'cry.gif', 'undecided.gif', 'azn.gif', 'afro.gif', 'police.gif', 'angel.gif'];
+			$smileysdescs = ['', $txt[289], $txt[450], $txt[288], $txt[287], $txt[292], $txt[293], $txt[291], $txt[294], $txt[295], $txt[451], $txt[296], $txt[526], $txt[527], $txt[529], $txt[530], $txt[528], '', '', '', ''];
 		}
 		else
 		{
@@ -1594,9 +1594,9 @@ function parsesmileys(&$message)
 				$result = db_query("
 					SELECT code, filename, description
 					FROM {$db_prefix}smileys", __FILE__, __LINE__);
-				$smileysfrom = array();
-				$smileysto = array();
-				$smileysdescs = array();
+				$smileysfrom = [];
+				$smileysto = [];
+				$smileysdescs = [];
 				while ($row = mysql_fetch_assoc($result))
 				{
 					$smileysfrom[] = $row['code'];
@@ -1605,7 +1605,7 @@ function parsesmileys(&$message)
 				}
 				mysql_free_result($result);
 
-				cache_put_data('parsing_smileys', array($smileysfrom, $smileysto, $smileysdescs), 480);
+				cache_put_data('parsing_smileys', [$smileysfrom, $smileysto, $smileysdescs], 480);
 			}
 			else
 				list ($smileysfrom, $smileysto, $smileysdescs) = $temp;
@@ -1619,7 +1619,7 @@ function parsesmileys(&$message)
 		{
 			$smileyfromcache[] = '/(?<=[>:\?\.\s' . $non_breaking_space . '[\]()*\\\;]|^)(' . preg_quote($smileysfrom[$i], '/') . '|' . preg_quote(htmlspecialchars($smileysfrom[$i], ENT_QUOTES), '/') . ')(?=[^[:alpha:]0-9]|$)/' . ($context['utf8'] ? 'u' : '');
 			// Escape a bunch of smiley-related characters in the description so it doesn't get a double dose :P.
-			$smileytocache[] = '<img src="' . htmlspecialchars($modSettings['smileys_url'] . '/' . $user_info['smiley_set'] . '/' . $smileysto[$i]) . '" alt="' . strtr(htmlspecialchars($smileysdescs[$i]), array(':' => '&#58;', '(' => '&#40;', ')' => '&#41;', '$' => '&#36;', '[' => '&#091;')) . '" border="0" />';
+			$smileytocache[] = '<img src="' . htmlspecialchars($modSettings['smileys_url'] . '/' . $user_info['smiley_set'] . '/' . $smileysto[$i]) . '" alt="' . strtr(htmlspecialchars($smileysdescs[$i]), [':' => '&#58;', '(' => '&#40;', ')' => '&#41;', '$' => '&#36;', '[' => '&#091;']) . '" border="0" />';
 		}
 	}
 
@@ -1631,7 +1631,7 @@ function parsesmileys(&$message)
 // This gets all possible permutations of an array.
 function permute($array)
 {
-	$orders = array($array);
+	$orders = [$array];
 
 	$n = count($array);
 	$p = range(0, $n);
@@ -1696,14 +1696,14 @@ function timeformat($logTime, $show_today = true)
 
 	if (setlocale(LC_TIME, $txt['lang_locale']))
 	{
-		foreach (array('%a', '%A', '%b', '%B') as $token)
+		foreach (['%a', '%A', '%b', '%B'] as $token)
 			if (strpos($str, $token) !== false)
 				$str = str_replace($token, $func['ucwords'](strftime($token, $time)), $str);
 	}
 	else
 	{
 		// Do-it-yourself time localization.  Fun.
-		foreach (array('%a' => 'days_short', '%A' => 'days', '%b' => 'months_short', '%B' => 'months') as $token => $text_label)
+		foreach (['%a' => 'days_short', '%A' => 'days', '%b' => 'months_short', '%B' => 'months'] as $token => $text_label)
 			if (strpos($str, $token) !== false)
 				$str = str_replace($token, $txt[$text_label][(int) strftime($token === '%a' || $token === '%A' ? '%w' : '%m', $time)], $str);
 		if (strpos($str, '%p'))
@@ -1717,5 +1717,5 @@ function timeformat($logTime, $show_today = true)
 // Removes special entities from strings.  Compatibility...
 function un_htmlspecialchars($string)
 {
-	return strtr($string, array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES)) + array('&#039;' => '\'', '&nbsp;' => ' '));
+	return strtr($string, array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES)) + ['&#039;' => '\'', '&nbsp;' => ' ']);
 }

--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -63,7 +63,7 @@ SHARETHIS;
 
       $Validation = new Gdn_Validation();
       $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
-      $ConfigArray = array('Plugin.ShareThis.PublisherNumber','Plugin.ShareThis.ViaHandle', 'Plugin.ShareThis.CopyNShare');
+      $ConfigArray = ['Plugin.ShareThis.PublisherNumber','Plugin.ShareThis.ViaHandle', 'Plugin.ShareThis.CopyNShare'];
       if ($Sender->Form->AuthenticatedPostBack() === FALSE) {
          $ConfigArray['Plugin.ShareThis.PublisherNumber'] = $PublisherNumber;
          $ConfigArray['Plugin.ShareThis.ViaHandle'] = $ViaHandle;

--- a/plugins/Signatures/views/signature.php
+++ b/plugins/Signatures/views/signature.php
@@ -57,5 +57,5 @@
       ?>
    </li>
 </ul>
-<?php echo $this->Form->close('Save', '', array('class' => 'Button Primary')); ?>
+<?php echo $this->Form->close('Save', '', ['class' => 'Button Primary']); ?>
 </div>

--- a/plugins/Solr/class.searchmodel.php
+++ b/plugins/Solr/class.searchmodel.php
@@ -5,7 +5,7 @@
 
 class SearchModel extends Gdn_Model {
 	/// PROPERTIES ///
-   public $Types = array(1 => 'Discussion', 2 => 'Comment');
+   public $Types = [1 => 'Discussion', 2 => 'Comment'];
 
    /// METHODS ///
 
@@ -15,7 +15,7 @@ class SearchModel extends Gdn_Model {
          throw new Gdn_UserException("The search url has not been configured.");
 
       if (!$Search)
-         return array();
+         return [];
 
       // Escepe the search.
       $Search = preg_replace('`([][+&|!(){}^"~*?:\\\\-])`', "\\\\$1", $Search);
@@ -23,14 +23,14 @@ class SearchModel extends Gdn_Model {
       // Add the category watch.
       $Categories = CategoryModel::CategoryWatch();
       if ($Categories === FALSE) {
-         return array();
+         return [];
       } elseif ($Categories !== TRUE) {
          $Search = 'CategoryID:('.implode(' ', $Categories).') AND '.$Search;
       }
 
       // Build the search url.
       $BaseUrl .= strpos($BaseUrl, '?') === FALSE ? '?' : '&';
-      $Query = array('q' => $Search, 'start' => $Offset, 'rows' => $Limit);
+      $Query = ['q' => $Search, 'start' => $Offset, 'rows' => $Limit];
       $Url = $BaseUrl.http_build_query($Query);
 
       // Grab the data.
@@ -41,13 +41,13 @@ class SearchModel extends Gdn_Model {
 
       // Parse the result into the form that the search controller expects.
       $Xml = new SimpleXMLElement($CurlResult);
-      $Result = array();
+      $Result = [];
 
       if (!isset($Xml->result))
-         return array();
+         return [];
 
       foreach ($Xml->result->children() as $Doc) {
-         $Row = array();
+         $Row = [];
          foreach ($Doc->children() as $Field) {
             $Name = (string)$Field['name'];
             $Row[$Name] = (string)$Field;
@@ -67,7 +67,7 @@ class SearchModel extends Gdn_Model {
       }
 
       // Join the users into the result.
-      Gdn_DataSet::Join($Result, array('table' => 'User', 'parent' => 'UserID', 'prefix' => '', 'Name', 'Photo'));
+      Gdn_DataSet::Join($Result, ['table' => 'User', 'parent' => 'UserID', 'prefix' => '', 'Name', 'Photo']);
 
       return $Result;
 	}

--- a/plugins/Solr/class.solr.plugin.php
+++ b/plugins/Solr/class.solr.plugin.php
@@ -5,13 +5,13 @@
  */
 
 class SolrPlugin extends Gdn_Plugin {
-   public function SettingsController_Solr_Create($Sender, $Args = array()) {
+   public function SettingsController_Solr_Create($Sender, $Args = []) {
       $Sender->Permission('Garden.Settings.Manage');
 
       $Conf = new ConfigurationModule($Sender);
-      $Conf->Initialize(array(
-          'Plugins.Solr.SearchUrl' => array('Default' => 'http://localhost:8983/solr/select/?')
-      ));
+      $Conf->Initialize([
+          'Plugins.Solr.SearchUrl' => ['Default' => 'http://localhost:8983/solr/select/?']
+      ]);
 
       $Sender->AddSideMenu();
       $Sender->SetData('Title', T('Solr Search Settings'));

--- a/plugins/Spoof/class.spoof.plugin.php
+++ b/plugins/Spoof/class.spoof.plugin.php
@@ -35,11 +35,11 @@ class SpoofPlugin implements Gdn_IPlugin {
 		// Validate the transient key && permissions
 		if (Gdn::Session()->ValidateTransientKey($TransientKey) && Gdn::Session()->CheckPermission('Garden.Settings.Manage')) {
 			$Identity = new Gdn_CookieIdentity();
-			$Identity->Init(array(
+			$Identity->Init([
 				'Salt' => Gdn::Config('Garden.Cookie.Salt'),
 				'Name' => Gdn::Config('Garden.Cookie.Name'),
 				'Domain' => Gdn::Config('Garden.Cookie.Domain')
-			));
+			]);
 			$Identity->SetIdentity($SpoofUserID, TRUE);
 		}
 		if ($this->_DeliveryType !== DELIVERY_TYPE_ALL) {
@@ -89,7 +89,7 @@ class SpoofPlugin implements Gdn_IPlugin {
       $ViewingUserID = Gdn::Session()->UserID;
 
       if ($Sender->User->UserID != $ViewingUserID)
-         $SideMenu->AddLink('Options', T('Spoof User'), '/user/autospoof/'.$Sender->User->UserID.'/'.Gdn::Session()->TransientKey(), '', array('class' => 'PopConfirm'));
+         $SideMenu->AddLink('Options', T('Spoof User'), '/user/autospoof/'.$Sender->User->UserID.'/'.Gdn::Session()->TransientKey(), '', ['class' => 'PopConfirm']);
    }
 
 
@@ -123,11 +123,11 @@ class SpoofPlugin implements Gdn_IPlugin {
 
 				if ($SpoofUser) {
 					$Identity = new Gdn_CookieIdentity();
-					$Identity->Init(array(
+					$Identity->Init([
 						'Salt' => Gdn::Config('Garden.Cookie.Salt'),
 						'Name' => Gdn::Config('Garden.Cookie.Name'),
 						'Domain' => Gdn::Config('Garden.Cookie.Domain')
-					));
+					]);
 					$Identity->SetIdentity($SpoofUser->UserID, TRUE);
 	                redirectTo('profile');
 				} else {

--- a/plugins/SteamConnect/class.steamconnect.plugin.php
+++ b/plugins/SteamConnect/class.steamconnect.plugin.php
@@ -47,10 +47,10 @@ class SteamConnectPlugin extends Gdn_Plugin {
             $Url = $this->_AuthorizeHref();
 
             // Add the steam method to the controller.
-            $Method = array(
+            $Method = [
                 'Name' => 'Steam',
-                'SignInHtml' => SocialSigninButton('Steam', $Url, 'button', array('class' => 'js-extern'))
-            );
+                'SignInHtml' => SocialSigninButton('Steam', $Url, 'button', ['class' => 'js-extern'])
+            ];
 
             $Sender->Data['Methods'][] = $Method;
         }
@@ -75,13 +75,13 @@ class SteamConnectPlugin extends Gdn_Plugin {
     private function _GetButton() {
         if ($this->isConfig()) {
             $Url = $this->_AuthorizeHref();
-            return SocialSigninButton('Steam', $Url, 'icon', array('class' => 'js-extern'));
+            return SocialSigninButton('Steam', $Url, 'icon', ['class' => 'js-extern']);
         }
     }
 
     public function Base_BeforeSignInLink_Handler($Sender) {
         if (!Gdn::Session()->IsValid() && $this->isConfig()) {
-            echo "\n".Wrap($this->_GetButton(), 'li', array('class' => 'Connect SteamConnect'));
+            echo "\n".Wrap($this->_GetButton(), 'li', ['class' => 'Connect SteamConnect']);
         }
     }
 
@@ -92,10 +92,10 @@ class SteamConnectPlugin extends Gdn_Plugin {
         $SteamID = $this->getSteamID($OpenID);
 
         // Make a call to steam.
-        $qs = array(
+        $qs = [
             'key' => C('Plugins.SteamConnect.APIKey'),
             'steamids' => $SteamID
-        );
+        ];
 
         $url = 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?'.http_build_query($qs);
 
@@ -135,9 +135,9 @@ class SteamConnectPlugin extends Gdn_Plugin {
             .' <a href="http://steamcommunity.com/dev/apikey">'.T('Get one here.').'</a></div>';
 
         $Conf = new ConfigurationModule($Sender);
-        $Conf->Initialize(array(
-            'Plugins.SteamConnect.APIKey' => array('Control' => 'TextBox', 'LabelCode' => 'Steam Web API Key', 'Description' => $APIKeyDescription)
-        ));
+        $Conf->Initialize([
+            'Plugins.SteamConnect.APIKey' => ['Control' => 'TextBox', 'LabelCode' => 'Steam Web API Key', 'Description' => $APIKeyDescription]
+        ]);
 
         $Sender->AddSideMenu();
         $Sender->SetData('Title', sprintf(T('%s Settings'), T('Steam Connect')));

--- a/plugins/SubmarineDiscussions/class.submarinediscussions.plugin.php
+++ b/plugins/SubmarineDiscussions/class.submarinediscussions.plugin.php
@@ -7,7 +7,7 @@ class SubmarineDiscussionsPlugin extends Gdn_Plugin {
    public function PostController_DiscussionFormOptions_Handler($Sender) {
       $Session = Gdn::Session();
       if ($Session->CheckPermission('Vanilla.Discussions.Sink'))
-         $Sender->EventArguments['Options'] .= '<li>'.$Sender->Form->CheckBox('Sink', T('Sink'), array('value' => '1')).'</li>';
+         $Sender->EventArguments['Options'] .= '<li>'.$Sender->Form->CheckBox('Sink', T('Sink'), ['value' => '1']).'</li>';
    }
    
    /**

--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -60,7 +60,7 @@ class TouchIconPlugin extends Gdn_Plugin {
                   $TouchIconPath,
                   114,
                   114,
-                  array('OutputType' => 'png', 'ImageQuality' => '8')
+                  ['OutputType' => 'png', 'ImageQuality' => '8']
                );
 
                SaveToConfig('Garden.TouchIcon', $ImageInfo['SaveName']);

--- a/plugins/TouchIcon/views/touchicon.php
+++ b/plugins/TouchIcon/views/touchicon.php
@@ -3,7 +3,7 @@ $Session = Gdn::session();
 ?>
 <h1><?php echo T('Touch Icon'); ?></h1>
 <?php
-echo $this->Form->open(array('enctype' => 'multipart/form-data'));
+echo $this->Form->open(['enctype' => 'multipart/form-data']);
 echo $this->Form->errors();
 echo wrap(t('TouchIconInfo', 'The touch icon appears when you bookmark a website on the homescreen of an Apple device.
          These are usually 57x57 or 114x114 pixels. Apple adds rounded corners and lighting effect automatically.'),

--- a/plugins/TrackingCodes/class.trackingcodes.plugin.php
+++ b/plugins/TrackingCodes/class.trackingcodes.plugin.php
@@ -46,7 +46,7 @@ class TrackingCodesPlugin extends Gdn_Plugin {
       if ($TransientKey !== FALSE && $Session->ValidateTransientKey($TransientKey)) {
 			$TrackingCodes = C('Plugins.TrackingCodes.All');
 			if (!is_array($TrackingCodes))
-				$TrackingCodes = array();
+				$TrackingCodes = [];
 
 			if ($Key !== FALSE)
 				foreach ($TrackingCodes as $Index => $Code) {
@@ -72,7 +72,7 @@ class TrackingCodesPlugin extends Gdn_Plugin {
       if ($TransientKey !== FALSE && $Session->ValidateTransientKey($TransientKey)) {
 			$TrackingCodes = C('Plugins.TrackingCodes.All');
 			if (!is_array($TrackingCodes))
-				$TrackingCodes = array();
+				$TrackingCodes = [];
 
 			if ($Key !== FALSE)
 				foreach ($TrackingCodes as $Index => $Code) {
@@ -102,7 +102,7 @@ class TrackingCodesPlugin extends Gdn_Plugin {
 		$Sender->Code = FALSE;
 		$TrackingCodes = C('Plugins.TrackingCodes.All');
 		if (!is_array($TrackingCodes))
-			$TrackingCodes = array();
+			$TrackingCodes = [];
 
 		if ($EditKey !== FALSE)
 			foreach ($TrackingCodes as $Index => $Code) {
@@ -152,7 +152,7 @@ class TrackingCodesPlugin extends Gdn_Plugin {
 
 		$TrackingCodes = C('Plugins.TrackingCodes.All');
 		if (!is_array($TrackingCodes))
-			$TrackingCodes = array();
+			$TrackingCodes = [];
 		foreach ($TrackingCodes as $Index => $Code) {
 			if (GetValue('Enabled', $Code) == '1')
 				echo GetValue('Code', $Code);

--- a/plugins/TrackingCodes/views/edit.php
+++ b/plugins/TrackingCodes/views/edit.php
@@ -20,12 +20,12 @@ echo $this->Form->Errors();
    <li>
       <?php
          echo $this->Form->Label('Code', 'Code');
-         echo $this->Form->TextBox('Code', array('MultiLine' => TRUE));
+         echo $this->Form->TextBox('Code', ['MultiLine' => TRUE]);
       ?>
    </li>
    <li>
       <?php
-         echo $this->Form->CheckBox('Enabled', 'Enable this tracking code', array('value' => '1'));
+         echo $this->Form->CheckBox('Enabled', 'Enable this tracking code', ['value' => '1']);
       ?>
    </li>
 </ul>

--- a/plugins/TrackingCodes/views/index.php
+++ b/plugins/TrackingCodes/views/index.php
@@ -2,7 +2,7 @@
 $Session = Gdn::Session();
 $TrackingCodes = C('Plugins.TrackingCodes.All');
 if (!is_array($TrackingCodes))
-   $TrackingCodes = array();
+   $TrackingCodes = [];
 
 ?>
 <h1><?php echo T('Tracking Codes'); ?></h1>

--- a/plugins/Vanoogle/class.vanoogle.plugin.php
+++ b/plugins/Vanoogle/class.vanoogle.plugin.php
@@ -32,7 +32,7 @@ class VanooglePlugin extends Gdn_Plugin {
 
         $Validation = new Gdn_Validation();
         $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
-        $ConfigurationModel->SetField(array("Plugins.Vanoogle.CSE"));
+        $ConfigurationModel->SetField(["Plugins.Vanoogle.CSE"]);
         $Sender->Form->SetModel($ConfigurationModel);
 
         if ($Sender->Form->AuthenticatedPostBack() === FALSE) {
@@ -64,11 +64,11 @@ class VanooglePlugin extends Gdn_Plugin {
             return;
 
         // Normally one would use ->AddJsFile or ->Head->AddScript, but these insert a version arg in the url that makes the google api barf.
-        $Sender->Head->AddTag('script', array(
+        $Sender->Head->AddTag('script', [
             'src' => Asset('https://www.google.com/jsapi', FALSE, FALSE),
             'type' => 'text/javascript',
             'id' => C("Plugins.Vanoogle.CSE")
-        ));
+        ]);
         $Sender->AddCssFile('vanoogle.css', 'plugins/Vanoogle');
         $Sender->AddJsFile('vanoogle.js', 'plugins/Vanoogle');
     }

--- a/plugins/Vanoogle/views/settings.php
+++ b/plugins/Vanoogle/views/settings.php
@@ -27,14 +27,14 @@
 		<ul class='CheckBoxList'>
 			<li>
 				<?php
-					echo $this->Form->Label("Enter your Custom Search Engine ID.  If you don't have one, create one here: <a target='_blank' href='http://www.google.com/cse/'>http://www.google.com/cse/", "Plugins.Vanoogle.CSE", array(
+					echo $this->Form->Label("Enter your Custom Search Engine ID.  If you don't have one, create one here: <a target='_blank' href='http://www.google.com/cse/'>http://www.google.com/cse/", "Plugins.Vanoogle.CSE", [
 						"class" => "CheckBoxLabel",
-					));
+					]);
 					echo "<br>"; 
-					echo $this->Form->Input("Plugins.Vanoogle.CSE", "input", array(
+					echo $this->Form->Input("Plugins.Vanoogle.CSE", "input", [
 						"size" => "40",
 						"style" => "font-family: Courier, 'Courier New', monospace;", 
-					)); 
+					]); 
 				?>
 			</li>
 		</ul>

--- a/plugins/Voting/class.voting.plugin.php
+++ b/plugins/Voting/class.voting.plugin.php
@@ -20,10 +20,10 @@ class VotingPlugin extends Gdn_Plugin {
    public function SettingsController_Voting_Create($Sender) {
       $Sender->Permission('Garden.Settings.Manage');
       $Conf = new ConfigurationModule($Sender);
-		$Conf->Initialize(array(
-			'Plugins.Voting.ModThreshold1' => array('Type' => 'int', 'Control' => 'TextBox', 'Default' => -10, 'Description' => 'The vote that will flag a post for moderation.'),
-			'Plugins.Voting.ModThreshold2' => array('Type' => 'int', 'Control' => 'TextBox', 'Default' => -20, 'Description' => 'The vote that will remove a post to the moderation queue.')
-		));
+		$Conf->Initialize([
+			'Plugins.Voting.ModThreshold1' => ['Type' => 'int', 'Control' => 'TextBox', 'Default' => -10, 'Description' => 'The vote that will flag a post for moderation.'],
+			'Plugins.Voting.ModThreshold2' => ['Type' => 'int', 'Control' => 'TextBox', 'Default' => -20, 'Description' => 'The vote that will remove a post to the moderation queue.']
+		]);
 
      $Sender->AddSideMenu('settings/voting');
      $Sender->SetData('Title', T('Vote Settings'));
@@ -81,7 +81,7 @@ class VotingPlugin extends Gdn_Plugin {
 			Wrap(T('Comments')) . Gdn_Format::BigNumber($Discussion->CountComments)
 			// ,'/discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::Url($Discussion->Name).($Discussion->CountCommentWatch > 0 ? '/#Item_'.$Discussion->CountCommentWatch : '')
 			// )
-			, 'div', array('class' => $Css));
+			, 'div', ['class' => $Css]);
 
 		// Views
 		echo Wrap(
@@ -89,7 +89,7 @@ class VotingPlugin extends Gdn_Plugin {
 			Wrap(T('Views')) . Gdn_Format::BigNumber($Discussion->CountViews)
 			// , '/discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::Url($Discussion->Name).($Discussion->CountCommentWatch > 0 ? '/#Item_'.$Discussion->CountCommentWatch : '')
 			// )
-			, 'div', array('class' => 'StatBox ViewsBox'));
+			, 'div', ['class' => 'StatBox ViewsBox']);
 
 		// Follows
 		$Title = T($Discussion->Bookmarked == '1' ? 'Unbookmark' : 'Bookmark');
@@ -98,10 +98,10 @@ class VotingPlugin extends Gdn_Plugin {
 				Wrap(T('Follows')) . Gdn_Format::BigNumber($Discussion->CountBookmarks),
 				'/discussion/bookmark/'.$Discussion->DiscussionID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl),
 				'',
-				array('title' => $Title)
-			), 'div', array('class' => 'StatBox FollowsBox'));
+				['title' => $Title]
+			), 'div', ['class' => 'StatBox FollowsBox']);
 		} else {
-			echo Wrap(Wrap(T('Follows')) . $Discussion->CountBookmarks, 'div', array('class' => 'StatBox FollowsBox'));
+			echo Wrap(Wrap(T('Follows')) . $Discussion->CountBookmarks, 'div', ['class' => 'StatBox FollowsBox']);
 		}
 
 		// Votes
@@ -110,10 +110,10 @@ class VotingPlugin extends Gdn_Plugin {
 				Wrap(T('Votes')) . Gdn_Format::BigNumber($CountVotes),
 				'/discussion/votediscussion/'.$Discussion->DiscussionID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl),
 				'',
-				array('title' => T('Vote'))
-			), 'div', array('class' => 'StatBox VotesBox'));
+				['title' => T('Vote')]
+			), 'div', ['class' => 'StatBox VotesBox']);
 		} else {
-			echo Wrap(Wrap(T('Votes')) . $CountVotes, 'div', array('class' => 'StatBox VotesBox'));
+			echo Wrap(Wrap(T('Votes')) . $CountVotes, 'div', ['class' => 'StatBox VotesBox']);
 		}
 	}
 
@@ -133,7 +133,7 @@ class VotingPlugin extends Gdn_Plugin {
             break;
          case 'popular':
          default:
-            $CommentModel->OrderBy(array('coalesce(c.Score, 0) desc', 'c.CommentID'));
+            $CommentModel->OrderBy(['coalesce(c.Score, 0) desc', 'c.CommentID']);
             break;
       }
    }
@@ -157,7 +157,7 @@ class VotingPlugin extends Gdn_Plugin {
          }
       }
 
-      if (!in_array($Sort, array('popular', 'date')))
+      if (!in_array($Sort, ['popular', 'date']))
          $Sort = 'popular';
       self::$_CommentSort = $Sort;
       return $Sort;
@@ -180,9 +180,9 @@ class VotingPlugin extends Gdn_Plugin {
 			echo
 				Wrap($AnswerCount.' '.Plural($AnswerCount, 'Comment', 'Comments'), 'strong');
 				echo ' sorted by '
-               .Anchor('Votes', Url(DiscussionUrl($Sender->Discussion).'?Sort=popular', TRUE), '', array('rel' => 'nofollow', 'class' => self::CommentSort() == 'popular' ? 'Active' : ''))
+               .Anchor('Votes', Url(DiscussionUrl($Sender->Discussion).'?Sort=popular', TRUE), '', ['rel' => 'nofollow', 'class' => self::CommentSort() == 'popular' ? 'Active' : ''])
                .' '
-               .Anchor('Date Added', Url(DiscussionUrl($Sender->Discussion).'?Sort=date', TRUE), '', array('rel' => 'nofollow', 'class' => self::CommentSort() == 'date' ? 'Active' : ''));
+               .Anchor('Date Added', Url(DiscussionUrl($Sender->Discussion).'?Sort=date', TRUE), '', ['rel' => 'nofollow', 'class' => self::CommentSort() == 'date' ? 'Active' : '']);
 			?>
 			</div>
 		</li>
@@ -229,9 +229,9 @@ class VotingPlugin extends Gdn_Plugin {
       }
 
       echo '<span class="Voter">';
-			echo Anchor(Wrap(Wrap('Vote Up', 'i'), 'i', array('class' => 'ArrowSprite SpriteUp', 'rel' => 'nofollow')), $VoteUpUrl, 'VoteUp'.$CssClass);
+			echo Anchor(Wrap(Wrap('Vote Up', 'i'), 'i', ['class' => 'ArrowSprite SpriteUp', 'rel' => 'nofollow']), $VoteUpUrl, 'VoteUp'.$CssClass);
 			echo Wrap(StringIsNullOrEmpty($Object->Score) ? '0' : Gdn_Format::BigNumber($Object->Score));
-			echo Anchor(Wrap(Wrap('Vote Down', 'i'), 'i', array('class' => 'ArrowSprite SpriteDown', 'rel' => 'nofollow')), $VoteDownUrl, 'VoteDown'.$CssClass);
+			echo Anchor(Wrap(Wrap('Vote Down', 'i'), 'i', ['class' => 'ArrowSprite SpriteDown', 'rel' => 'nofollow']), $VoteDownUrl, 'VoteDown'.$CssClass);
 		echo '</span>';
  }
 
@@ -279,7 +279,7 @@ class VotingPlugin extends Gdn_Plugin {
             $Moderate = FALSE;
 
             if ($Total <= C('Plugins.Voting.ModThreshold1', -10)) {
-               $LogOptions = array('GroupBy' => array('RecordID'));
+               $LogOptions = ['GroupBy' => ['RecordID']];
                // Get the comment row.
                $Data = $CommentModel->GetID($CommentID, DATASET_TYPE_ARRAY);
                if ($Data) {
@@ -301,7 +301,7 @@ class VotingPlugin extends Gdn_Plugin {
             }
             if ($Total <= C('Plugins.Voting.ModThreshold2', -20)) {
                // Remove the comment.
-               $CommentModel->Delete($CommentID, array('Log' => 'Moderate'));
+               $CommentModel->Delete($CommentID, ['Log' => 'Moderate']);
 
                $Sender->InformMessage(sprintf(T('The %s has been removed for moderation.'), T('comment')));
             } elseif ($Moderate) {
@@ -363,7 +363,7 @@ class VotingPlugin extends Gdn_Plugin {
             $Moderate = FALSE;
 
             if ($Total <= C('Plugins.Voting.ModThreshold1', -10)) {
-               $LogOptions = array('GroupBy' => array('RecordID'));
+               $LogOptions = ['GroupBy' => ['RecordID']];
                // Get the comment row.
                if (isset($Discussion))
                   $Data = (array)$Discussion;
@@ -388,7 +388,7 @@ class VotingPlugin extends Gdn_Plugin {
             }
             if ($Total <= C('Plugins.Voting.ModThreshold2', -20)) {
                // Remove the comment.
-               $DiscussionModel->Delete($DiscussionID, array('Log' => 'Moderate'));
+               $DiscussionModel->Delete($DiscussionID, ['Log' => 'Moderate']);
 
                $Sender->InformMessage(sprintf(T('The %s has been removed for moderation.'), T('discussion')));
             } elseif ($Moderate) {
@@ -467,7 +467,7 @@ class VotingPlugin extends Gdn_Plugin {
       $CountDiscussions = $DiscussionModel->GetCount();
       $Sender->SetData('CountDiscussions', $CountDiscussions);
       $Sender->AnnounceData = FALSE;
-		$Sender->SetData('Announcements', array(), TRUE);
+		$Sender->SetData('Announcements', [], TRUE);
       $DiscussionModel->SQL->OrderBy('d.CountViews', 'desc');
       $Sender->DiscussionData = $DiscussionModel->Get($Offset, $Limit);
       $Sender->SetData('Discussions', $Sender->DiscussionData, TRUE);

--- a/plugins/example/class.example.plugin.php
+++ b/plugins/example/class.example.plugin.php
@@ -104,10 +104,10 @@ class ExamplePlugin extends Gdn_Plugin {
 
 		$validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
-        $configurationModel->setField(array(
+        $configurationModel->setField([
             'Plugin.Example.RenderCondition'     => 'all',
             'Plugin.Example.TrimSize'      => 100
-        ));
+        ]);
 
         // Set the model on the form.
         $sender->Form->setModel($configurationModel);
@@ -196,9 +196,9 @@ class ExamplePlugin extends Gdn_Plugin {
                 )
             );
 
-            echo wrap($discussionBody, 'div', array(
+            echo wrap($discussionBody, 'div', [
                 'class'  => "ExampleDescription"
-            ));
+            ]);
         }
     }
 

--- a/plugins/example/views/example.php
+++ b/plugins/example/views/example.php
@@ -12,11 +12,11 @@
 <ul>
     <li><?php
         echo $this->Form->label('Display condition', 'Plugin.Example.RenderCondition');
-        echo $this->Form->dropDown('Plugin.Example.RenderCondition', array(
+        echo $this->Form->dropDown('Plugin.Example.RenderCondition', [
             'all' => 'Discussions & Announcements',
             'announcements' => 'Just Announcements',
             'discussions' => 'Just Discussions'
-        ));
+        ]);
     ?></li>
     <li><?php
         echo $this->Form->label('Excerpt length', 'Plugin.Example.TrimSize');

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -128,7 +128,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             $target = '/';
         }
 
-        $qs = array('client_id' => $provider['AuthenticationKey'], 'Target' => $target);
+        $qs = ['client_id' => $provider['AuthenticationKey'], 'Target' => $target];
         return $qs;
     }
 
@@ -279,7 +279,7 @@ class JsConnectPlugin extends Gdn_Plugin {
         $finalTarget = urlencode(url('/entry/jsconnect', true).'?'.http_build_query($qs));
 
         $registerUrl = str_ireplace(
-            array('{target}', '{redirect}'),
+            ['{target}', '{redirect}'],
             $finalTarget,
             $registerUrl);
 
@@ -459,7 +459,7 @@ class JsConnectPlugin extends Gdn_Plugin {
     public function base_getAppSettingsMenuItems_handler($Sender) {
         $Menu = $Sender->EventArguments['SideMenu'];
         $Menu->addItem('Users', t('Users'));
-        $Menu->addLink('Users', 'jsConnect', 'settings/jsconnect', 'Garden.Settings.Manage', array('class' => 'nav-jsconnect'));
+        $Menu->addLink('Users', 'jsConnect', 'settings/jsconnect', 'Garden.Settings.Manage', ['class' => 'nav-jsconnect']);
     }
 
     /**
@@ -564,7 +564,7 @@ class JsConnectPlugin extends Gdn_Plugin {
      * @param Gdn_Controller $Sender
      * @param array $Args
      */
-    public function profileController_jsConnect_create($Sender, $Args = array()) {
+    public function profileController_jsConnect_create($Sender, $Args = []) {
         include_once dirname(__FILE__).'/functions.jsconnect.php';
 
         $client_id = $Sender->Request->get('client_id', 0);
@@ -575,7 +575,7 @@ class JsConnectPlugin extends Gdn_Plugin {
         $Secret = val('AssociationSecret', $Provider);
 
         if (Gdn::session()->isValid()) {
-            $User = ArrayTranslate((array)Gdn::session()->User, array('UserID' => 'UniqueID', 'Name', 'Email', 'PhotoUrl', 'DateOfBirth', 'Gender'));
+            $User = ArrayTranslate((array)Gdn::session()->User, ['UserID' => 'UniqueID', 'Name', 'Email', 'PhotoUrl', 'DateOfBirth', 'Gender']);
 
             // Grab the user's roles.
             $Roles = Gdn::userModel()->getRoles(Gdn::session()->UserID);
@@ -626,7 +626,7 @@ class JsConnectPlugin extends Gdn_Plugin {
      * @param SettingsController $Sender
      * @param array $Args
      */
-    public function settingsController_jsConnect_create($Sender, $Args = array()) {
+    public function settingsController_jsConnect_create($Sender, $Args = []) {
         $Sender->addJsFile('jsconnect-settings.js', 'plugins/jsconnect');
         $Sender->permission('Garden.Settings.Manage');
         $Sender->addSideMenu();
@@ -687,7 +687,7 @@ class JsConnectPlugin extends Gdn_Plugin {
                 $provider = self::getProvider($client_id);
                 touchValue('Trusted', $provider, 1);
             } else {
-                $provider = array();
+                $provider = [];
             }
             $form->setData($provider);
         }

--- a/plugins/jsconnect/functions.jsconnect.php
+++ b/plugins/jsconnect/functions.jsconnect.php
@@ -31,35 +31,35 @@ function writeJsConnect($user, $request, $clientID, $secret, $secure = true) {
     if ($secure) {
         // Check the client.
         if (!isset($request['v'])) {
-            $error = array('error' => 'invalid_request', 'message' => 'Missing the v parameter.');
+            $error = ['error' => 'invalid_request', 'message' => 'Missing the v parameter.'];
         } elseif ($request['v'] !== '2') {
-            $error = array('error' => 'invalid_request', 'message' => "Unsupported version {$request['v']}.");
+            $error = ['error' => 'invalid_request', 'message' => "Unsupported version {$request['v']}."];
         } elseif (!isset($request['client_id'])) {
-            $error = array('error' => 'invalid_request', 'message' => 'The client_id parameter is missing.');
+            $error = ['error' => 'invalid_request', 'message' => 'The client_id parameter is missing.'];
         } elseif ($request['client_id'] != $clientID) {
-            $error = array('error' => 'invalid_client', 'message' => "Unknown client {$request['client_id']}.");
+            $error = ['error' => 'invalid_client', 'message' => "Unknown client {$request['client_id']}."];
         } elseif (!isset($request['timestamp']) && !isset($request['sig'])) {
             if (is_array($user) && count($user) > 0) {
                 // This isn't really an error, but we are just going to return public information when no signature is sent.
-                $error = array('name' => (string)@$user['name'], 'photourl' => @$user['photourl'], 'signedin' => true);
+                $error = ['name' => (string)@$user['name'], 'photourl' => @$user['photourl'], 'signedin' => true];
             } else {
-                $error = array('name' => '', 'photourl' => '');
+                $error = ['name' => '', 'photourl' => ''];
             }
         } elseif (!isset($request['timestamp']) || !is_numeric($request['timestamp'])) {
-            $error = array('error' => 'invalid_request', 'message' => 'The timestamp parameter is missing or invalid.');
+            $error = ['error' => 'invalid_request', 'message' => 'The timestamp parameter is missing or invalid.'];
         } elseif (!isset($request['sig'])) {
-            $error = array('error' => 'invalid_request', 'message' => 'Missing sig parameter.');
+            $error = ['error' => 'invalid_request', 'message' => 'Missing sig parameter.'];
         } // Make sure the timestamp hasn't timedout
         elseif (abs($request['timestamp'] - JsTimestamp()) > JS_TIMEOUT) {
-            $error = array('error' => 'invalid_request', 'message' => 'The timestamp is invalid.');
+            $error = ['error' => 'invalid_request', 'message' => 'The timestamp is invalid.'];
         } elseif (!isset($request['nonce'])) {
-            $error = array('error' => 'invalid_request', 'message' => 'Missing nonce parameter.');
+            $error = ['error' => 'invalid_request', 'message' => 'Missing nonce parameter.'];
         } elseif (!isset($request['ip'])) {
-            $error = array('error' => 'invalid_request', 'message' => 'Missing ip parameter.');
+            $error = ['error' => 'invalid_request', 'message' => 'Missing ip parameter.'];
         } else {
             $signature = jsHash($request['ip'].$request['nonce'].$request['timestamp'].$secret, $secure);
             if ($signature != $request['sig']) {
-                $error = array('error' => 'access_denied', 'message' => 'Signature invalid.');
+                $error = ['error' => 'access_denied', 'message' => 'Signature invalid.'];
             }
         }
     }
@@ -76,7 +76,7 @@ function writeJsConnect($user, $request, $clientID, $secret, $secure = true) {
             $result['v'] = '2';
         }
     } else {
-        $result = array('name' => '', 'photourl' => '');
+        $result = ['name' => '', 'photourl' => ''];
     }
 
     $json = json_encode($result);

--- a/plugins/vBulletinCompatibility/class.vbulletincompatibility.plugin.php
+++ b/plugins/vBulletinCompatibility/class.vbulletincompatibility.plugin.php
@@ -14,12 +14,12 @@ class VbulletinCompatibilityPlugin extends Gdn_Plugin {
    }
    
    public function Gdn_Router_BeforeLoadRoutes_Handler($Sender) {
-      $VbRoutes = array(
-          'forumdisplay\.php\?f=(\d+)'    => array('categories/$1', 'Permanent'),
-          'showthread\.php\?t=(\d+)'      => array('discussion/$1', 'Permanent'),
-          'showthread\.php\?p=(\d+)'      => array('discussion/comment/$1', 'Permanent'),
-          'member\.php\?u=(\d+)'          => array('profile/$1/x', 'Permanent')
-      );
+      $VbRoutes = [
+          'forumdisplay\.php\?f=(\d+)'    => ['categories/$1', 'Permanent'],
+          'showthread\.php\?t=(\d+)'      => ['discussion/$1', 'Permanent'],
+          'showthread\.php\?p=(\d+)'      => ['discussion/comment/$1', 'Permanent'],
+          'member\.php\?u=(\d+)'          => ['profile/$1/x', 'Permanent']
+      ];
       
       $Sender->EventArguments['Routes'] = array_merge($Sender->EventArguments['Routes'], $VbRoutes);
    }


### PR DESCRIPTION
Convert all arrays to short syntax.

I used this script: https://gist.github.com/DaazKu/9de870dcfd4237ea6e93d9f2bbd0d34e
It's using the tokenizer so it's pretty safe. I've been using it in all my previous refactoring and never had a problem with it.

Easy command line review:
```
git diff --color --unified=0 --word-diff-regex=. HEAD^ | grep -Ev "^.\[(1|36)m(@@|\+{3}|-{3}|index [a-z0-9]+?\.\.|diff --git)" | less
```

Related https://github.com/vanilla/vanilla/issues/5744