### PR TITLE
Fix inability to setup QnA for the first time alongside Reactions

### DIFF
--- a/plugins/QnA/structure.php
+++ b/plugins/QnA/structure.php
@@ -157,7 +157,7 @@ if ($this->Reactions && class_exists('ReactionModel')) {
         }
 
         // AcceptAnswer
-        $record = $Rm->getWhere(['UrlCode' => 'AcceptAnswer']);
+        $record = $Rm->getWhere(['UrlCode' => 'AcceptAnswer'])->resultArray();
         if (!$record) {
             $result = $Rm->defineReactionType([
                 'UrlCode' => 'AcceptAnswer',


### PR DESCRIPTION
Q&A's structure routine has a block dedicated to [adding or updating an "Accepted Answer" reaction](https://github.com/vanilla/addons/blob/3a41a3c7510fd3237050f893c9a5e8cb6abbd9fd/plugins/QnA/structure.php#L160), if the Reactions is enabled. The problem is it uses a truthy/falsy condition, based on the result of `Gdn_Model::getWhere`. This function returns a `Gdn_Dataset` object, so the result will always be truthy. Because of this, the "Accepted Answer" reaction is always attempting to be updated. If it doesn't exist, a fatal SQL error is thrown and the Q&A addon cannot be enabled.

This update calls `resultArray` on the `Gdn_Dataset` result from `Gdn_Model::getWhere`. If no results are found, an empty array is returned. This is a valid falsy value, so the condition functions as intended.