### PR TITLE
Improve load time of Participated Discussions

### DIFF
--- a/plugins/Participated/addon.json
+++ b/plugins/Participated/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Participated Discussions",
-    "description": "Users may view a list of all discussions they have commented on. This is a more user-friendly version of an auto-subscribe option.",
-    "version": "1.1.1",
+    "description": "Users may view a list of all discussions they have participated in. This is a more user-friendly version of an auto-subscribe option.",
+    "version": "2.0",
     "mobileFriendly": true,
     "requiredTheme": false,
     "hasLocale": true,

--- a/plugins/Participated/class.participated.plugin.php
+++ b/plugins/Participated/class.participated.plugin.php
@@ -53,10 +53,8 @@ class ParticipatedPlugin extends Gdn_Plugin {
             ->select('ud.CountComments', '', 'CountCommentWatch')
             ->from('UserDiscussion ud')
             ->join('Discussion d', 'ud.DiscussionID = d.DiscussionID')
-            ->join('Comment c', 'ud.DiscussionID = c.DiscussionID and c.InsertUserID = ud.UserID')
             ->where('ud.UserID', $userID)
             ->where('ud.Participated', 1)
-            ->groupBy('d.DiscussionID')
             ->orderBy('d.DateLastComment', 'desc')
             ->limit($limit, $offset);
 


### PR DESCRIPTION
#477 updated the Participated Discussions addon to use the `UserDiscussion` table for pulling its data. However, to maintain identical functionality, joining in records from the `Comment` table was necessary. This additional join negates a lot of the performance gains possible from switching over to `UserDiscussion`, especially for prolific commenters.

This update alters the functionality of Participated Discussions in a fundamental way: every discussion a user has *participated* in will be displayed. This means discussions the user has created will now be included in this list, in addition to discussions the user has commented on. Current functionality has the list only pulling the latter.

I've also altered the addon description to reflect the functionality change and incremented its version.

Closes #499