### PR TITLE
Refactor function names to respect our coding standard

### DIFF
--- a/plugins/Akismet/class.akismet.php
+++ b/plugins/Akismet/class.akismet.php
@@ -31,7 +31,7 @@
  *
  *  <b>Usage:</b>
  *  <code>
- *    $akismet = new Akismet('http://www.example.com/blog/', 'aoeu1aoue');
+ *    $akismet = new akismet('http://www.example.com/blog/', 'aoeu1aoue');
  *    $akismet->setCommentAuthor($name);
  *    $akismet->setCommentAuthorEmail($email);
  *    $akismet->setCommentAuthorURL($url);
@@ -46,7 +46,7 @@
  *  Optionally you may wish to check if your WordPress API key is valid as in the example below.
  * 
  * <code>
- *   $akismet = new Akismet('http://www.example.com/blog/', 'aoeu1aoue');
+ *   $akismet = new akismet('http://www.example.com/blog/', 'aoeu1aoue');
  *   
  *   if($akismet->isKeyValid()) {
  *     // api key is okay

--- a/plugins/AllowRawFormat/class.allowrawformat.plugin.php
+++ b/plugins/AllowRawFormat/class.allowrawformat.plugin.php
@@ -5,9 +5,9 @@
  */
 
 class AllowRawFormatPlugin extends Gdn_Plugin {
-   public function Base_BeforeDispatch_Handler($sender, $args) {
-      if (Gdn::Session()->CheckPermission('Plugins.AllowRawFormat.Allow')) {
-         SaveToConfig('Garden.InputFormatter', 'Raw', ['Save' => FALSE]);
+   public function base_beforeDispatch_handler($sender, $args) {
+      if (Gdn::session()->checkPermission('Plugins.AllowRawFormat.Allow')) {
+         saveToConfig('Garden.InputFormatter', 'Raw', ['Save' => FALSE]);
       }
    }
 }

--- a/plugins/AuthorSelector/class.authorselector.plugin.php
+++ b/plugins/AuthorSelector/class.authorselector.plugin.php
@@ -35,7 +35,7 @@ class AuthorSelectorPlugin extends Gdn_Plugin {
         $discussionID = $sender->Request->get('discussionid');
         $discussion = $sender->DiscussionModel->getID($discussionID);
         if (!$discussion) {
-            throw NotFoundException('Discussion');
+            throw notFoundException('Discussion');
         }
 
         // Check edit permission

--- a/plugins/Bump/class.bump.plugin.php
+++ b/plugins/Bump/class.bump.plugin.php
@@ -36,7 +36,7 @@ class BumpPlugin extends Gdn_Plugin {
      * @return void.
      */
     public function discussionController_bump_create($sender, $args) {
-        $sender->Permission('Garden.Moderation.Manage');
+        $sender->permission('Garden.Moderation.Manage');
 
         // Get discussion
         $discussionID = $sender->Request->get('discussionid');

--- a/plugins/Buttons/class.buttons.plugin.php
+++ b/plugins/Buttons/class.buttons.plugin.php
@@ -10,13 +10,13 @@
 
 class ButtonsPlugin extends Gdn_Plugin {
 
-   public function Base_Render_Before($sender) {
+   public function base_render_before($sender) {
       if ($sender->MasterView == '' || $sender->MasterView == 'default')
-         $sender->AddCssFile('buttons.css', 'plugins/Buttons');
+         $sender->addCssFile('buttons.css', 'plugins/Buttons');
    }
 
-   public function Setup() {}
+   public function setup() {}
 
-   public function Structure() {}
+   public function structure() {}
 
 }

--- a/plugins/CategoryCollapser/class.categorycollapser.plugin.php
+++ b/plugins/CategoryCollapser/class.categorycollapser.plugin.php
@@ -4,9 +4,9 @@ class CategoryCollapserPlugin extends Gdn_Plugin {
    /**
 	 * Just include our JS on all category pages.
 	 */
-   public function CategoriesController_Render_Before($sender) {
-      $sender->AddJsFile("category_collapse.js", "plugins/CategoryCollapser");
-      $style = Wrap('
+   public function categoriesController_render_before($sender) {
+      $sender->addJsFile("category_collapse.js", "plugins/CategoryCollapser");
+      $style = wrap('
       .Expando {
          float: right;
          background: url(plugins/CategoryCollapser/design/tagsprites.png) no-repeat 0 -52px;
@@ -17,6 +17,6 @@ class CategoryCollapserPlugin extends Gdn_Plugin {
          cursor: pointer; }
       .Expando-Collapsed .Expando {
          background-position: 0 -69px; }', 'style');
-      $sender->AddAsset('Head', $style);
+      $sender->addAsset('Head', $style);
    }
 }

--- a/plugins/CivilTongueEx/views/index.php
+++ b/plugins/CivilTongueEx/views/index.php
@@ -1,11 +1,11 @@
 <?php if (!defined('APPLICATION')) exit();
-echo Wrap($this->Data('Title'), 'h1');
+echo wrap($this->data('Title'), 'h1');
 
-$desc =  T('Civil Tongue lets you make a list of words that are not allowed on the forum and replace them. This plugins also helps to make your forum suitable for younger audiences.');
+$desc =  t('Civil Tongue lets you make a list of words that are not allowed on the forum and replace them. This plugins also helps to make your forum suitable for younger audiences.');
 echo wrap($desc, 'div', ['class' => 'alert alert-info padded']);
 
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 <ul>
     <li class="form-group">
@@ -14,7 +14,7 @@ echo $this->Form->Errors();
             echo wrap(t('Separate each word with a semi-colon ";"'), 'div', ['class' => 'info']); ?>
         </div>
         <div class="input-wrap">
-            <?php echo $this->Form->TextBox('Plugins.CivilTongue.Words', ['MultiLine' => TRUE]); ?>
+            <?php echo $this->Form->textBox('Plugins.CivilTongue.Words', ['MultiLine' => TRUE]); ?>
         </div>
     </li>
     <li class="form-group">
@@ -23,8 +23,8 @@ echo $this->Form->Errors();
             echo wrap(t('Enter the word you wish to replace the banned word with.'), 'div', ['class' => 'info']); ?>
         </div>
         <div class="input-wrap">
-            <?php echo $this->Form->TextBox('Plugins.CivilTongue.Replacement'); ?>
+            <?php echo $this->Form->textBox('Plugins.CivilTongue.Replacement'); ?>
         </div>
     </li>
 </ul>
-<?php echo $this->Form->Close('Save'); ?>
+<?php echo $this->Form->close('Save'); ?>

--- a/plugins/CloudflareSupport/class.cloudflaresupport.plugin.php
+++ b/plugins/CloudflareSupport/class.cloudflaresupport.plugin.php
@@ -50,7 +50,7 @@ class CloudflareSupportPlugin extends Gdn_Plugin {
          return;
       }
 
-      $requestAddress = Gdn::Request()->RequestAddress();
+      $requestAddress = Gdn::request()->requestAddress();
       $cloudflareRequest = FALSE;
       foreach ($this->CloudflareSourceIPs as $cloudflareIPRange) {
 
@@ -59,14 +59,14 @@ class CloudflareSupportPlugin extends Gdn_Plugin {
             continue;
          }
 
-         Gdn::Request()->RequestAddress($cloudflareClientIP);
+         Gdn::request()->requestAddress($cloudflareClientIP);
          $cloudflareRequest = TRUE;
          break;
       }
 
       // Let people know that the CF plugin is turned on.
       if ($cloudflareRequest && !headers_sent()) {
-         header("X-CF-Powered-By: CF-Vanilla v" . $this->GetPluginKey('Version'));
+         header("X-CF-Powered-By: CF-Vanilla v" . $this->getPluginKey('Version'));
       }
    }
 

--- a/plugins/CssThemes/class.cssthemes.plugin.php
+++ b/plugins/CssThemes/class.cssthemes.plugin.php
@@ -8,9 +8,9 @@ You should have received a copy of the GNU General Public License along with Gar
 Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 */
 
-$tmp = Gdn::FactoryOverwrite(TRUE);
-Gdn::FactoryInstall('CssCacher', 'Gdn_CssThemes', __FILE__);
-Gdn::FactoryOverwrite($tmp);
+$tmp = Gdn::factoryOverwrite(TRUE);
+Gdn::factoryInstall('CssCacher', 'Gdn_CssThemes', __FILE__);
+Gdn::factoryOverwrite($tmp);
 unset($tmp);
 
 
@@ -39,12 +39,12 @@ class CssThemes extends Gdn_Plugin {
 
 	/// Methods ///
 
-	public function ApplyTheme($originalPath, $cachePath, $insertNames = TRUE) {
+	public function applyTheme($originalPath, $cachePath, $insertNames = TRUE) {
 		// Get the theme settings.
-		$sQL = Gdn::SQL();
+		$sQL = Gdn::sql();
 		if(is_null($this->ThemeSettings)) {
-			$data = $sQL->Get('ThemeSetting')->ResultArray();
-			$data = ConsolidateArrayValuesByKey($data, 'Name', 'Setting', '');
+			$data = $sQL->get('ThemeSetting')->resultArray();
+			$data = consolidateArrayValuesByKey($data, 'Name', 'Setting', '');
 			$this->ThemeSettings = $data;
 		}
 
@@ -58,7 +58,7 @@ class CssThemes extends Gdn_Plugin {
 		// Insert the missing settings into the database.
 		if($insertNames) {
 			foreach($this->MissingSettings as $name => $setting) {
-				$sQL->Insert('ThemeSetting', ['Name' => $name, 'Setting' => $setting]);
+				$sQL->insert('ThemeSetting', ['Name' => $name, 'Setting' => $setting]);
 			}
 			$this->MissingSettings = [];
 		}
@@ -85,20 +85,20 @@ class CssThemes extends Gdn_Plugin {
 	}
 
 	protected function _ApplyImport($match) {
-		$noFollow = ArrayValue(4, $match);
+		$noFollow = arrayValue(4, $match);
 		$url = $match[2];
 
 		if($noFollow !== FALSE) {
 			// Don't apply the theme to this import.
 			$originalAssetPath = str_replace([PATH_ROOT, DS], ['', '/'], $this->_OrignialPath);
-			$url = Asset(CombinePaths([dirname($originalAssetPath), $url], '/'));
+			$url = asset(combinePaths([dirname($originalAssetPath), $url], '/'));
 		} else {
 			// Also parse the import.
 			$orignalPath = $this->_OrignialPath;
-			$importPath = CombinePaths([dirname($orignalPath), $url]);
-			$url = $this->Get($importPath, $this->_AppName);
+			$importPath = combinePaths([dirname($orignalPath), $url]);
+			$url = $this->get($importPath, $this->_AppName);
 			$url = str_replace([PATH_ROOT, DS], ['', '/'], $url);
-			$url = Asset($url);
+			$url = asset($url);
 
 			$this->_OrignalPath = $orignalPath;
 		}
@@ -109,21 +109,21 @@ class CssThemes extends Gdn_Plugin {
 	}
 
 	protected function _ApplyUrl($match) {
-		$noFollow = ArrayValue(5, $match);
+		$noFollow = arrayValue(5, $match);
 		$url = $match[2];
 		$extension = $match[3];
 
 		if($noFollow !== FALSE || strcasecmp($extension, '.css') != 0) {
 			// Don't apply the theme to this import.
 			$originalAssetPath = str_replace([PATH_ROOT, DS], ['', '/'], $this->_OrignialPath);
-			$url = Asset(CombinePaths([dirname($originalAssetPath), $url.$extension], '/'));
+			$url = asset(combinePaths([dirname($originalAssetPath), $url.$extension], '/'));
 		} else {
 			// Cache the css too.
 			$orignalPath = $this->_OrignialPath;
-			$importPath = CombinePaths([dirname($orignalPath), $url.$extension]);
-			$url = $this->Get($importPath, $this->_AppName);
+			$importPath = combinePaths([dirname($orignalPath), $url.$extension]);
+			$url = $this->get($importPath, $this->_AppName);
 			$url = str_replace([PATH_ROOT, DS], ['', '/'], $url);
-			$url = Asset($url);
+			$url = asset($url);
 
 			$this->_OrignalPath = $orignalPath;
 		}
@@ -132,7 +132,7 @@ class CssThemes extends Gdn_Plugin {
 		return $result;
 	}
 
-	public function Get($originalPath, $appName) {
+	public function get($originalPath, $appName) {
 		if(!file_exists($originalPath))
 			return FALSE;
 
@@ -147,7 +147,7 @@ class CssThemes extends Gdn_Plugin {
 		if(!file_exists($cachePath) || filemtime($originalPath) > filemtime($cachePath)) {
 			$css = file_get_contents($originalPath);
 
-			$result = $this->ApplyTheme($originalPath, $cachePath);
+			$result = $this->applyTheme($originalPath, $cachePath);
 		} else {
 			$result = $cachePath;
 		}
@@ -155,7 +155,7 @@ class CssThemes extends Gdn_Plugin {
 		return $result;
 	}
 
-	public function GetNames($css, $insertNames = FALSE) {
+	public function getNames($css, $insertNames = FALSE) {
 		$result = [];
 
 		if(preg_match_all(self::RegEx, $css, $matches)) {
@@ -165,7 +165,7 @@ class CssThemes extends Gdn_Plugin {
 		}
 		// Insert all of the names into the database.
 		if(count($result) > 0) {
-			$sQL = Gdn::SQL();
+			$sQL = Gdn::sql();
 			// Get the existing names.
 			$insert = $result;
 
@@ -173,7 +173,7 @@ class CssThemes extends Gdn_Plugin {
 			// Insert the necessary settings.
 			if($insertNames) {
 				foreach($insert as $name => $setting) {
-					$sQL->Insert('ThemeSetting', ['Name' => $name, 'Setting' => $setting]);
+					$sQL->insert('ThemeSetting', ['Name' => $name, 'Setting' => $setting]);
 				}
 			}
 		}
@@ -181,33 +181,33 @@ class CssThemes extends Gdn_Plugin {
 		return $result;
 	}
 
-	public function Base_GetAppSettingsMenuItems_Handler($sender) {
+	public function base_getAppSettingsMenuItems_handler($sender) {
       $menu = $sender->EventArguments['SideMenu'];
-		$menu->AddLink('Add-ons', 'Colors', 'plugin/cssthemes', 'Garden.Themes.Manage');
+		$menu->addLink('Add-ons', 'Colors', 'plugin/cssthemes', 'Garden.Themes.Manage');
 	}
 
-	public function PluginController_Colors_Create($sender) {
-		$sender->Form = Gdn::Factory('Form');
+	public function pluginController_colors_create($sender) {
+		$sender->Form = Gdn::factory('Form');
 
 		$this->Colors = [];
 
-		$this->ParseCss(PATH_APPLICATIONS);
-		//$this->ParseCss(PATH_THEMES);
+		$this->parseCss(PATH_APPLICATIONS);
+		//$this->parseCss(PATH_THEMES);
 
 		asort($this->Colors);
 		$sender->Colors = $this->Colors;
 
 		// Add the javascript & css.
-		//$Sender->Head->AddScript('/plugins/cssthemes/colorpicker.js');
-		//$Sender->Head->AddScript('/plugins/cssthemes/cssthemes.js');
-		$sender->Head->AddCss('/plugins/cssthemes/colorpicker.css');
-		$sender->Head->AddCss('/plugins/cssthemes/cssthemes.css');
+		//$Sender->Head->addScript('/plugins/cssthemes/colorpicker.js');
+		//$Sender->Head->addScript('/plugins/cssthemes/cssthemes.js');
+		$sender->Head->addCss('/plugins/cssthemes/colorpicker.css');
+		$sender->Head->addCss('/plugins/cssthemes/cssthemes.css');
 
-		$sender->View = $this->GetView('colors.php');
-		$sender->Render();
+		$sender->View = $this->getView('colors.php');
+		$sender->render();
 	}
 
-	public function ParseCss($path) {
+	public function parseCss($path) {
 		// Look for all of the css files in the path.
 		$cssPaths = glob($path.DS.'*.css');
 		if($cssPaths) {
@@ -229,21 +229,21 @@ class CssThemes extends Gdn_Plugin {
 			foreach($paths as $path) {
 				if(in_array(strrchr($path, DS), [DS.'vforg', DS.'vfcom']))
 					continue;
-				$this->ParseCss($path);
+				$this->parseCss($path);
 			}
 		}
 	}
 
-	public function RGB($color) {
+	public function rGB($color) {
 		return [hexdec(substr($color, 0, 2)), hexdec(substr($color, 2, 2)), hexdec(substr($color, 4, 2))];
 	}
 
-	public function GetColors($match) {
+	public function getColors($match) {
 		$color = strtolower($match[1]);
 		if(strlen($color) == 3)
 			$color = str_repeat(substr($color, 0, 1), 2).str_repeat(substr($color, 1, 1), 2).str_repeat(substr($color, 2, 1), 2);
 
-		list($h, $s, $v) = $this->RGB2HSB(hexdec(substr($color, 0, 2)), hexdec(substr($color, 2, 2)), hexdec(substr($color, 4, 2)));
+		list($h, $s, $v) = $this->rGB2HSB(hexdec(substr($color, 0, 2)), hexdec(substr($color, 2, 2)), hexdec(substr($color, 4, 2)));
 
 		if($s < .2) {
 			$s = 0;
@@ -258,7 +258,7 @@ class CssThemes extends Gdn_Plugin {
 		return implode($match);
 	}
 
-	function RGB2HSB($r, $g = NULL, $b = NULL) {
+	function rGB2HSB($r, $g = NULL, $b = NULL) {
 		if(is_null($g)) {
 			list($r, $g, $b) = (array)$r;
 		}
@@ -303,64 +303,64 @@ class CssThemes extends Gdn_Plugin {
 	/**
 	 * @package $sender Gdn_Controller
 	 */
-	public function PluginController_CssThemes_Create($sender) {
-		$sender->Form = Gdn::Factory('Form');
+	public function pluginController_cssThemes_create($sender) {
+		$sender->Form = Gdn::factory('Form');
 		$model = new Gdn_Model('ThemeSetting');
-		$sender->Form->SetModel($model);
+		$sender->Form->setModel($model);
 
-		if($sender->Form->AuthenticatedPostBack() === FALSE) {
+		if($sender->Form->authenticatedPostBack() === FALSE) {
 			// Grab the colors.
-			$data = $model->Get();
-			//$Data = ConsolidateArrayValuesByKey($Data->ResultArray(), 'Name', 'Setting');
-			$sender->SetData('ThemeSettings', $data->ResultArray());
-			//$Sender->Form->SetData($Data);
+			$data = $model->get();
+			//$Data = consolidateArrayValuesByKey($Data->resultArray(), 'Name', 'Setting');
+			$sender->setData('ThemeSettings', $data->resultArray());
+			//$Sender->Form->setData($Data);
 		} else {
-			$data = $sender->Form->FormDataSet();
+			$data = $sender->Form->formDataSet();
 
 			// Update the database.
-			$sQL = Gdn::SQL();
+			$sQL = Gdn::sql();
 			foreach($data as $row) {
-				$sQL->Put(
+				$sQL->put(
 					'ThemeSetting',
 					['Setting' => $row['Setting']],
 					['Name' => $row['Name']]);
 			}
 
 			// Clear out the css cache.
-			$files = SafeGlob(PATH_CACHE.DS.'css'.DS.'*.css');
+			$files = safeGlob(PATH_CACHE.DS.'css'.DS.'*.css');
 			foreach($files as $file) {
 				unlink($file);
 			}
 
-			$sender->SetData('ThemeSettings', $data);
-			$sender->StatusMessage = T('Your changes have been saved.');
+			$sender->setData('ThemeSettings', $data);
+			$sender->StatusMessage = t('Your changes have been saved.');
 		}
 
 		// Add the javascript & css.
-		$sender->Head->AddScript('/plugins/cssthemes/colorpicker.js');
-		$sender->Head->AddScript('/plugins/cssthemes/cssthemes.js');
-		$sender->Head->AddCss('/plugins/cssthemes/colorpicker.css');
-		$sender->Head->AddCss('/plugins/cssthemes/cssthemes.css');
+		$sender->Head->addScript('/plugins/cssthemes/colorpicker.js');
+		$sender->Head->addScript('/plugins/cssthemes/cssthemes.js');
+		$sender->Head->addCss('/plugins/cssthemes/colorpicker.css');
+		$sender->Head->addCss('/plugins/cssthemes/cssthemes.css');
 
 		// Add the side module.
-      $sender->AddSideMenu('/plugin/cssthemes');
+      $sender->addSideMenu('/plugin/cssthemes');
 
-		$sender->View = $this->GetView('cssthemes.php');
-		$sender->Render();
+		$sender->View = $this->getView('cssthemes.php');
+		$sender->render();
 	}
 
-	public function Setup() {
+	public function setup() {
 		if (!file_exists(PATH_CACHE.DS.'css')) mkdir(PATH_CACHE.DS.'css');
 
 		// Setup the theme table.
-		$st = Gdn::Structure();
-		$st->Table('bThemeSetting')
-			->Column('Name', 'varchar(50)', FALSE, 'primary')
-			->Column('Setting', 'varchar(50)')
-			->Set(FALSE, FALSE);
+		$st = Gdn::structure();
+		$st->table('bThemeSetting')
+			->column('Name', 'varchar(50)', FALSE, 'primary')
+			->column('Setting', 'varchar(50)')
+			->set(FALSE, FALSE);
 
 		// Insert default values.
-		$st->Database->Query('insert '.$st->Database->DatabasePrefix.'bThemeSetting (Name, Setting) values '.
+		$st->Database->query('insert '.$st->Database->DatabasePrefix.'bThemeSetting (Name, Setting) values '.
 		"('Banner Background Color', '#44c7f4'),
 		('Banner Font Color', '#fff'),
 		('Banner Font Shadow Color', '#30ACD6'),
@@ -392,7 +392,7 @@ class CssThemes extends Gdn_Plugin {
 		('Panel Selected Font Color', '#ff0084')");
 	}
 
-	public function CleanUp() {
-	   Gdn::Structure()->Table('bThemeSetting')->Drop();
+	public function cleanUp() {
+	   Gdn::structure()->table('bThemeSetting')->drop();
 	}
 }

--- a/plugins/CssThemes/views/colors.php
+++ b/plugins/CssThemes/views/colors.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 
 <h1>Colors</h1>

--- a/plugins/CssThemes/views/cssthemes.php
+++ b/plugins/CssThemes/views/cssthemes.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 
 <table id="CssThemes">
@@ -23,7 +23,7 @@ foreach($this->Data["ThemeSettings"] as $Row) {
 	}
 ?>
 	<tr class="ColorRow">
-		<td><?php echo T($Name); ?></td>
+		<td><?php echo t($Name); ?></td>
 		<td>
 			<div class="ColorPicker" style="background-color: <?php echo $Row['Setting']; ?>">
 				&nbsp;
@@ -31,8 +31,8 @@ foreach($this->Data["ThemeSettings"] as $Row) {
 		</td>
 		<td>
 			<?php
-				echo $this->Form->Input('Name[]', 'hidden', ['value' => $Row['Name']]);
-				echo $this->Form->Input('Setting[]', 'text', ['value' => $Row['Setting'], 'class' => 'Setting']);
+				echo $this->Form->input('Name[]', 'hidden', ['value' => $Row['Name']]);
+				echo $this->Form->input('Setting[]', 'text', ['value' => $Row['Setting'], 'class' => 'Setting']);
 			?>
 		</td>
 	</tr>
@@ -41,5 +41,5 @@ foreach($this->Data["ThemeSettings"] as $Row) {
 ?>
 </table>
 <?php
-echo $this->Form->Close("Save");
+echo $this->Form->close("Save");
 ?>

--- a/plugins/CustomizeText/class.customizetext.plugin.php
+++ b/plugins/CustomizeText/class.customizetext.plugin.php
@@ -19,16 +19,16 @@ class CustomizeTextPlugin extends Gdn_Plugin {
    
    public function __construct() {
       parent::__construct();
-      if (!C('Garden.Locales.DeveloperMode', FALSE))
-         SaveToConfig('Garden.Locales.DeveloperMode', TRUE);
+      if (!c('Garden.Locales.DeveloperMode', FALSE))
+         saveToConfig('Garden.Locales.DeveloperMode', TRUE);
    }
 
    /**
 	 * Add the customize text menu option.
 	 */
-   public function Base_GetAppSettingsMenuItems_Handler($sender) {
+   public function base_getAppSettingsMenuItems_handler($sender) {
 		$menu = &$sender->EventArguments['SideMenu'];
-      $menu->AddLink('Appearance', 'Customize Text', 'settings/customizetext', 'Garden.Settings.Manage');
+      $menu->addLink('Appearance', 'Customize Text', 'settings/customizetext', 'Garden.Settings.Manage');
 	}
 
 	/**
@@ -36,15 +36,15 @@ class CustomizeTextPlugin extends Gdn_Plugin {
     * 
     * @param Gdn_Controller $sender
 	 */
-   public function SettingsController_CustomizeText_Create($sender) {
-      $sender->Permission('Garden.Settings.Manage');
+   public function settingsController_customizeText_create($sender) {
+      $sender->permission('Garden.Settings.Manage');
       
-      $sender->AddSideMenu('settings/customizetext');
-		$sender->AddJsFile('jquery.autogrow.js');
+      $sender->addSideMenu('settings/customizetext');
+		$sender->addJsFile('jquery.autogrow.js');
       
-      $sender->Title('Customize Text');
+      $sender->title('Customize Text');
 
-		$directive = GetValue(0, $sender->RequestArgs, '');
+		$directive = getValue(0, $sender->RequestArgs, '');
 		$view = 'customizetext';
 		if ($directive == 'rebuild')
 			$view = 'rebuild';
@@ -53,10 +53,10 @@ class CustomizeTextPlugin extends Gdn_Plugin {
       
       $method = 'none';
       
-      if ($sender->Form->IsPostback()) {
+      if ($sender->Form->isPostback()) {
          $method = 'search';
       
-         if ($sender->Form->GetValue('Save_All'))
+         if ($sender->Form->getValue('Save_All'))
             $method = 'save';
       }
       
@@ -69,16 +69,16 @@ class CustomizeTextPlugin extends Gdn_Plugin {
          case 'search':
          case 'save':
             
-            $keywords = strtolower($sender->Form->GetValue('Keywords'));
+            $keywords = strtolower($sender->Form->getValue('Keywords'));
             
             if ($method == 'search') {
-               $sender->Form->ClearInputs();
-               $sender->Form->SetFormValue('Keywords', $keywords);
+               $sender->Form->clearInputs();
+               $sender->Form->setFormValue('Keywords', $keywords);
             }
             
-            $definitions = Gdn::Locale()->GetDeveloperDefinitions();
+            $definitions = Gdn::locale()->getDeveloperDefinitions();
             $countDefinitions = sizeof($definitions);
-            $sender->SetData('CountDefinitions', $countDefinitions);
+            $sender->setData('CountDefinitions', $countDefinitions);
             
             $changed = FALSE;
             foreach ($definitions as $key => $baseDefinition) {
@@ -96,7 +96,7 @@ class CustomizeTextPlugin extends Gdn_Plugin {
                $modified = FALSE;
 
                // Found a definition, look it up in the real locale first, to see if it has been overridden
-               $currentDefinition = Gdn::Locale()->Translate($key, FALSE);
+               $currentDefinition = Gdn::locale()->translate($key, FALSE);
                if ($currentDefinition !== FALSE && $currentDefinition != $baseDefinition)
                   $modified = TRUE;
                else
@@ -111,7 +111,7 @@ class CustomizeTextPlugin extends Gdn_Plugin {
                   $currentDefinition = "\n{$currentDefinition}";
                
                if ($method == 'save') {
-                  $suppliedDefinition = $sender->Form->GetValue($elementName);
+                  $suppliedDefinition = $sender->Form->getValue($elementName);
 
                   // Has this field been changed?
                   if ($suppliedDefinition != FALSE && $suppliedDefinition != $currentDefinition) {
@@ -123,7 +123,7 @@ class CustomizeTextPlugin extends Gdn_Plugin {
                         $saveDefinition = str_replace("\r\n", "\n", $saveDefinition);
                      }
                      
-                     Gdn::Locale()->SetTranslation($key, $saveDefinition, [
+                     Gdn::locale()->setTranslation($key, $saveDefinition, [
                         'Save'         => TRUE,
                         'RemoveEmpty'  => TRUE
                      ]);
@@ -132,20 +132,20 @@ class CustomizeTextPlugin extends Gdn_Plugin {
                   }
                }
                
-               $sender->Form->SetFormValue($elementName, $currentDefinition);
+               $sender->Form->setFormValue($elementName, $currentDefinition);
             }
 
             if ($changed) {
-               $sender->InformMessage("Locale changes have been saved!");
+               $sender->informMessage("Locale changes have been saved!");
             }
             
             break;
       }
       
-      $sender->SetData('Matches', $matches);
+      $sender->setData('Matches', $matches);
       $countMatches = sizeof($matches);
-      $sender->SetData('CountMatches', $countMatches);
+      $sender->setData('CountMatches', $countMatches);
       
-      $sender->Render($view, '', 'plugins/CustomizeText');
+      $sender->render($view, '', 'plugins/CustomizeText');
    }
 }

--- a/plugins/CustomizeText/views/customizetext.php
+++ b/plugins/CustomizeText/views/customizetext.php
@@ -1,6 +1,6 @@
 <?php if (!defined('APPLICATION')) exit();?>
 <h1>Customize Text</h1>
-<?php echo $this->Form->Open(); ?>
+<?php echo $this->Form->open(); ?>
     <script type="text/javascript" language="javascript">
         jQuery(document).ready(function($) {
             if ($.autogrow)
@@ -16,7 +16,7 @@
     </script>
     <div class="form-group">
         <div class="label-wrap-wide">
-            <?php echo 'There are currently '.Wrap($this->Data('CountDefinitions', '0'), 'strong').' definitions available for editing. '; ?>
+            <?php echo 'There are currently '.wrap($this->data('CountDefinitions', '0'), 'strong').' definitions available for editing. '; ?>
         </div>
         <div class="input-wrap-right">
             <?php echo anchor('Find More', '/settings/customizetext/rebuild', 'btn btn-primary'); ?>
@@ -36,13 +36,13 @@
         </div>
     </div>
 <?php
-if ($this->Form->GetValue('Keywords', '') != '') {
+if ($this->Form->getValue('Keywords', '') != '') {
     echo '<div class="padded italic">';
-    printf(t("%s matches found for '%s'."), $this->Data('CountMatches'), $this->Form->GetValue('Keywords'));
+    printf(t("%s matches found for '%s'."), $this->data('CountMatches'), $this->Form->getValue('Keywords'));
     echo '</div>';
     echo '<ul>';
 
-    foreach ($this->Data('Matches') as $Key => $Definition) {
+    foreach ($this->data('Matches') as $Key => $Definition) {
         $KeyHash = md5($Key);
 
         $DefinitionText = $Definition['def'];
@@ -55,10 +55,10 @@ if ($this->Form->GetValue('Keywords', '') != '') {
 
         echo '<li class="form-group">';
         echo '<div class="label-wrap">';
-        echo Wrap(Gdn_Format::Text($Key), 'label', ['for' => "Form_{$ElementName}"]);
+        echo wrap(Gdn_Format::text($Key), 'label', ['for' => "Form_{$ElementName}"]);
 
-        if ($this->Form->IsPostBack()) {
-            $SuppliedDefinition = $this->Form->GetValue($ElementName);
+        if ($this->Form->isPostBack()) {
+            $SuppliedDefinition = $this->Form->getValue($ElementName);
 
             // Changed?
             if ($SuppliedDefinition !== FALSE && $SuppliedDefinition != $DefinitionText)
@@ -70,4 +70,4 @@ if ($this->Form->GetValue('Keywords', '') != '') {
     }
     echo '</ul>';
 }
-echo $this->Form->Close('Save All');
+echo $this->Form->close('Save All');

--- a/plugins/CustomizeText/views/rebuild.php
+++ b/plugins/CustomizeText/views/rebuild.php
@@ -30,11 +30,11 @@ $Urls = [
 	'/dashboard/entry/passwordrequest'
 ];
 array_map('Url', $Urls);
-$Locale = Gdn::Locale();
-$Definitions = $Locale->GetDeveloperDefinitions();
+$Locale = Gdn::locale();
+$Definitions = $Locale->getDeveloperDefinitions();
 $CountDefinitions = count($Definitions);
 ?>
-<h1><?php echo T('Customize Text'); ?></h1>
+<h1><?php echo t('Customize Text'); ?></h1>
 <div class="padded">
    <?php
 		echo 'There are currently <span class="CountDefinitions strong">'. $CountDefinitions . '</span> text definitions available for editing.';
@@ -55,9 +55,9 @@ jQuery(document).ready(function($) {
 				} else {
 					// Finished
 					gdn.informMessage('Crawling complete!', {'id':'crawlstate'});
-					// $('#Content').get('<?php echo Url('/settings/customizetext/rebuild?DeliveryType=VIEW'); ?>');
+					// $('#Content').get('<?php echo url('/settings/customizetext/rebuild?DeliveryType=VIEW'); ?>');
 					$.ajax({
-						url: '<?php echo Url('/settings/customizetext/rebuildcomplete?DeliveryType=VIEW'); ?>',
+						url: '<?php echo url('/settings/customizetext/rebuildcomplete?DeliveryType=VIEW'); ?>',
 						success: function(data) {
 							$('#Content').html(data);
 						}

--- a/plugins/CustomizeText/views/rebuildcomplete.php
+++ b/plugins/CustomizeText/views/rebuildcomplete.php
@@ -1,12 +1,12 @@
 <?php if (!defined('APPLICATION')) exit();
-$Locale = Gdn::Locale();
-$Definitions = $Locale->GetDeveloperDefinitions();
+$Locale = Gdn::locale();
+$Definitions = $Locale->getDeveloperDefinitions();
 $CountDefinitions = count($Definitions);
 ?>
-<h1><?php echo T('Customize Text'); ?></h1>
+<h1><?php echo t('Customize Text'); ?></h1>
 <div class="padded">
    <?php
 		echo 'Search complete. There are <strong>'. $CountDefinitions . '</strong> text definitions available for editing.';
-		echo Wrap(Anchor('Go edit them now!', 'settings/customizetext'), 'p');
+		echo wrap(anchor('Go edit them now!', 'settings/customizetext'), 'p');
    ?>
 </div>

--- a/plugins/Disqus/class.disqus.plugin.php
+++ b/plugins/Disqus/class.disqus.plugin.php
@@ -217,7 +217,7 @@ class DisqusPlugin extends Gdn_Plugin {
 
         $form = $sender->Form;
 
-        $accessToken = $form->getFormValue('AccessToken'); //Gdn::Session()->Stash('Disqus.AccessToken', NULL, NULL);
+        $accessToken = $form->getFormValue('AccessToken'); //Gdn::session()->stash('Disqus.AccessToken', NULL, NULL);
 
         // Get the access token.
         if ($code && !$accessToken) {

--- a/plugins/Emotify/class.emotify.plugin.php
+++ b/plugins/Emotify/class.emotify.plugin.php
@@ -13,37 +13,37 @@
 
 class EmotifyPlugin implements Gdn_IPlugin {
    
-   public function AssetModel_StyleCss_Handler($sender) {
-      $sender->AddCssFile('emotify.css', 'plugins/Emotify');
+   public function assetModel_styleCss_handler($sender) {
+      $sender->addCssFile('emotify.css', 'plugins/Emotify');
    }
 	
     /**
     * Disable Emoji sets.
     */
-    public function Gdn_Dispatcher_AfterAnalyzeRequest_Handler() {
-        SaveToConfig('Garden.EmojiSet', 'none', false);
+    public function gdn_Dispatcher_AfterAnalyzeRequest_Handler() {
+        saveToConfig('Garden.EmojiSet', 'none', false);
     }
 	
 	/**
 	 * Replace emoticons in comments.
 	 */
-	public function Base_AfterCommentFormat_Handler($sender) {
-		if (!C('Plugins.Emotify.FormatEmoticons', TRUE))
+	public function base_afterCommentFormat_handler($sender) {
+		if (!c('Plugins.Emotify.FormatEmoticons', TRUE))
 			return;
 
 		$object = $sender->EventArguments['Object'];
-		$object->FormatBody = $this->DoEmoticons($object->FormatBody);
+		$object->FormatBody = $this->doEmoticons($object->FormatBody);
 		$sender->EventArguments['Object'] = $object;
 	}
 	
-	public function DiscussionController_Render_Before($sender) {
+	public function discussionController_render_before($sender) {
 		$this->_EmotifySetup($sender);
 	}
 
 	/**
 	 * Return an array of emoticons.
 	 */
-	public static function GetEmoticons() {
+	public static function getEmoticons() {
 		return [
 			':)]' => '100',
 			';))' => '71',
@@ -195,24 +195,24 @@ class EmotifyPlugin implements Gdn_IPlugin {
 	/**
 	 * Replace emoticons in comment preview.
 	 */
-	public function PostController_AfterCommentPreviewFormat_Handler($sender) {
-		if (!C('Plugins.Emotify.FormatEmoticons', TRUE))
+	public function postController_afterCommentPreviewFormat_handler($sender) {
+		if (!c('Plugins.Emotify.FormatEmoticons', TRUE))
 			return;
 		
-		$sender->Comment->Body = $this->DoEmoticons($sender->Comment->Body);
+		$sender->Comment->Body = $this->doEmoticons($sender->Comment->Body);
 	}
 	
-	public function PostController_Render_Before($sender) {
+	public function postController_render_before($sender) {
 		$this->_EmotifySetup($sender);
 	}
    
-   public function NBBCPlugin_AfterNBBCSetup_Handler($sender, $args) {
-//      $BBCode = new BBCode();
+   public function nBBCPlugin_afterNBBCSetup_handler($sender, $args) {
+//      $BBCode = new bBCode();
       $bBCode = $args['BBCode'];
-      $bBCode->smiley_url = SmartAsset('/plugins/Emotify/design/images');
+      $bBCode->smiley_url = smartAsset('/plugins/Emotify/design/images');
       
       $smileys = [];
-      foreach (self::GetEmoticons() as $text => $filename) {
+      foreach (self::getEmoticons() as $text => $filename) {
          $smileys[$text]= $filename.'.gif';
       }
       
@@ -222,9 +222,9 @@ class EmotifyPlugin implements Gdn_IPlugin {
 	/**
 	 * Thanks to punbb 1.3.5 (GPL License) for this function - ported from their do_smilies function.
 	 */
-	public static function DoEmoticons($text) {
+	public static function doEmoticons($text) {
 		$text = ' '.$text.' ';
-		$emoticons = EmotifyPlugin::GetEmoticons();
+		$emoticons = EmotifyPlugin::getEmoticons();
 		foreach ($emoticons as $key => $replacement) {
 			if (strpos($text, $key) !== FALSE)
 				$text = preg_replace(
@@ -241,21 +241,21 @@ class EmotifyPlugin implements Gdn_IPlugin {
 	 * Prepare a page to be emotified.
 	 */
 	private function _EmotifySetup($sender) {
-		$sender->AddJsFile('emotify.js', 'plugins/Emotify');  
+		$sender->addJsFile('emotify.js', 'plugins/Emotify');  
 		// Deliver the emoticons to the page.
       $emoticons = [];
-      foreach ($this->GetEmoticons() as $i => $gif) {
+      foreach ($this->getEmoticons() as $i => $gif) {
          if (!isset($emoticons[$gif]))
             $emoticons[$gif] = $i;
       }
       $emoticons = array_flip($emoticons);
 
-		$sender->AddDefinition('Emoticons', base64_encode(json_encode($emoticons)));
+		$sender->addDefinition('Emoticons', base64_encode(json_encode($emoticons)));
 	}
 	
-	public function Setup() {
+	public function setup() {
 		//SaveToConfig('Plugins.Emotify.FormatEmoticons', TRUE);
-		SaveToConfig('Garden.Format.Hashtags', FALSE); // Autohashing to search is incompatible with emotify
+		saveToConfig('Garden.Format.Hashtags', FALSE); // Autohashing to search is incompatible with emotify
 	}
 	
 }

--- a/plugins/FacebookID/class.facebookid.plugin.php
+++ b/plugins/FacebookID/class.facebookid.plugin.php
@@ -4,42 +4,42 @@ class FacebookIDPlugin extends Gdn_Plugin {
    /** @var array */
    public $FacebookIDs = [];
 
-   public function UserInfoModule_OnBasicInfo_Handler($sender, $args) {
-      if (Gdn::Session()->CheckPermission('Plugins.FacebookID.View')) {
+   public function userInfoModule_onBasicInfo_handler($sender, $args) {
+      if (Gdn::session()->checkPermission('Plugins.FacebookID.View')) {
          // Grab the facebook ID.
-         $facebookID = Gdn::SQL()->GetWhere(
+         $facebookID = Gdn::sql()->getWhere(
             'UserAuthentication',
             ['ProviderKey' => 'facebook', 'UserID' => $sender->User->UserID]
-         )->Value('ForeignUserKey', T('n/a'));
+         )->value('ForeignUserKey', t('n/a'));
 
-         echo '<dt class="Value">'.T('Facebook ID').'</dt><dd>'.$facebookID.'</dd>';
+         echo '<dt class="Value">'.t('Facebook ID').'</dt><dd>'.$facebookID.'</dd>';
       }
    }
 
    /**
     * Show FacebookID on comments.
     */
-   public function Base_CommentInfo_Handler($sender, $args) {
-      if (!Gdn::Session()->CheckPermission('Plugins.FacebookID.View'))
+   public function base_commentInfo_handler($sender, $args) {
+      if (!Gdn::session()->checkPermission('Plugins.FacebookID.View'))
          return;
 
       if (!isset($sender->Data['Discussion']))
          return;
 
       if (!$this->FacebookIDs)
-         $this->FacebookIDs = $this->GetFacebookIDs([$sender->Data['Discussion'], $sender->Data['Comments']], 'InsertUserID');
+         $this->FacebookIDs = $this->getFacebookIDs([$sender->Data['Discussion'], $sender->Data['Comments']], 'InsertUserID');
 
 
-      $userID = GetValue('InsertUserID',$sender->EventArguments['Object'],'0');
-      $facebookID = GetValue($userID, $this->FacebookIDs, T('n/a'));
-      echo '<span>'.T('Facebook ID').': '.$facebookID.'</span> ';
+      $userID = getValue('InsertUserID',$sender->EventArguments['Object'],'0');
+      $facebookID = getValue($userID, $this->FacebookIDs, t('n/a'));
+      echo '<span>'.t('Facebook ID').': '.$facebookID.'</span> ';
    }
 
    /**
     * Show FacebookID on discussions (OP).
     */
-   public function Base_DiscussionInfo_Handler($sender, $args) {
-      $this->Base_CommentInfo_Handler($sender, $args);
+   public function base_discussionInfo_handler($sender, $args) {
+      $this->base_commentInfo_handler($sender, $args);
    }
 
    /**
@@ -48,17 +48,17 @@ class FacebookIDPlugin extends Gdn_Plugin {
     * @param <type> $args
     * @return <type>
     */
-   public function UserController_Render_Before($sender, $args) {
+   public function userController_render_before($sender, $args) {
       if (!in_array($sender->RequestMethod, ['index', 'browse']))
          return;
-      if (!Gdn::Session()->CheckPermission('Plugins.FacebookID.View'))
+      if (!Gdn::session()->checkPermission('Plugins.FacebookID.View'))
          return;
    }
 
-   public function GetFacebookIDs($datas, $userIDColumn) {
+   public function getFacebookIDs($datas, $userIDColumn) {
       $userIDs = [];
       foreach ($datas as $data) {
-         if ($userID = GetValue($userIDColumn, $data))
+         if ($userID = getValue($userIDColumn, $data))
             $userIDs[] = $userID;
          else {
             $iDs = array_column($data, $userIDColumn);
@@ -66,11 +66,11 @@ class FacebookIDPlugin extends Gdn_Plugin {
          }
       }
 
-      $fbIDs = Gdn::SQL()
-         ->WhereIn('UserID', array_unique($userIDs))
-         ->GetWhere(
+      $fbIDs = Gdn::sql()
+         ->whereIn('UserID', array_unique($userIDs))
+         ->getWhere(
          'UserAuthentication',
-         ['ProviderKey' => 'facebook'])->ResultArray();
+         ['ProviderKey' => 'facebook'])->resultArray();
 
       $result = array_column($fbIDs, 'ForeignUserKey', 'UserID');
       return $result;

--- a/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
+++ b/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
@@ -222,7 +222,7 @@ class FeedDiscussionsPlugin extends Gdn_Plugin {
                 $sender->Form->clearInputs();
 
             } catch (Exception $e) {
-                $sender->Form->addError(T($e->getMessage()));
+                $sender->Form->addError(t($e->getMessage()));
             }
         }
 

--- a/plugins/FileUpload/class.fileupload.plugin.php
+++ b/plugins/FileUpload/class.fileupload.plugin.php
@@ -142,10 +142,10 @@ class FileUploadPlugin extends Gdn_Plugin {
                 $this->mediaModel()->delete($media, true);
                 $delete['Status'] = 'success';
             } else {
-                throw PermissionException();
+                throw permissionException();
             }
         } else {
-            throw NotFoundException('Media');
+            throw notFoundException('Media');
         }
 
         $sender->setJSON('Delete', $delete);
@@ -330,7 +330,7 @@ class FileUploadPlugin extends Gdn_Plugin {
     protected function attachUploadsToComment($Controller, $Type = 'comment') {
         $RawType = ucfirst($Type);
 
-        if (StringEndsWith($Controller->RequestMethod, 'Comment', true) && $Type != 'comment') {
+        if (stringEndsWith($Controller->RequestMethod, 'Comment', true) && $Type != 'comment') {
             $Type = 'comment';
             $RawType = 'Comment';
             if (!isset($Controller->Comment)) {
@@ -364,7 +364,7 @@ class FileUploadPlugin extends Gdn_Plugin {
      */
     public function discussionController_download_create($sender) {
         if (!$this->CanDownload) {
-            throw PermissionException("File could not be streamed: Access is denied");
+            throw permissionException("File could not be streamed: Access is denied");
         }
 
         list($mediaID) = $sender->RequestArgs;
@@ -546,7 +546,7 @@ class FileUploadPlugin extends Gdn_Plugin {
         $upload = new Gdn_UploadImage();
         $path = $upload->copyLocal($subPath);
         if (!file_exists($path)) {
-            throw NotFoundException('File');
+            throw notFoundException('File');
         }
 
         // Figure out the dimensions of the upload.
@@ -562,7 +562,7 @@ class FileUploadPlugin extends Gdn_Plugin {
                 $model->save($media);
             }
 
-            $url = Asset('/plugins/FileUpload/images/file.png');
+            $url = asset('/plugins/FileUpload/images/file.png');
             redirectTo($url, 301);
         }
 
@@ -623,7 +623,7 @@ class FileUploadPlugin extends Gdn_Plugin {
             $media->ForeignID = $foreignID;
             $media->ForeignTable = $foreignType;
             try {
-//                $PlacementStatus = $this->PlaceMedia($Media, Gdn::Session()->UserID);
+//                $PlacementStatus = $this->placeMedia($Media, Gdn::session()->UserID);
                 $this->mediaModel()->save($media);
             } catch (Exception $e) {
                 die($e->getMessage());
@@ -646,7 +646,7 @@ class FileUploadPlugin extends Gdn_Plugin {
         $currentPath = [];
         foreach ($newFolder as $folderPart) {
             array_push($currentPath, $folderPart);
-            $testFolder = CombinePaths($currentPath);
+            $testFolder = combinePaths($currentPath);
 
             if (!is_dir($testFolder) && !@mkdir($testFolder, 0777, true)) {
                 throw new Exception("Failed creating folder '{$testFolder}' during PlaceMedia verification loop");
@@ -778,7 +778,7 @@ class FileUploadPlugin extends Gdn_Plugin {
             // Analyze file extension
             $FileNameParts = pathinfo($FileName);
             $Extension = strtolower($FileNameParts['extension']);
-            $AllowedExtensions = C('Garden.Upload.AllowedFileExtensions', ["*"]);
+            $AllowedExtensions = c('Garden.Upload.AllowedFileExtensions', ["*"]);
             if (!in_array($Extension, $AllowedExtensions) && !in_array('*',$AllowedExtensions)) {
                 throw new FileUploadPluginUploadErrorException("Uploaded file type is not allowed.", 11, $FileName, $FileKey);
             }
@@ -862,8 +862,8 @@ class FileUploadPlugin extends Gdn_Plugin {
                 'Filesize' => $FileSize,
                 'FormatFilesize' => Gdn_Format::bytes($FileSize,1),
                 'ProgressKey' => $Sender->ApcKey ? $Sender->ApcKey : '',
-                'Thumbnail' => base64_encode(MediaThumbnail($Media)),
-                'FinalImageLocation' => Url(self::url($Media)),
+                'Thumbnail' => base64_encode(mediaThumbnail($Media)),
+                'FinalImageLocation' => url(self::url($Media)),
                 'Parsed' => $Parsed
             ];
         } catch (FileUploadPluginUploadErrorException $e) {

--- a/plugins/FileUpload/views/attach_file.php
+++ b/plugins/FileUpload/views/attach_file.php
@@ -1,6 +1,6 @@
 <div class="AttachFileWrapper AttachmentWindow">
    <div class="AttachFileLink">
-      <a href="javascript:void(0);"><?php echo T('Attach a file'); ?></a>
+      <a href="javascript:void(0);"><?php echo t('Attach a file'); ?></a>
       <div class="CurrentUploader"></div>
    </div>
    <div class="AttachFileContainer">
@@ -10,17 +10,17 @@
             <div class="FileHover">
                <div class="FileMeta">
                   <div>
-                     <span class="FileName"><?php echo T('Filename'); ?></span>
-                     <span class="FileSize"><?php echo T('File Size'); ?></span>
+                     <span class="FileName"><?php echo t('Filename'); ?></span>
+                     <span class="FileSize"><?php echo t('File Size'); ?></span>
                   </div>
                   <span class="FileOptions"></span>
-                  <a class="InsertImage Hidden"><?php echo T('Insert Image'); ?></a>
-                  <a class="DeleteFile"><?php echo T('Delete'); ?></a>
+                  <a class="InsertImage Hidden"><?php echo t('Insert Image'); ?></a>
+                  <a class="DeleteFile"><?php echo t('Delete'); ?></a>
                </div>
             </div>
          </div>
          <div class="UploadProgress">
-            <div class="Foreground"><strong><?php echo T('Uploading...'); ?></strong></div>
+            <div class="Foreground"><strong><?php echo t('Uploading...'); ?></strong></div>
             <div class="Background">&nbsp;</div>
             <div>&nbsp;</div>
          </div>

--- a/plugins/FileUpload/views/fileupload_functions.php
+++ b/plugins/FileUpload/views/fileupload_functions.php
@@ -1,49 +1,49 @@
 <?php
 
-function MediaThumbnail($media, $data = FALSE) {
+function mediaThumbnail($media, $data = FALSE) {
       $media = (array)$media;
 
-      if (GetValue('ThumbPath', $media)) {
-         $src = Gdn_Upload::Url(ltrim(GetValue('ThumbPath', $media), '/'));
+      if (getValue('ThumbPath', $media)) {
+         $src = Gdn_Upload::url(ltrim(getValue('ThumbPath', $media), '/'));
       } else {
-         $width = GetValue('ImageWidth', $media);
-         $height = GetValue('ImageHeight', $media);
+         $width = getValue('ImageWidth', $media);
+         $height = getValue('ImageHeight', $media);
 
          if (!$width || !$height) {
-            $height = FileUploadPlugin::ThumbnailHeight();
+            $height = FileUploadPlugin::thumbnailHeight();
             if (!$height)
                $height = 100;
-               SetValue('ThumbHeight', $media, $height);
+               setValue('ThumbHeight', $media, $height);
 
-            return DefaultMediaThumbnail($media);
+            return defaultMediaThumbnail($media);
          }
 
          $requiresThumbnail = FALSE;
-         if (FileUploadPlugin::ThumbnailHeight() && $height > FileUploadPlugin::ThumbnailHeight())
+         if (FileUploadPlugin::thumbnailHeight() && $height > FileUploadPlugin::thumbnailHeight())
             $requiresThumbnail = TRUE;
-         elseif (FileUploadPlugin::ThumbnailWidth() && $width > FileUploadPlugin::ThumbnailWidth())
+         elseif (FileUploadPlugin::thumbnailWidth() && $width > FileUploadPlugin::thumbnailWidth())
             $requiresThumbnail = TRUE;
 
-         $path = ltrim(GetValue('Path', $media), '/');
+         $path = ltrim(getValue('Path', $media), '/');
          if ($requiresThumbnail) {
-            $src = Url('/utility/thumbnail/'.GetValue('MediaID', $media, 'x').'/'.$path, TRUE);
+            $src = url('/utility/thumbnail/'.getValue('MediaID', $media, 'x').'/'.$path, TRUE);
          } else {
-            $src = Gdn_Upload::Url($path);
+            $src = Gdn_Upload::url($path);
          }
       }
       if ($data)
-         $result = ['src' => $src, 'width' => GetValue('ThumbWidth', $media), 'height' => GetValue('ThumbHeight', $media)];
+         $result = ['src' => $src, 'width' => getValue('ThumbWidth', $media), 'height' => getValue('ThumbHeight', $media)];
       else
-         $result = Img($src, ['class' => 'ImageThumbnail', 'width' => GetValue('ThumbWidth', $media), 'height' => GetValue('ThumbHeight', $media)]);
+         $result = img($src, ['class' => 'ImageThumbnail', 'width' => getValue('ThumbWidth', $media), 'height' => getValue('ThumbHeight', $media)]);
 
       return $result;
 
 }
 
-function DefaultMediaThumbnail($media) {
+function defaultMediaThumbnail($media) {
   $result = '<span class="Thumb-Default">'.
    '<span class="Thumb-Extension">'.pathinfo($media['Name'], PATHINFO_EXTENSION).'</span>'.
-   Img('/plugins/FileUpload/images/file.png', ['class' => 'ImageThumbnail', 'height' => GetValue('ThumbHeight', $media)]).
+   img('/plugins/FileUpload/images/file.png', ['class' => 'ImageThumbnail', 'height' => getValue('ThumbHeight', $media)]).
    '</span>';
 
    return $result;

--- a/plugins/FileUpload/views/link_files.php
+++ b/plugins/FileUpload/views/link_files.php
@@ -1,27 +1,27 @@
 <div class="Attachments">
    <div class="AttachFileContainer">
       <?php
-         $CanDownload = $this->Data('CanDownload');
-         foreach ($this->Data('CommentMediaList') as $Media) {
-            $IsOwner = (Gdn::Session()->IsValid() && (Gdn::Session()->UserID == GetValue('InsertUserID',$Media,NULL)));
+         $CanDownload = $this->data('CanDownload');
+         foreach ($this->data('CommentMediaList') as $Media) {
+            $IsOwner = (Gdn::session()->isValid() && (Gdn::session()->UserID == getValue('InsertUserID',$Media,NULL)));
             $this->EventArguments['CanDownload'] =& $CanDownload;
             $this->EventArguments['Media'] =& $Media;
-            $this->FireEvent('BeforeFile');
+            $this->fireEvent('BeforeFile');
 
       ?>
             <div class="Attachment">
                <div class="FilePreview">
                   <?php
-                  $Path = GetValue('Path', $Media);
+                  $Path = getValue('Path', $Media);
                   $Img = '';
 
                   if ($CanDownload) {
-                     $DownloadUrl = Url(FileUploadPlugin::Url($Media));
+                     $DownloadUrl = url(FileUploadPlugin::url($Media));
                      $Img = '<a href="'.$DownloadUrl.'">';
                   }
 
-                  $ThumbnailUrl = FileUploadPlugin::ThumbnailUrl($Media);
-                  $Img .= MediaThumbnail($Media);
+                  $ThumbnailUrl = FileUploadPlugin::thumbnailUrl($Media);
+                  $Img .= mediaThumbnail($Media);
                   if ($CanDownload)
                      $Img .= '</a>';
 
@@ -47,20 +47,20 @@
                         echo ' <span class="FileSize">'.$Media->ImageWidth.'&#160;x&#160;'.$Media->ImageHeight.'</span> - ';
                      }
 
-                     echo ' <span class="FileSize">', Gdn_Format::Bytes($Media->Size, 0), '</span>';
+                     echo ' <span class="FileSize">', Gdn_Format::bytes($Media->Size, 0), '</span>';
                      echo '</div>';
 
                      $Actions = '';
-                     if (StringBeginsWith($this->ControllerName, 'post', TRUE))
-                        $Actions = ConcatSep(' | ', $Actions, '<a class="InsertImage" href="'.Url(FileUploadPlugin::Url($Path)).'">'.T('Insert Image').'</a>');
+                     if (stringBeginsWith($this->ControllerName, 'post', TRUE))
+                        $Actions = concatSep(' | ', $Actions, '<a class="InsertImage" href="'.url(FileUploadPlugin::url($Path)).'">'.t('Insert Image').'</a>');
 
-                     if (GetValue('ForeignTable', $Media) == 'discussion')
+                     if (getValue('ForeignTable', $Media) == 'discussion')
                         $PermissionName = "Vanilla.Discussions.Edit";
                      else
                         $PermissionName = "Vanilla.Comments.Edit";
 
-                     if ($IsOwner || Gdn::Session()->CheckPermission($PermissionName, TRUE, 'Category', $this->Data('Discussion.PermissionCategoryID')))
-                        $Actions = ConcatSep(' | ', $Actions, '<a class="DeleteFile" href="'.Url("/plugin/fileupload/delete/{$Media->MediaID}").'"><span>'.T('Delete').'</span></a>');
+                     if ($IsOwner || Gdn::session()->checkPermission($PermissionName, TRUE, 'Category', $this->data('Discussion.PermissionCategoryID')))
+                        $Actions = concatSep(' | ', $Actions, '<a class="DeleteFile" href="'.url("/plugin/fileupload/delete/{$Media->MediaID}").'"><span>'.t('Delete').'</span></a>');
 
                      if ($Actions)
                         echo '<div>', $Actions, '</div>';

--- a/plugins/ForumMerge/class.forummerge.plugin.php
+++ b/plugins/ForumMerge/class.forummerge.plugin.php
@@ -16,26 +16,26 @@ class ForumMergePlugin implements Gdn_IPlugin {
    /**
     * Add to the dashboard menu.
     */
-   public function Base_GetAppSettingsMenuItems_Handler($sender, $args) {
-      $args['SideMenu']->AddLink('Import', T('Merge'), 'utility/merge', 'Garden.Settings.Manage');
+   public function base_getAppSettingsMenuItems_handler($sender, $args) {
+      $args['SideMenu']->addLink('Import', t('Merge'), 'utility/merge', 'Garden.Settings.Manage');
    }
 
    /**
     * Admin screen for merging forums.
     */
-   public function UtilityController_Merge_Create($sender) {
-      $sender->Permission('Garden.Settings.Manage');
-      $sender->AddSideMenu('utility/merge');
+   public function utilityController_merge_create($sender) {
+      $sender->permission('Garden.Settings.Manage');
+      $sender->addSideMenu('utility/merge');
 
-      if ($sender->Form->AuthenticatedPostBack()) {
-         $database = $sender->Form->GetFormValue('Database');
-         $prefix = $sender->Form->GetFormValue('Prefix');
-         $legacySlug = $sender->Form->GetFormValue('LegacySlug');
-         $this->MergeCategories = ($sender->Form->GetFormValue('MergeCategories')) ? TRUE : FALSE;
-         $this->MergeForums($database, $prefix, $legacySlug);
+      if ($sender->Form->authenticatedPostBack()) {
+         $database = $sender->Form->getFormValue('Database');
+         $prefix = $sender->Form->getFormValue('Prefix');
+         $legacySlug = $sender->Form->getFormValue('LegacySlug');
+         $this->MergeCategories = ($sender->Form->getFormValue('MergeCategories')) ? TRUE : FALSE;
+         $this->mergeForums($database, $prefix, $legacySlug);
       }
 
-      $sender->Render($sender->FetchViewLocation('merge', '', 'plugins/ForumMerge'));
+      $sender->render($sender->fetchViewLocation('merge', '', 'plugins/ForumMerge'));
    }
 
    /**
@@ -43,12 +43,12 @@ class ForumMergePlugin implements Gdn_IPlugin {
     *
     * @return string CSV list of columns in both copies of the table minus the primary key.
     */
-   public function GetColumns($table, $oldDatabase, $oldPrefix, $options = []) {
-      Gdn::Structure()->Database->DatabasePrefix = '';
-      $oldColumns = Gdn::Structure()->Get($oldDatabase.'.'.$oldPrefix.$table)->Columns();
+   public function getColumns($table, $oldDatabase, $oldPrefix, $options = []) {
+      Gdn::structure()->Database->DatabasePrefix = '';
+      $oldColumns = Gdn::structure()->get($oldDatabase.'.'.$oldPrefix.$table)->columns();
 
-      Gdn::Structure()->Database->DatabasePrefix = C('Database.DatabasePrefix');
-      $newColumns = Gdn::Structure()->Get($table)->Columns();
+      Gdn::structure()->Database->DatabasePrefix = c('Database.DatabasePrefix');
+      $newColumns = Gdn::structure()->get($table)->columns();
 
       $columns = array_intersect_key($oldColumns, $newColumns);
       unset($columns[$table.'ID']);
@@ -66,8 +66,8 @@ class ForumMergePlugin implements Gdn_IPlugin {
     * @param $tableName
     * @return bool
     */
-   public function OldTableExists($tableName) {
-      return (Gdn::SQL()->Query('SHOW TABLES IN `'.$this->OldDatabase.'` LIKE "'.$this->OldPrefix.$tableName.'"')->NumRows() == 1);
+   public function oldTableExists($tableName) {
+      return (Gdn::sql()->query('SHOW TABLES IN `'.$this->OldDatabase.'` LIKE "'.$this->OldPrefix.$tableName.'"')->numRows() == 1);
    }
 
    /**
@@ -78,30 +78,30 @@ class ForumMergePlugin implements Gdn_IPlugin {
     *
     * @todo Compare column names between forums and use intersection
     */
-   public function MergeForums($oldDatabase, $oldPrefix, $legacySlug) {
-      $newPrefix = C('Database.DatabasePrefix');
+   public function mergeForums($oldDatabase, $oldPrefix, $legacySlug) {
+      $newPrefix = c('Database.DatabasePrefix');
       $this->OldDatabase = $oldDatabase;
       $this->OldPrefix = $oldPrefix;
 
       $doLegacy = !empty($legacySlug);
 
       // USERS //
-      if ($this->OldTableExists('User')) {
-         $userColumns = $this->GetColumns('User', $oldDatabase, $oldPrefix);
+      if ($this->oldTableExists('User')) {
+         $userColumns = $this->getColumns('User', $oldDatabase, $oldPrefix);
 
          // Merge IDs of duplicate users
-         Gdn::SQL()->Query('update '.$newPrefix.'User u set u.OldID =
+         Gdn::sql()->query('update '.$newPrefix.'User u set u.OldID =
             (select u2.UserID from `'.$oldDatabase.'`.'.$oldPrefix.'User u2 where u2.Email = u.Email limit 1)');
 
          // Copy non-duplicate users
-         Gdn::SQL()->Query('insert into '.$newPrefix.'User ('.$userColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'User ('.$userColumns.', OldID)
             select '.$userColumns.', UserID
             from `'.$oldDatabase.'`.'.$oldPrefix.'User
             where Email not in (select Email from '.$newPrefix.'User)');
 
          // UserMeta
-         if ($this->OldTableExists('UserMeta')) {
-            Gdn::SQL()->Query('insert ignore into '.$newPrefix.'UserMeta (UserID, Name, Value)
+         if ($this->oldTableExists('UserMeta')) {
+            Gdn::sql()->query('insert ignore into '.$newPrefix.'UserMeta (UserID, Name, Value)
                select u.UserID, um.Name, um.Value
                from '.$newPrefix.'User u, `'.$oldDatabase.'`.'.$oldPrefix.'UserMeta um
                where u.OldID = um.UserID');
@@ -110,22 +110,22 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
 
       // ROLES //
-      if ($this->OldTableExists('Role')) {
-         $roleColumns = $this->GetColumns('Role', $oldDatabase, $oldPrefix);
+      if ($this->oldTableExists('Role')) {
+         $roleColumns = $this->getColumns('Role', $oldDatabase, $oldPrefix);
 
          // Merge IDs of duplicate roles
-         Gdn::SQL()->Query('update '.$newPrefix.'Role r set r.OldID =
+         Gdn::sql()->query('update '.$newPrefix.'Role r set r.OldID =
             (select r2.RoleID from `'.$oldDatabase.'`.'.$oldPrefix.'Role r2 where r2.Name = r.Name)');
 
          // Copy non-duplicate roles
-         Gdn::SQL()->Query('insert into '.$newPrefix.'Role ('.$roleColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'Role ('.$roleColumns.', OldID)
             select '.$roleColumns.', RoleID
             from `'.$oldDatabase.'`.'.$oldPrefix.'Role
             where Name not in (select Name from '.$newPrefix.'Role)');
 
          // UserRole
-         if ($this->OldTableExists('UserRole')) {
-            Gdn::SQL()->Query('insert ignore into '.$newPrefix.'UserRole (RoleID, UserID)
+         if ($this->oldTableExists('UserRole')) {
+            Gdn::sql()->query('insert ignore into '.$newPrefix.'UserRole (RoleID, UserID)
                select r.RoleID, u.UserID
                from '.$newPrefix.'User u, '.$newPrefix.'Role r, `'.$oldDatabase.'`.'.$oldPrefix.'UserRole ur
                where u.OldID = (ur.UserID) and r.OldID = (ur.RoleID)');
@@ -134,17 +134,17 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
 
       // CATEGORIES //
-      if ($this->OldTableExists('Category')) {
+      if ($this->oldTableExists('Category')) {
          $categoryColumnOptions = ['Legacy' => $doLegacy];
-         $categoryColumns = $this->GetColumns('Category', $oldDatabase, $oldPrefix, $categoryColumnOptions);
+         $categoryColumns = $this->getColumns('Category', $oldDatabase, $oldPrefix, $categoryColumnOptions);
 
          /*if ($this->MergeCategories) {
             // Merge IDs of duplicate category names
-            Gdn::SQL()->Query('update '.$NewPrefix.'Category c set c.OldID =
+            Gdn::sql()->query('update '.$NewPrefix.'Category c set c.OldID =
                (select c2.CategoryID from `'.$OldDatabase.'`.'.$OldPrefix.'Category c2 where c2.Name = c.Name)');
 
             // Copy non-duplicate categories
-            Gdn::SQL()->Query('insert into '.$NewPrefix.'Category ('.$CategoryColumns.', OldID)
+            Gdn::sql()->query('insert into '.$NewPrefix.'Category ('.$CategoryColumns.', OldID)
                select '.$CategoryColumns.', CategoryID
                from `'.$OldDatabase.'`.'.$OldPrefix.'Category
                where Name not in (select Name from '.$NewPrefix.'Category)');
@@ -152,12 +152,12 @@ class ForumMergePlugin implements Gdn_IPlugin {
          else {*/
          // Import categories
          if ($doLegacy) {
-            Gdn::SQL()->Query('insert into ' . $newPrefix . 'Category (' . $categoryColumns . ', OldID, ForeignID)
+            Gdn::sql()->query('insert into ' . $newPrefix . 'Category (' . $categoryColumns . ', OldID, ForeignID)
                select ' . $categoryColumns . ', CategoryID, concat(\'' . $legacySlug . '-\', CategoryID)
                from `' . $oldDatabase . '`.' . $oldPrefix . 'Category
                where Name <> "Root"');
          } else {
-            Gdn::SQL()->Query('insert into ' . $newPrefix . 'Category (' . $categoryColumns . ', OldID)
+            Gdn::sql()->query('insert into ' . $newPrefix . 'Category (' . $categoryColumns . ', OldID)
                select ' . $categoryColumns . ', CategoryID
                from `' . $oldDatabase . '`.' . $oldPrefix . 'Category
                where Name <> "Root"');
@@ -165,26 +165,26 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
          // Remap hierarchy in the ugliest way possible
          $categoryMap = [];
-         $categories = Gdn::SQL()->Select('CategoryID')
-            ->Select('ParentCategoryID')
-            ->Select('OldID')
-            ->From('Category')
-            ->Where(['OldID >' => 0])
-            ->Get()->Result(DATASET_TYPE_ARRAY);
+         $categories = Gdn::sql()->select('CategoryID')
+            ->select('ParentCategoryID')
+            ->select('OldID')
+            ->from('Category')
+            ->where(['OldID >' => 0])
+            ->get()->result(DATASET_TYPE_ARRAY);
          foreach ($categories as $category) {
             $categoryMap[$category['OldID']] = $category['CategoryID'];
          }
          foreach ($categories as $category) {
             if ($category['ParentCategoryID'] > 0 && !empty($categoryMap[$category['ParentCategoryID']])) {
                $parentID = $categoryMap[$category['ParentCategoryID']];
-               Gdn::SQL()->Update('Category')
-                  ->Set(['ParentCategoryID' => $parentID])
-                  ->Where(['CategoryID' => $category['CategoryID']])
-                  ->Put();
+               Gdn::sql()->update('Category')
+                  ->set(['ParentCategoryID' => $parentID])
+                  ->where(['CategoryID' => $category['CategoryID']])
+                  ->put();
             }
          }
          $categoryModel = new CategoryModel();
-         $categoryModel->RebuildTree();
+         $categoryModel->rebuildTree();
 
          //}
 
@@ -194,36 +194,36 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
 
       // DISCUSSIONS //
-      if ($this->OldTableExists('Discussion')) {
+      if ($this->oldTableExists('Discussion')) {
          $discussionColumnOptions = ['Legacy' => $doLegacy];
-         $discussionColumns = $this->GetColumns('Discussion', $oldDatabase, $oldPrefix, $discussionColumnOptions);
+         $discussionColumns = $this->getColumns('Discussion', $oldDatabase, $oldPrefix, $discussionColumnOptions);
 
          // Copy over all discussions
          if ($doLegacy) {
-            Gdn::SQL()->Query('insert into ' . $newPrefix . 'Discussion (' . $discussionColumns . ', OldID, ForeignID)
+            Gdn::sql()->query('insert into ' . $newPrefix . 'Discussion (' . $discussionColumns . ', OldID, ForeignID)
                select ' . $discussionColumns . ', DiscussionID, concat(\'' . $legacySlug . '-\', DiscussionID)
                from `' . $oldDatabase . '`.' . $oldPrefix . 'Discussion');
          } else {
-            Gdn::SQL()->Query('insert into ' . $newPrefix . 'Discussion (' . $discussionColumns . ', OldID)
+            Gdn::sql()->query('insert into ' . $newPrefix . 'Discussion (' . $discussionColumns . ', OldID)
                select ' . $discussionColumns . ', DiscussionID
                from `' . $oldDatabase . '`.' . $oldPrefix . 'Discussion');
          }
 
          // Convert imported discussions to use new UserIDs
-         Gdn::SQL()->Query('update '.$newPrefix.'Discussion d
+         Gdn::sql()->query('update '.$newPrefix.'Discussion d
            set d.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = d.InsertUserID)
            where d.OldID > 0');
-         Gdn::SQL()->Query('update '.$newPrefix.'Discussion d
+         Gdn::sql()->query('update '.$newPrefix.'Discussion d
            set d.UpdateUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = d.UpdateUserID)
            where d.OldID > 0
              and d.UpdateUserID is not null');
-         Gdn::SQL()->Query('update '.$newPrefix.'Discussion d
+         Gdn::sql()->query('update '.$newPrefix.'Discussion d
            set d.CategoryID = (SELECT c.CategoryID from '.$newPrefix.'Category c where c.OldID = d.CategoryID)
            where d.OldID > 0');
 
          // UserDiscussion
-         if ($this->OldTableExists('UserDiscussion')) {
-            Gdn::SQL()->Query('insert ignore into '.$newPrefix.'UserDiscussion
+         if ($this->oldTableExists('UserDiscussion')) {
+            Gdn::sql()->query('insert ignore into '.$newPrefix.'UserDiscussion
                   (DiscussionID, UserID, Score, CountComments, DateLastViewed, Dismissed, Bookmarked)
                select d.DiscussionID, u.UserID, ud.Score, ud.CountComments, ud.DateLastViewed, ud.Dismissed, ud.Bookmarked
                from '.$newPrefix.'User u, '.$newPrefix.'Discussion d, `'.$oldDatabase.'`.'.$oldPrefix.'UserDiscussion ud
@@ -233,92 +233,92 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
 
       // COMMENTS //
-      if ($this->OldTableExists('Comment')) {
+      if ($this->oldTableExists('Comment')) {
          $commentColumnOptions = ['Legacy' => $doLegacy];
-         $commentColumns = $this->GetColumns('Comment', $oldDatabase, $oldPrefix, $commentColumnOptions);
+         $commentColumns = $this->getColumns('Comment', $oldDatabase, $oldPrefix, $commentColumnOptions);
 
          // Copy over all comments
          if ($doLegacy) {
-            Gdn::SQL()->Query('insert into ' . $newPrefix . 'Comment (' . $commentColumns . ', OldID, ForeignID)
+            Gdn::sql()->query('insert into ' . $newPrefix . 'Comment (' . $commentColumns . ', OldID, ForeignID)
                select ' . $commentColumns . ', CommentID, concat(\'' . $legacySlug . '-\', CommentID)
                from `' . $oldDatabase . '`.' . $oldPrefix . 'Comment');
          } else {
-            Gdn::SQL()->Query('insert into ' . $newPrefix . 'Comment (' . $commentColumns . ', OldID)
+            Gdn::sql()->query('insert into ' . $newPrefix . 'Comment (' . $commentColumns . ', OldID)
                select ' . $commentColumns . ', CommentID
                from `' . $oldDatabase . '`.' . $oldPrefix . 'Comment');
          }
 
          // Convert imported comments to use new UserIDs
-         Gdn::SQL()->Query('update '.$newPrefix.'Comment c
+         Gdn::sql()->query('update '.$newPrefix.'Comment c
            set c.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = c.InsertUserID)
            where c.OldID > 0');
-         Gdn::SQL()->Query('update '.$newPrefix.'Comment c
+         Gdn::sql()->query('update '.$newPrefix.'Comment c
            set c.UpdateUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = c.UpdateUserID)
            where c.OldID > 0
              and c.UpdateUserID is not null');
 
          // Convert imported comments to use new DiscussionIDs
-         Gdn::SQL()->Query('update '.$newPrefix.'Comment c
+         Gdn::sql()->query('update '.$newPrefix.'Comment c
            set c.DiscussionID = (SELECT d.DiscussionID from '.$newPrefix.'Discussion d where d.OldID = c.DiscussionID)
            where c.OldID > 0');
       }
 
 
       // MEDIA //
-      if ($this->OldTableExists('Media')) {
-         $mediaColumns = $this->GetColumns('Media', $oldDatabase, $oldPrefix);
+      if ($this->oldTableExists('Media')) {
+         $mediaColumns = $this->getColumns('Media', $oldDatabase, $oldPrefix);
 
          // Copy over all media
-         Gdn::SQL()->Query('insert into '.$newPrefix.'Media ('.$mediaColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'Media ('.$mediaColumns.', OldID)
             select '.$mediaColumns.', MediaID
             from `'.$oldDatabase.'`.'.$oldPrefix.'Media');
 
          // InsertUserID
-         Gdn::SQL()->Query('update '.$newPrefix.'Media m
+         Gdn::sql()->query('update '.$newPrefix.'Media m
            set m.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = m.InsertUserID)
            where m.OldID > 0');
 
          // ForeignID / ForeignTable
-         //Gdn::SQL()->Query('update '.$NewPrefix.'Media m
+         //Gdn::sql()->query('update '.$NewPrefix.'Media m
          //  set m.ForeignID = (SELECT c.CommentID from '.$NewPrefix.'Comment c where c.OldID = m.ForeignID)
          //  where m.OldID > 0 and m.ForeignTable = \'comment\'');
-         Gdn::SQL()->Query('update '.$newPrefix.'Media m
+         Gdn::sql()->query('update '.$newPrefix.'Media m
            set m.ForeignID = (SELECT d.DiscussionID from '.$newPrefix.'Discussion d where d.OldID = m.ForeignID)
            where m.OldID > 0 and m.ForeignTable = \'discussion\'');
       }
 
 
       // CONVERSATION //
-      if ($this->OldTableExists('Conversation')) {
-         $conversationColumns = $this->GetColumns('Conversation', $oldDatabase, $oldPrefix);
+      if ($this->oldTableExists('Conversation')) {
+         $conversationColumns = $this->getColumns('Conversation', $oldDatabase, $oldPrefix);
 
          // Copy over all Conversations
-         Gdn::SQL()->Query('insert into '.$newPrefix.'Conversation ('.$conversationColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'Conversation ('.$conversationColumns.', OldID)
             select '.$conversationColumns.', ConversationID
             from `'.$oldDatabase.'`.'.$oldPrefix.'Conversation');
          // InsertUserID
-         Gdn::SQL()->Query('update '.$newPrefix.'Conversation c
+         Gdn::sql()->query('update '.$newPrefix.'Conversation c
            set c.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = c.InsertUserID)
            where c.OldID > 0');
          // UpdateUserID
-         Gdn::SQL()->Query('update '.$newPrefix.'Conversation c
+         Gdn::sql()->query('update '.$newPrefix.'Conversation c
            set c.UpdateUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = c.UpdateUserID)
            where c.OldID > 0');
          // Contributors
          // a. Build userid lookup
 
-         $users = Gdn::SQL()->Query('select UserID, OldID from '.$newPrefix.'User');
+         $users = Gdn::sql()->query('select UserID, OldID from '.$newPrefix.'User');
          $userIDLookup = [];
-         foreach($users->Result() as $user) {
-            $oldID = GetValue('OldID', $user);
-            $userIDLookup[$oldID] = GetValue('UserID', $user);
+         foreach($users->result() as $user) {
+            $oldID = getValue('OldID', $user);
+            $userIDLookup[$oldID] = getValue('UserID', $user);
          }
          // b. Translate contributor userids
-         $conversations = Gdn::SQL()->Query('select ConversationID, Contributors
+         $conversations = Gdn::sql()->query('select ConversationID, Contributors
             from '.$newPrefix.'Conversation
             where Contributors <> ""');
-         foreach($conversations->Result() as $conversation) {
-            $contributors = dbdecode(GetValue('Contributors', $conversation));
+         foreach($conversations->result() as $conversation) {
+            $contributors = dbdecode(getValue('Contributors', $conversation));
             if (!is_array($contributors))
                continue;
             $updatedContributors = [];
@@ -327,41 +327,41 @@ class ForumMergePlugin implements Gdn_IPlugin {
                   $updatedContributors[] = $userIDLookup[$userID];
             }
             // c. Update each conversation
-            $conversationID = GetValue('ConversationID', $conversation);
-            Gdn::SQL()->Query('update '.$newPrefix.'Conversation
+            $conversationID = getValue('ConversationID', $conversation);
+            Gdn::sql()->query('update '.$newPrefix.'Conversation
                set Contributors = "'.mysql_real_escape_string(dbencode($updatedContributors)).'"
                where ConversationID = '.$conversationID);
          }
 
          // ConversationMessage
          // Copy over all ConversationMessages
-         Gdn::SQL()->Query('insert into '.$newPrefix.'ConversationMessage (ConversationID,Body,Format,
+         Gdn::sql()->query('insert into '.$newPrefix.'ConversationMessage (ConversationID,Body,Format,
                InsertUserID,DateInserted,InsertIPAddress,OldID)
             select ConversationID,Body,Format,InsertUserID,DateInserted,InsertIPAddress,MessageID
             from `'.$oldDatabase.'`.'.$oldPrefix.'ConversationMessage');
          // ConversationID
-         Gdn::SQL()->Query('update '.$newPrefix.'ConversationMessage cm
+         Gdn::sql()->query('update '.$newPrefix.'ConversationMessage cm
            set cm.ConversationID =
               (SELECT c.ConversationID from '.$newPrefix.'Conversation c where c.OldID = cm.ConversationID)
            where cm.OldID > 0');
          // InsertUserID
-         Gdn::SQL()->Query('update '.$newPrefix.'ConversationMessage c
+         Gdn::sql()->query('update '.$newPrefix.'ConversationMessage c
            set c.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = c.InsertUserID)
            where c.OldID > 0');
 
          // Conversation FirstMessageID
-         Gdn::SQL()->Query('update '.$newPrefix.'Conversation c
+         Gdn::sql()->query('update '.$newPrefix.'Conversation c
            set c.FirstMessageID =
               (SELECT cm.MessageID from '.$newPrefix.'ConversationMessage cm where cm.OldID = c.FirstMessageID)
            where c.OldID > 0');
          // Conversation LastMessageID
-         Gdn::SQL()->Query('update '.$newPrefix.'Conversation c
+         Gdn::sql()->query('update '.$newPrefix.'Conversation c
            set c.LastMessageID =
               (SELECT cm.MessageID from '.$newPrefix.'ConversationMessage cm where cm.OldID = c.LastMessageID)
            where c.OldID > 0');
 
          // UserConversation
-         Gdn::SQL()->Query('insert ignore into '.$newPrefix.'UserConversation
+         Gdn::sql()->query('insert ignore into '.$newPrefix.'UserConversation
                (ConversationID, UserID, CountReadMessages, DateLastViewed, DateCleared,
                Bookmarked, Deleted, DateConversationUpdated)
             select c.ConversationID, u.UserID,  uc.CountReadMessages, uc.DateLastViewed, uc.DateCleared,
@@ -372,51 +372,51 @@ class ForumMergePlugin implements Gdn_IPlugin {
 
 
       // POLLS //
-      if ($this->OldTableExists('Poll')) {
-         $pollColumns = $this->GetColumns('Poll', $oldDatabase, $oldPrefix);
-         $pollOptionColumns = $this->GetColumns('PollOption', $oldDatabase, $oldPrefix);
+      if ($this->oldTableExists('Poll')) {
+         $pollColumns = $this->getColumns('Poll', $oldDatabase, $oldPrefix);
+         $pollOptionColumns = $this->getColumns('PollOption', $oldDatabase, $oldPrefix);
 
          // Copy over all polls & options
-         Gdn::SQL()->Query('insert into '.$newPrefix.'Poll ('.$pollColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'Poll ('.$pollColumns.', OldID)
             select '.$pollColumns.', PollID
             from `'.$oldDatabase.'`.'.$oldPrefix.'Poll');
-         Gdn::SQL()->Query('insert into '.$newPrefix.'PollOption ('.$pollOptionColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'PollOption ('.$pollOptionColumns.', OldID)
             select '.$pollOptionColumns.', PollOptionID
             from `'.$oldDatabase.'`.'.$oldPrefix.'PollOption');
 
          // Convert imported options to use new PollIDs
-         Gdn::SQL()->Query('update '.$newPrefix.'PollOption o
+         Gdn::sql()->query('update '.$newPrefix.'PollOption o
            set o.PollID = (SELECT p.DiscussionID from '.$newPrefix.'Poll p where p.OldID = o.PollID)
            where o.OldID > 0');
 
          // Convert imported polls & options to use new UserIDs
-         Gdn::SQL()->Query('update '.$newPrefix.'Poll p
+         Gdn::sql()->query('update '.$newPrefix.'Poll p
            set p.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = p.InsertUserID)
            where p.OldID > 0');
-         Gdn::SQL()->Query('update '.$newPrefix.'PollOption o
+         Gdn::sql()->query('update '.$newPrefix.'PollOption o
            set o.InsertUserID = (SELECT u.UserID from '.$newPrefix.'User u where u.OldID = o.InsertUserID)
            where o.OldID > 0');
       }
 
       // TAGS //
-      if ($this->OldTableExists('Tag')) {
-         $tagColumns = $this->GetColumns('Tag', $oldDatabase, $oldPrefix);
-         $tagDiscussionColumns = $this->GetColumns('TagDiscussion', $oldDatabase, $oldPrefix);
+      if ($this->oldTableExists('Tag')) {
+         $tagColumns = $this->getColumns('Tag', $oldDatabase, $oldPrefix);
+         $tagDiscussionColumns = $this->getColumns('TagDiscussion', $oldDatabase, $oldPrefix);
 
          // Record reference of source forum tag ID
-         Gdn::SQL()->Query('update '.$newPrefix.'Tag t set t.OldID =
+         Gdn::sql()->query('update '.$newPrefix.'Tag t set t.OldID =
             (select t2.TagID from `'.$oldDatabase.'`.'.$oldPrefix.'Tag t2 where t2.Name = t.Name limit 1)');
 
          // Import tags not present in destination forum
-         Gdn::SQL()->Query('insert into '.$newPrefix.'Tag ('.$tagColumns.', OldID)
+         Gdn::sql()->query('insert into '.$newPrefix.'Tag ('.$tagColumns.', OldID)
             select '.$tagColumns.', TagID
             from `'.$oldDatabase.'`.'.$oldPrefix.'Tag
             where Name not in (select Name from '.$newPrefix.'Tag)');
 
          // TagDiscussion
-         if ($this->OldTableExists('TagDiscussion')) {
+         if ($this->oldTableExists('TagDiscussion')) {
             // Insert source tag:discussion mapping
-            Gdn::SQL()->Query('insert ignore into '.$newPrefix.'TagDiscussion (TagID, DiscussionID, OldCategoryID)
+            Gdn::sql()->query('insert ignore into '.$newPrefix.'TagDiscussion (TagID, DiscussionID, OldCategoryID)
                select t.TagID, d.DiscussionID, td.CategoryID
                from '.$newPrefix.'Tag t, '.$newPrefix.'Discussion d, `'.$oldDatabase.'`.'.$oldPrefix.'TagDiscussion td
                where t.OldID = (td.TagID) and d.OldID = (td.DiscussionID)');
@@ -425,7 +425,7 @@ class ForumMergePlugin implements Gdn_IPlugin {
              * Incoming tags may or may not have CategoryIDs associated with them, so we'll need to update them with a
              * current CategoryID, if applicable, based on the original category ID (OldCategoryID) from the source
              */
-            Gdn::SQL()->Query('update '.$newPrefix.'TagDiscussion td set CategoryID =
+            Gdn::sql()->query('update '.$newPrefix.'TagDiscussion td set CategoryID =
                (select c.CategoryID from '.$newPrefix.'Category c where c.OldID = td.OldCategoryID limit 1)
                where OldCategoryID > 0');
          }
@@ -444,54 +444,54 @@ class ForumMergePlugin implements Gdn_IPlugin {
    /**
     * Nuke every OldID column before a second merge.
     */
-   public function UtilityController_MergeReset_Create() {
-      Gdn::SQL()->Update('Activity')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Category')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Comment')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Conversation')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('ConversationMessage')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Discussion')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Media')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Role')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('Tag')->Set('OldID', NULL)->Put();
-      Gdn::SQL()->Update('TagDiscussion')->Set('OldCategoryID', NULL)->Put();
-      Gdn::SQL()->Update('User')->Set('OldID', NULL)->Put();
+   public function utilityController_mergeReset_create() {
+      Gdn::sql()->update('Activity')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Category')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Comment')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Conversation')->set('OldID', NULL)->put();
+      Gdn::sql()->update('ConversationMessage')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Discussion')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Media')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Role')->set('OldID', NULL)->put();
+      Gdn::sql()->update('Tag')->set('OldID', NULL)->put();
+      Gdn::sql()->update('TagDiscussion')->set('OldCategoryID', NULL)->put();
+      Gdn::sql()->update('User')->set('OldID', NULL)->put();
 
-      $construct = Gdn::Database()->Structure();
-      $construct->Table('Poll');
-      if ($construct->TableExists()) {
-         Gdn::SQL()->Update('Poll')->Set('OldID', NULL)->Put();
-         Gdn::SQL()->Update('PollOption')->Set('OldID', NULL)->Put();
+      $construct = Gdn::database()->structure();
+      $construct->table('Poll');
+      if ($construct->tableExists()) {
+         Gdn::sql()->update('Poll')->set('OldID', NULL)->put();
+         Gdn::sql()->update('PollOption')->set('OldID', NULL)->put();
       }
    }
 
-   public function Setup() {
-      $this->Structure();
+   public function setup() {
+      $this->structure();
    }
 
-   public function Structure() {
-      $px = Gdn::Database()->DatabasePrefix;
+   public function structure() {
+      $px = Gdn::database()->DatabasePrefix;
 
       // Preparing to capture SQL (not execute) for operations that may need to be performed manually by the user
-      Gdn::Structure()->CaptureOnly = TRUE;
-      Gdn::Structure()->Database->CapturedSql = [];
+      Gdn::structure()->CaptureOnly = TRUE;
+      Gdn::structure()->Database->CapturedSql = [];
 
       // Comment table threshold check
-      $currentComments =  GDN::SQL()->Query("show table status where Name = '{$px}Comment'")->FirstRow()->Rows;
+      $currentComments =  GDN::sql()->query("show table status where Name = '{$px}Comment'")->firstRow()->Rows;
       if ($currentComments > $this->TableRowThreshold) { // Does the number of rows exceed the threshold?
          // Execute functions for generating the SQL related to structural updates.  SQL is saved in CapturedSql
-         Gdn::Structure()->Table('Comment')->Column('OldID', 'int', true, 'key')
-            ->Column('ForeignID', 'varchar(32)', true, 'key')->Set();
+         Gdn::structure()->table('Comment')->column('OldID', 'int', true, 'key')
+            ->column('ForeignID', 'varchar(32)', true, 'key')->set();
       }
 
       // Allow execution of structural operations
-      Gdn::Structure()->CaptureOnly = FALSE;
+      Gdn::structure()->CaptureOnly = FALSE;
 
       /**
        * If any SQL commands were captured, it means we have a problem.  Throw an exception and report the necessary
        * SQL commands back to the user
        */
-      $capturedSql = Gdn::Structure()->Database->CapturedSql;
+      $capturedSql = Gdn::structure()->Database->CapturedSql;
       if (!empty($capturedSql)) {
          throw new Exception(
             "Due to the size of some tables, the following MySQL commands will need to be manually executed:\n" .
@@ -499,25 +499,25 @@ class ForumMergePlugin implements Gdn_IPlugin {
          );
       }
 
-      Gdn::Structure()->Table('Activity')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('Category')->Column('OldID', 'int', TRUE, 'key')
-         ->Column('ForeignID', 'varchar(32)', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('Comment')->Column('OldID', 'int', true, 'key')
-         ->Column('ForeignID', 'varchar(32)', true, 'key')->Set();
-      Gdn::Structure()->Table('Conversation')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('ConversationMessage')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('Discussion')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('Media')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('Role')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('Tag')->Column('OldID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('TagDiscussion')->Column('OldCategoryID', 'int', TRUE, 'key')->Set();
-      Gdn::Structure()->Table('User')->Column('OldID', 'int', TRUE, 'key')->Set();
+      Gdn::structure()->table('Activity')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('Category')->column('OldID', 'int', TRUE, 'key')
+         ->column('ForeignID', 'varchar(32)', TRUE, 'key')->set();
+      Gdn::structure()->table('Comment')->column('OldID', 'int', true, 'key')
+         ->column('ForeignID', 'varchar(32)', true, 'key')->set();
+      Gdn::structure()->table('Conversation')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('ConversationMessage')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('Discussion')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('Media')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('Role')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('Tag')->column('OldID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('TagDiscussion')->column('OldCategoryID', 'int', TRUE, 'key')->set();
+      Gdn::structure()->table('User')->column('OldID', 'int', TRUE, 'key')->set();
 
-      $construct = Gdn::Database()->Structure();
-      $construct->Table('Poll');
-      if ($construct->TableExists()) {
-         Gdn::Structure()->Table('Poll')->Column('OldID', 'int', TRUE, 'key')->Set();
-         Gdn::Structure()->Table('PollOption')->Column('OldID', 'int', TRUE, 'key')->Set();
+      $construct = Gdn::database()->structure();
+      $construct->table('Poll');
+      if ($construct->tableExists()) {
+         Gdn::structure()->table('Poll')->column('OldID', 'int', TRUE, 'key')->set();
+         Gdn::structure()->table('PollOption')->column('OldID', 'int', TRUE, 'key')->set();
       }
    }
 }

--- a/plugins/ForumMerge/views/merge.php
+++ b/plugins/ForumMerge/views/merge.php
@@ -1,30 +1,30 @@
 <?php if (!defined('APPLICATION')) exit();
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
    <ul>
       <li>
          <?php
-         echo $this->Form->Label('Database');
-         echo $this->Form->TextBox('Database');
+         echo $this->Form->label('Database');
+         echo $this->Form->textBox('Database');
          ?>
       </li>
       <li>
          <?php
-         echo $this->Form->Label('Table Prefix', 'Prefix');
-         echo $this->Form->TextBox('Prefix');
+         echo $this->Form->label('Table Prefix', 'Prefix');
+         echo $this->Form->textBox('Prefix');
          ?>
       </li>
       <li>
-         <?php echo $this->Form->Label('Legacy Slug', 'LegacySlug'); ?>
-         <div class="Info"><?php echo T('ForumMerge.Merge.LegacySlug', 'Optional. Enter a slug used to associate all content from this source.  All sources should use a unique slug.  This will be used for legacy redirects.  If specified, all incoming ForeignIDs for categories, comments and discussions will be lost.'); ?></div>
-         <?php echo $this->Form->TextBox('LegacySlug'); ?>
+         <?php echo $this->Form->label('Legacy Slug', 'LegacySlug'); ?>
+         <div class="Info"><?php echo t('ForumMerge.Merge.LegacySlug', 'Optional. Enter a slug used to associate all content from this source.  All sources should use a unique slug.  This will be used for legacy redirects.  If specified, all incoming ForeignIDs for categories, comments and discussions will be lost.'); ?></div>
+         <?php echo $this->Form->textBox('LegacySlug'); ?>
       </li>
       <!--<li>
       <?php
-      echo $this->Form->CheckBox('MergeCategories', T('Merge categories'));
+      echo $this->Form->checkBox('MergeCategories', t('Merge categories'));
       ?>
    </li>-->
    </ul>
 <?php
-echo $this->Form->Close('Begin');
+echo $this->Form->close('Begin');

--- a/plugins/HipChat/class.hipchat.plugin.php
+++ b/plugins/HipChat/class.hipchat.plugin.php
@@ -45,7 +45,7 @@ class HipChatPlugin extends Gdn_Plugin {
         ]);
 
         $sender->addSideMenu();
-        $sender->setData('Title', sprintf(T('%s Settings'), 'HipChat'));
+        $sender->setData('Title', sprintf(t('%s Settings'), 'HipChat'));
         $sender->ConfigurationModule = $conf;
         $conf->renderAll();
     }

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -240,7 +240,7 @@ EOT;
      * @param $sender
      * @param $args
      */
-    public function BBCode_afterBBCodeSetup_handler($sender, $args) {
+    public function bBCode_afterBBCodeSetup_handler($sender, $args) {
         $nbbc = $args['BBCode'];
         $nbbc->setEscapeContent(false);
     }

--- a/plugins/Ignore/views/confirm.php
+++ b/plugins/Ignore/views/confirm.php
@@ -1,33 +1,33 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 
-<h1><?php echo $this->Data('Title'); ?></h1>
+<h1><?php echo $this->data('Title'); ?></h1>
 
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 
-switch ($this->Data('Mode')) {
+switch ($this->data('Mode')) {
    case 'set':
-      echo '<div class="P">'.sprintf(T('Are you sure you want to ignore <b>%s</b>?'), $this->Data('User.Name')).'</div>';
+      echo '<div class="P">'.sprintf(t('Are you sure you want to ignore <b>%s</b>?'), $this->data('User.Name')).'</div>';
       
-      if ($this->Data('Conversations')) {
-         $Conversations = (array)$this->Data('Conversations');
+      if ($this->data('Conversations')) {
+         $Conversations = (array)$this->data('Conversations');
          $NumConversationsAffected = count($Conversations);
          echo '<div class="Warning">';
-         echo sprintf(T('Ignoring this person will remove you from <b>%s %s</b> with them.'), $NumConversationsAffected, Plural($NumConversationsAffected, 'conversation', 'conversations'));
+         echo sprintf(t('Ignoring this person will remove you from <b>%s %s</b> with them.'), $NumConversationsAffected, plural($NumConversationsAffected, 'conversation', 'conversations'));
          echo '</div>';
       }
       
       break;
    
    case 'unset':
-      echo '<div class="P">'.sprintf(T('Are you sure you want to unignore <b>%s</b>?'), $this->Data('User.Name')).'</div>';
+      echo '<div class="P">'.sprintf(t('Are you sure you want to unignore <b>%s</b>?'), $this->data('User.Name')).'</div>';
       break;
 }
 
 echo '<div class="Buttons Buttons-Confirm">';
-echo $this->Form->Button('OK', ['class' => 'Button Primary']);
-echo $this->Form->Button('Cancel', ['type' => 'button', 'class' => 'Button Close']);
+echo $this->Form->button('OK', ['class' => 'Button Primary']);
+echo $this->Form->button('Cancel', ['type' => 'button', 'class' => 'Button Close']);
 echo '<div>';
-echo $this->Form->Close();
+echo $this->Form->close();
 ?>

--- a/plugins/Ignore/views/ignore.php
+++ b/plugins/Ignore/views/ignore.php
@@ -1,42 +1,42 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-<h2 class="H"><?php echo $this->Data('Title'); ?></h2>
+<h2 class="H"><?php echo $this->data('Title'); ?></h2>
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 
-$NumIgnoredUsers = sizeof($this->Data('IgnoreList'));
-$Moderator = Gdn::Session()->CheckPermission('Garden.Users.Edit');
-$Restricted = $this->Data('IgnoreRestricted');
+$NumIgnoredUsers = sizeof($this->data('IgnoreList'));
+$Moderator = Gdn::session()->checkPermission('Garden.Users.Edit');
+$Restricted = $this->data('IgnoreRestricted');
 
 ?>
-<?php if ($this->Data('ForceEditing', FALSE)): ?>
-   <div class="Warning"><?php echo sprintf(T("You are viewing %s's ignore list"),$this->Data('ForceEditing')); ?></div>
+<?php if ($this->data('ForceEditing', FALSE)): ?>
+   <div class="Warning"><?php echo sprintf(t("You are viewing %s's ignore list"),$this->data('ForceEditing')); ?></div>
 <?php endif; ?>
 
 <?php if ($NumIgnoredUsers): ?>
 <table class="IgnoreList <?php echo ($Restricted) ? 'Restricted' : ''; ?>">
    <thead>
       <tr>
-         <th colspan="2"><?php echo T('User'); ?></th>
-         <th><?php echo T('Date Ignored'); ?></th>
+         <th colspan="2"><?php echo t('User'); ?></th>
+         <th><?php echo t('Date Ignored'); ?></th>
          <th></th>
       </tr>
    </thead>
    <tbody>
-      <?php foreach ($this->Data('IgnoreList') as $IgnoredUser): ?>
+      <?php foreach ($this->data('IgnoreList') as $IgnoredUser): ?>
 
       <?php
          $DateIgnoredTime = strtotime($IgnoredUser['IgnoreDate']);
          if (!$DateIgnoredTime)
             $DateIgnored = 'Unknown';
          else
-            $DateIgnored = Gdn_Format::Date($DateIgnoredTime);
+            $DateIgnored = Gdn_Format::date($DateIgnoredTime);
       ?>
       <tr>
-         <td class="IgnoreUserPhoto"><?php echo UserPhoto($IgnoredUser); ?></td>
-         <td class="IgnoreUserName"><?php echo UserAnchor($IgnoredUser); ?></td>
+         <td class="IgnoreUserPhoto"><?php echo userPhoto($IgnoredUser); ?></td>
+         <td class="IgnoreUserName"><?php echo userAnchor($IgnoredUser); ?></td>
          <td class="IgnoreUserDate"><?php echo $DateIgnored; ?></td>
-         <td class="IgnoreUserAction"><?php echo (!$this->Data('ForceEditing') & !$Restricted) ? Anchor('Unignore', "/user/ignore/toggle/{$IgnoredUser['UserID']}/".Gdn_Format::Url($IgnoredUser['Name']), 'Ignore Button Popup') : ''; ?></td>
+         <td class="IgnoreUserAction"><?php echo (!$this->data('ForceEditing') & !$Restricted) ? anchor('Unignore', "/user/ignore/toggle/{$IgnoredUser['UserID']}/".Gdn_Format::url($IgnoredUser['Name']), 'Ignore Button Popup') : ''; ?></td>
       </tr>
       <?php endforeach; ?>
    </tbody>
@@ -44,38 +44,38 @@ $Restricted = $this->Data('IgnoreRestricted');
 <?php endif; ?>
 
 <?php
-$NumIgnoreLimit = $this->Data('IgnoreLimit');
+$NumIgnoreLimit = $this->data('IgnoreLimit');
 if ($NumIgnoreLimit != 'infinite'):
    $IgnoreListPercent = round(($NumIgnoredUsers / $NumIgnoreLimit) * 100, 2);
-   echo Wrap(sprintf(T("Ignore list is <b>%s%%</b> full (<b>%d/%d</b>)."), $IgnoreListPercent, $NumIgnoredUsers, $NumIgnoreLimit), 'div');
+   echo wrap(sprintf(t("Ignore list is <b>%s%%</b> full (<b>%d/%d</b>)."), $IgnoreListPercent, $NumIgnoredUsers, $NumIgnoreLimit), 'div');
 else:
-   echo Wrap(sprintf(T("<b>Unlimited</b> list, ignored <b>%d</b> %s"), $NumIgnoredUsers, Plural($NumIgnoredUsers, 'person','people')), 'div');
+   echo wrap(sprintf(t("<b>Unlimited</b> list, ignored <b>%d</b> %s"), $NumIgnoredUsers, plural($NumIgnoredUsers, 'person','people')), 'div');
 endif;
 ?>
 
 <?php if ($Restricted): ?>
-   <?php $ReferTo = ($this->Data('ForceEditing') ? sprintf(T("%s is"), $this->Data('ForceEditing')) : T("You are")); ?>
+   <?php $ReferTo = ($this->data('ForceEditing') ? sprintf(t("%s is"), $this->data('ForceEditing')) : t("You are")); ?>
    <div class="Info">
-      <?php echo sprintf(T("%s prohibited from using the ignore feature."),$ReferTo); ?>
-      <?php if ($Moderator && $this->Data('ForceEditing', TRUE)):
-         echo Anchor('Restore', "/user/ignorelist/allow/{$this->User->UserID}/".Gdn_Format::Url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']);
+      <?php echo sprintf(t("%s prohibited from using the ignore feature."),$ReferTo); ?>
+      <?php if ($Moderator && $this->data('ForceEditing', TRUE)):
+         echo anchor('Restore', "/user/ignorelist/allow/{$this->User->UserID}/".Gdn_Format::url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']);
       endif; ?>
    </div>
-<?php elseif ($Moderator && $this->Data('ForceEditing', TRUE)): ?>
-   <div class="Warning"><?php echo sprintf(T("Revoke <b>%s</b>'s ignore list privileges?"), $this->Data('ForceEditing')); ?> <?php echo Anchor('Revoke', "/user/ignorelist/revoke/{$this->User->UserID}/".Gdn_Format::Url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']); ?></div>
+<?php elseif ($Moderator && $this->data('ForceEditing', TRUE)): ?>
+   <div class="Warning"><?php echo sprintf(t("Revoke <b>%s</b>'s ignore list privileges?"), $this->data('ForceEditing')); ?> <?php echo anchor('Revoke', "/user/ignorelist/revoke/{$this->User->UserID}/".Gdn_Format::url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']); ?></div>
 <?php endif; ?>
 
-<?php if (!$this->Data('ForceEditing') && !$Restricted): ?>
+<?php if (!$this->data('ForceEditing') && !$Restricted): ?>
 <ul>
    <li>
       <?php
-         echo $this->Form->Label('Ignore Someone', 'AddIgnore');
-         echo $this->Form->Textbox('AddIgnore');
+         echo $this->Form->label('Ignore Someone', 'AddIgnore');
+         echo $this->Form->textbox('AddIgnore');
       ?>
    </li>
 </ul>
-<?php echo $this->Form->Close('OK');
+<?php echo $this->Form->close('OK');
 
 else:
-   echo $this->Form->Close();
+   echo $this->Form->close();
 endif;

--- a/plugins/Liked/class.liked.plugin.php
+++ b/plugins/Liked/class.liked.plugin.php
@@ -2,7 +2,7 @@
 
 class LikedPlugin extends Gdn_Plugin {
 
-	public function DiscussionController_Render_Before($sender) {
+	public function discussionController_render_before($sender) {
       $fB_SDK = <<<EOD
 <div id="fb-root"></div>
 <script>(function(d, s, id) {
@@ -13,16 +13,16 @@ class LikedPlugin extends Gdn_Plugin {
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
 EOD;
-      $sender->AddAsset('Panel', $fB_SDK);
+      $sender->addAsset('Panel', $fB_SDK);
 	}
 
-	public function DiscussionController_AfterDiscussionBody_Handler($sender) {
+	public function discussionController_afterDiscussionBody_handler($sender) {
       echo '<div class="fb-like" data-href="';
-      echo Gdn_Url::Request(true, true, true);
+      echo Gdn_Url::request(true, true, true);
       echo '" data-send="false" data-width="450" data-show-faces="false" data-font="lucida grande"></div>';
 	}
 
-   public function Setup() {
+   public function setup() {
       // No setup required.
    }
 }

--- a/plugins/LocaleDeveloper/class.developerlocale.php
+++ b/plugins/LocaleDeveloper/class.developerlocale.php
@@ -13,28 +13,28 @@ class DeveloperLocale extends Gdn_Locale {
      *
      * return array
      */
-    public function AllDefinitions() {
+    public function allDefinitions() {
         $result = array_merge($this->_Definition, $this->_CapturedDefinitions);
         return $result;
     }
 
-    public function CapturedDefinitions() {
+    public function capturedDefinitions() {
         return $this->_CapturedDefinitions;
     }
 
-    public static function GuessPrefix() {
+    public static function guessPrefix() {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
         foreach ($trace as $i => $row) {
             if (strcasecmp($row['function'], 't') === 0) {
                 if ($trace[$i + 1]['function'] == 'Plural')
-                    return self::PrefixFromPath($trace[$i + 1]['file']);
+                    return self::prefixFromPath($trace[$i + 1]['file']);
                 else
-                    return self::PrefixFromPath($row['file']);
+                    return self::prefixFromPath($row['file']);
             }
             if (strcasecmp($row['function'], 'Translate') === 0) {
                 if (!in_array(basename($row['file']), ['functions.general.php', 'class.gdn.php'])) {
-                    return self::PrefixFromPath($row['file']);
+                    return self::prefixFromPath($row['file']);
                 }
             }
         }
@@ -42,7 +42,7 @@ class DeveloperLocale extends Gdn_Locale {
         return FALSE;
     }
 
-    public static function PrefixFromPath($path) {
+    public static function prefixFromPath($path) {
         $result = '';
 
         if (preg_match('`/plugins/([^/]+)`i', $path, $matches)) {
@@ -69,13 +69,13 @@ class DeveloperLocale extends Gdn_Locale {
         return $result;
     }
 
-    public function Translate($code, $default = FALSE) {
-        $result = parent::Translate($code, $default);
+    public function translate($code, $default = FALSE) {
+        $result = parent::translate($code, $default);
 
         if (!$code || substr($code, 0, 1) == '@')
             return $result;
 
-        $prefix = self::GuessPrefix();
+        $prefix = self::guessPrefix();
 
         if (!$prefix) {
             return $result;
@@ -87,7 +87,7 @@ class DeveloperLocale extends Gdn_Locale {
             die();
         }
 
-        if (Gdn_Theme::InSection('Dashboard'))
+        if (Gdn_Theme::inSection('Dashboard'))
             $prefix = 'dash_'.$prefix;
         else
             $prefix = 'site_'.$prefix;

--- a/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
+++ b/plugins/LocaleDeveloper/class.localedeveloper.plugin.php
@@ -28,17 +28,17 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
      * @param Gdn_Controller $Sender
      * @param array $Args
      */
-    public function Base_Render_After($Sender, $Args) {
-        $Locale = Gdn::Locale();
+    public function base_render_after($Sender, $Args) {
+        $Locale = Gdn::locale();
         if (!is_a($Locale, 'DeveloperLocale'))
             return;
 
-        $Path = $this->LocalePath.'/tmp_'.RandomString(10);
+        $Path = $this->LocalePath.'/tmp_'.randomString(10);
         if (!file_exists(dirname($Path)))
             mkdir(dirname($Path), 0777, TRUE);
         elseif (file_exists($Path)) {
             // Load the existing definitions.
-            $Locale->Load($Path);
+            $Locale->load($Path);
         }
 
         // Load the core definitions.
@@ -65,7 +65,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         $Ignore = $Definition;
         $Definition = [];
 
-        $CapturedDefinitions = $Locale->CapturedDefinitions();
+        $CapturedDefinitions = $Locale->capturedDefinitions();
 
 //      decho ($CapturedDefinitions);
 //      die();
@@ -94,8 +94,8 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
                 Logger::error("Could not open {path}.", ['path' => $Path]);
                 continue;
             }
-            fwrite($fp, $this->GetFileHeader());
-            LocaleModel::WriteDefinitions($fp, $Definition);
+            fwrite($fp, $this->getFileHeader());
+            LocaleModel::writeDefinitions($fp, $Definition);
             fclose($fp);
 
             // Copy the file over the existing one.
@@ -103,14 +103,14 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         }
     }
 
-    public function Gdn_Dispatcher_BeforeDispatch_Handler($sender) {
-        if (C('Plugins.LocaleDeveloper.CaptureDefinitions')) {
+    public function gdn_Dispatcher_BeforeDispatch_Handler($sender) {
+        if (c('Plugins.LocaleDeveloper.CaptureDefinitions')) {
             // Install the developer locale.
-            $_Locale = new DeveloperLocale(Gdn::Locale()->Current(), C('EnabledApplications'), C('EnabledPlugins'));
+            $_Locale = new DeveloperLocale(Gdn::locale()->current(), c('EnabledApplications'), c('EnabledPlugins'));
 
-            $tmp = Gdn::FactoryOverwrite(TRUE);
-            Gdn::FactoryInstall(Gdn::AliasLocale, 'Gdn_Locale', NULL, Gdn::FactorySingleton, $_Locale);
-            Gdn::FactoryOverwrite($tmp);
+            $tmp = Gdn::factoryOverwrite(TRUE);
+            Gdn::factoryInstall(Gdn::AliasLocale, 'Gdn_Locale', NULL, Gdn::FactorySingleton, $_Locale);
+            Gdn::factoryOverwrite($tmp);
             unset($tmp);
         }
     }
@@ -120,28 +120,28 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
      * @param Gdn_Controller $sender
      * @param array $args
      */
-    public function SettingsController_Render_Before($sender, $args) {
+    public function settingsController_render_before($sender, $args) {
         if (strcasecmp($sender->RequestMethod, 'locales') != 0)
             return;
 
         // Add a little pointer to the settings.
         $text = '<div class="Info">'.
-            sprintf(T('Locale Developer Settings %s.'), Anchor(T('here'), '/settings/localedeveloper')).
+            sprintf(t('Locale Developer Settings %s.'), anchor(t('here'), '/settings/localedeveloper')).
             '</div>';
-        $sender->AddAsset('Content', $text, 'LocaleDeveloperLink');
+        $sender->addAsset('Content', $text, 'LocaleDeveloperLink');
     }
 
     /**
      *
      * @var SettingsController $sender
      */
-    public function SettingsController_LocaleDeveloper_Create($sender, $args = []) {
-        $sender->Permission('Garden.Settings.Manage');
+    public function settingsController_localeDeveloper_create($sender, $args = []) {
+        $sender->permission('Garden.Settings.Manage');
 
-        $sender->AddSideMenu();
-        $sender->SetData('Title', T('Locale Developer'));
+        $sender->addSideMenu();
+        $sender->setData('Title', t('Locale Developer'));
 
-        switch (strtolower(GetValue(0, $args, ''))) {
+        switch (strtolower(getValue(0, $args, ''))) {
             case '':
                 $this->_Settings($sender, $args);
                 break;
@@ -157,25 +157,25 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
     public function _Download($sender, $args) {
         try {
             // Create the zip file.
-            $path = $this->CreateZip();
+            $path = $this->createZip();
 
             // Serve the zip file.
-            Gdn_FileSystem::ServeFile($path, basename($path), 'application/zip');
+            Gdn_FileSystem::serveFile($path, basename($path), 'application/zip');
         } catch (Exception $ex) {
-            $this->Form->AddError($ex);
+            $this->Form->addError($ex);
             $this->_Settings($sender, $args);
         }
     }
 
-    public function EnsureDefinitionFile() {
+    public function ensureDefinitionFile() {
         $path = $this->LocalePath.'/definitions.php';
         if (file_exists($path))
             unlink($path);
-        $contents = $this->GetFileHeader().self::FormatInfoArray('$LocaleInfo', $this->GetInfoArray());
-        Gdn_FileSystem::SaveFile($path, $contents);
+        $contents = $this->getFileHeader().self::formatInfoArray('$LocaleInfo', $this->getInfoArray());
+        Gdn_FileSystem::saveFile($path, $contents);
     }
 
-    public static function FormatInfoArray($variableName, $array) {
+    public static function formatInfoArray($variableName, $array) {
         $variableName = '$'.trim($variableName, '$');
 
         $result = '';
@@ -188,7 +188,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         return $result;
     }
 
-    public static function FormatValue($value, $singleLine = TRUE) {
+    public static function formatValue($value, $singleLine = TRUE) {
         if (is_bool($value)) {
             return $value ? 'TRUE' : 'FALSE';
         } elseif (is_numeric($value)) {
@@ -209,7 +209,7 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
                 if ($singleLine == 'TRUEFALSE')
                     $singleLine = FALSE;
 
-                $result .= "'".addcslashes($key, "'")."' => ".self::FormatValue($arrayValue, $singleLine);
+                $result .= "'".addcslashes($key, "'")."' => ".self::formatValue($arrayValue, $singleLine);
             }
 
             $result = 'array('.$result.')';
@@ -222,8 +222,8 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         }
     }
 
-    public function GetFileHeader() {
-        $now = Gdn_Format::ToDateTime();
+    public function getFileHeader() {
+        $now = Gdn_Format::toDateTime();
 
         $result = "<?php if (!defined('APPLICATION')) exit();
 /** This file was generated by the Locale Developer plugin on $now **/\n\n";
@@ -231,16 +231,16 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
         return $result;
     }
 
-    public function GetInfoArray() {
-        $info = C('Plugins.LocaleDeveloper');
+    public function getInfoArray() {
+        $info = c('Plugins.LocaleDeveloper');
         foreach ($info as $key => $value) {
             if (!$value)
                 unset($info[$key]);
         }
 
-        $infoArray = [GetValue('Key', $info, 'LocaleDeveloper') => [
-            'Locale' => GetValue('Locale', $info, Gdn::Locale()->Current()),
-            'Name' => GetValue('Name', $info, 'Locale Developer'),
+        $infoArray = [getValue('Key', $info, 'LocaleDeveloper') => [
+            'Locale' => getValue('Locale', $info, Gdn::locale()->current()),
+            'Name' => getValue('Name', $info, 'Locale Developer'),
             'Description' => 'Automatically gernerated by the Locale Developer plugin.',
             'Version' => '0.1a',
             'Author' => "Your Name",
@@ -255,23 +255,23 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
     public function _GoogleTranslate($sender, $args) {
         $sender->Form = $this->Form;
 
-        if ($this->Form->IsPostBack()) {
+        if ($this->Form->isPostBack()) {
             exit('Foo');
 
         } else {
             // Load all of the definitions.
-            //$Definitions = $this->LoadDefinitions();
-            //$Sender->SetData('Definitions', $Definitions);
+            //$Definitions = $this->loadDefinitions();
+            //$Sender->setData('Definitions', $Definitions);
         }
 
-        $sender->Render('googletranslate', '', 'plugins/LocaleDeveloper');
+        $sender->render('googletranslate', '', 'plugins/LocaleDeveloper');
     }
 
-//   public function LoadDefinitions($Path = NULL) {
+//   public function loadDefinitions($Path = NULL) {
 //      if ($Path === NULL)
 //         $Path = $this->LocalePath;
 //
-//      $Paths = SafeGlob($Path.'/*.php');
+//      $Paths = safeGlob($Path.'/*.php');
 //      $Definition = array();
 //      foreach ($Paths as $Path) {
 //         // Skip the locale developer's changes file.
@@ -287,109 +287,109 @@ class LocaleDeveloperPlugin extends Gdn_Plugin {
 
         // Grab the existing locale packs.
         $localeModel = new LocaleModel();
-        $localePacks = $localeModel->AvailableLocalePacks();
+        $localePacks = $localeModel->availableLocalePacks();
         $localArray = [];
         foreach ($localePacks as $key => $info) {
-            $localeArray[$key] = GetValue('Name', $info, $key);
+            $localeArray[$key] = getValue('Name', $info, $key);
         }
-        $sender->SetData('LocalePacks', $localeArray);
+        $sender->setData('LocalePacks', $localeArray);
 
-        if ($this->Form->IsPostBack()) {
-            if ($this->Form->GetFormValue('Save')) {
-                $values = ArrayTranslate($this->Form->FormValues(), ['Key', 'Name', 'Locale', 'CaptureDefinitions']);
+        if ($this->Form->isPostBack()) {
+            if ($this->Form->getFormValue('Save')) {
+                $values = arrayTranslate($this->Form->formValues(), ['Key', 'Name', 'Locale', 'CaptureDefinitions']);
                 $saveValues = [];
                 foreach ($values as $key => $value) {
                     $saveValues['Plugins.LocaleDeveloper.'.$key] = $value;
                 }
 
                 // Save the settings.
-                SaveToConfig($saveValues, '', ['RemoveEmpty' => TRUE]);
+                saveToConfig($saveValues, '', ['RemoveEmpty' => TRUE]);
 
-                $sender->StatusMessage = T('Your changes have been saved.');
-            } elseif ($this->Form->GetFormValue('GenerateChanges')) {
-                $key = $this->Form->GetFormValue('LocalePackForChanges');
+                $sender->StatusMessage = t('Your changes have been saved.');
+            } elseif ($this->Form->getFormValue('GenerateChanges')) {
+                $key = $this->Form->getFormValue('LocalePackForChanges');
                 if (!$key)
-                    $this->Form->AddError('ValidateRequired', 'Locale Pack');
+                    $this->Form->addError('ValidateRequired', 'Locale Pack');
                 $path = PATH_ROOT.'/locales/'.$key;
                 if (!file_exists($path))
-                    $this->Form->AddError('Could not find the selected locale pack.');
+                    $this->Form->addError('Could not find the selected locale pack.');
 
-                if ($this->Form->ErrorCount() == 0) {
+                if ($this->Form->errorCount() == 0) {
                     try {
-                        $localeModel->GenerateChanges($path, $this->LocalePath);
-                        $sender->StatusMessage = T('Your changes have been saved.');
+                        $localeModel->generateChanges($path, $this->LocalePath);
+                        $sender->StatusMessage = t('Your changes have been saved.');
                     } catch (Exception $ex) {
-                        $this->Form->AddError($ex);
+                        $this->Form->addError($ex);
                     }
                 }
-            } elseif ($this->Form->GetFormValue('Copy')) {
-                $key = $this->Form->GetFormValue('LocalePackForCopy');
+            } elseif ($this->Form->getFormValue('Copy')) {
+                $key = $this->Form->getFormValue('LocalePackForCopy');
                 if (!$key)
-                    $this->Form->AddError('ValidateRequired', 'Locale Pack');
+                    $this->Form->addError('ValidateRequired', 'Locale Pack');
                 $path = PATH_ROOT.'/locales/'.$key;
                 if (!file_exists($path))
-                    $this->Form->AddError('Could not find the selected locale pack.');
+                    $this->Form->addError('Could not find the selected locale pack.');
 
-                if ($this->Form->ErrorCount() == 0) {
+                if ($this->Form->errorCount() == 0) {
                     try {
-                        $localeModel->CopyDefinitions($path, $this->LocalePath.'/copied.php');
-                        $sender->StatusMessage = T('Your changes have been saved.');
+                        $localeModel->copyDefinitions($path, $this->LocalePath.'/copied.php');
+                        $sender->StatusMessage = t('Your changes have been saved.');
                     } catch (Exception $ex) {
-                        $this->Form->AddError($ex);
+                        $this->Form->addError($ex);
                     }
                 }
-            } elseif ($this->Form->GetFormValue('Remove')) {
-                $files = SafeGlob($this->LocalePath.'/*');
+            } elseif ($this->Form->getFormValue('Remove')) {
+                $files = safeGlob($this->LocalePath.'/*');
                 foreach ($files as $file) {
                     $result = unlink($file);
                     if (!$result) {
-                        $this->Form->AddError('@'.sprintf(T('Could not remove %s.'), $file));
+                        $this->Form->addError('@'.sprintf(t('Could not remove %s.'), $file));
                     }
                 }
-                if ($this->Form->ErrorCount() == 0)
-                    $sender->StatusMessage = T('Your changes have been saved.');
+                if ($this->Form->errorCount() == 0)
+                    $sender->StatusMessage = t('Your changes have been saved.');
             }
         } else {
-            $values = C('Plugins.LocaleDeveloper');
+            $values = c('Plugins.LocaleDeveloper');
             foreach ($values as $key => $value) {
-                $this->Form->SetFormValue($key, $value);
+                $this->Form->setFormValue($key, $value);
             }
         }
 
-        $sender->SetData('LocalePath', $this->LocalePath);
+        $sender->setData('LocalePath', $this->LocalePath);
 
-        $sender->Render('', '', 'plugins/LocaleDeveloper');
+        $sender->render('', '', 'plugins/LocaleDeveloper');
     }
 
-    public function WriteInfoArray($fp) {
-        $info = C('Plugins.LocaleDeveloper');
+    public function writeInfoArray($fp) {
+        $info = c('Plugins.LocaleDeveloper');
 
         // Write the info array.
-        $infoArray = $this->GetInfoArray();
+        $infoArray = $this->getInfoArray();
 
-        $infoString = self::FormatInfoArray('$LocaleInfo', $infoArray);
+        $infoString = self::formatInfoArray('$LocaleInfo', $infoArray);
         fwrite($fp, $infoString);
     }
 
-    public function CreateZip() {
+    public function createZip() {
         if (!class_exists('ZipArchive')) {
             throw new Exception('Your server does not support zipping files.', 400);
         }
 
-        $info = $this->GetInfoArray();
-        $this->EnsureDefinitionFile();
+        $info = $this->getInfoArray();
+        $this->ensureDefinitionFile();
 
         // Get the basename of the locale.
         $key = key($info);
 
         $zipPath = PATH_UPLOADS."/$key.zip";
-        $tmpPath = PATH_UPLOADS."/tmp_".RandomString(10);
+        $tmpPath = PATH_UPLOADS."/tmp_".randomString(10);
 
         $zip = new ZipArchive();
         $zip->open($tmpPath, ZIPARCHIVE::CREATE);
 
         // Add all of the files in the locale to the zip.
-        $files = SafeGlob(rtrim($this->LocalePath, '/').'/*.*', ['php', 'txt']);
+        $files = safeGlob(rtrim($this->LocalePath, '/').'/*.*', ['php', 'txt']);
         foreach ($files as $file) {
             $localPath = $key.'/'.basename($file);
             $zip->addFile($file, $localPath);

--- a/plugins/LocaleDeveloper/views/googletranslate.php
+++ b/plugins/LocaleDeveloper/views/googletranslate.php
@@ -10,7 +10,7 @@ function googleTranslateElementInit() {
 </script><script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <?php
 
-$Definitions = (array)$this->Data('Definitions', []);
+$Definitions = (array)$this->data('Definitions', []);
 
 foreach ($Definitions as $Code => $Translation) {
    echo '<div class="Definition" Code="'.urlencode($Code).'">',

--- a/plugins/LocaleDeveloper/views/localedeveloper.php
+++ b/plugins/LocaleDeveloper/views/localedeveloper.php
@@ -1,71 +1,71 @@
 <?php if (!defined('APPLICATION')) exit();
 
-echo '<h1>', $this->Data('Title'), '</h1>';
+echo '<h1>', $this->data('Title'), '</h1>';
 
-$Form = $this->Form; //new Gdn_Form();
-echo $Form->Open();
-echo $Form->Errors();
+$Form = $this->Form; //new gdn_Form();
+echo $Form->open();
+echo $Form->errors();
 ?>
 <div class="Info">
-   <?php echo sprintf(T('This plugin helps locale package development.', 'This plugin helps locale package development. The plugin keeps a working locale pack at <code>%s</code>.'),
-      $this->Data('LocalePath'));
+   <?php echo sprintf(t('This plugin helps locale package development.', 'This plugin helps locale package development. The plugin keeps a working locale pack at <code>%s</code>.'),
+      $this->data('LocalePath'));
       echo ' ';
-      echo sprintf(T('For more help on localization check out the page <a href="%s">here</a>.'), 'http://vanillaforums.org/page/localization');
+      echo sprintf(t('For more help on localization check out the page <a href="%s">here</a>.'), 'http://vanillaforums.org/page/localization');
    ?>
 </div>
-<h3><?php echo T('Settings'); ?></h3>
+<h3><?php echo t('Settings'); ?></h3>
 <ul>
    <li>
-      <?php echo sprintf(T('Locale info file settings.', '<p>When you generate the zip file you can set the information for the locale below.</p> <p>You can download a zip of the locale pack by clicking <a href="%s">here</a>.</p>'), Url("/settings/localedeveloper/download")); ?>
+      <?php echo sprintf(t('Locale info file settings.', '<p>When you generate the zip file you can set the information for the locale below.</p> <p>You can download a zip of the locale pack by clicking <a href="%s">here</a>.</p>'), url("/settings/localedeveloper/download")); ?>
    </li>
    <li>
       <?php
-      echo $this->Form->Label('Locale Key (Folder)', 'Key'),
-         $this->Form->TextBox('Key');
+      echo $this->Form->label('Locale Key (Folder)', 'Key'),
+         $this->Form->textBox('Key');
       ?>
    </li>
    <li>
       <?php
-      echo $this->Form->Label('Locale Name', 'Name'),
-         $this->Form->TextBox('Name');
+      echo $this->Form->label('Locale Name', 'Name'),
+         $this->Form->textBox('Name');
       ?>
    </li>
    <li>
       <?php
-      echo $this->Form->Label('_Locale', 'Locale'),
-         $this->Form->TextBox('Locale', ['Class' => 'SmallInput']);
+      echo $this->Form->label('_Locale', 'Locale'),
+         $this->Form->textBox('Locale', ['Class' => 'SmallInput']);
       ?>
    </li>
    <li>
       <?php
-      echo $this->Form->CheckBox('CaptureDefinitions', 'Capture definitions throughout the site. You must visit the pages in the site in order for the definitions to be captured. The captured definitions will be put in the <code>captured.php</code> and <code>captured_admin.php</code>.');
+      echo $this->Form->checkBox('CaptureDefinitions', 'Capture definitions throughout the site. You must visit the pages in the site in order for the definitions to be captured. The captured definitions will be put in the <code>captured.php</code> and <code>captured_admin.php</code>.');
       ?>
    </li>
 </ul>
-<?php echo $Form->Button('Save'); ?>
-<h3><?php echo T('Tools'); ?></h3>
+<?php echo $Form->button('Save'); ?>
+<h3><?php echo t('Tools'); ?></h3>
 <ul>
    <li>
       <?php
-         echo T('Copy locale pack.', 'Copy the definitions from a locale pack to the Locale Developer. The definitions will be put in the <code>copied.php</code> file.');
-         echo $Form->Label('Choose a locale pack', 'LocalePackForCopy');
-         echo $Form->DropDown('LocalePackForCopy', $this->Data('LocalePacks'));
-         echo $Form->Button('Copy');
+         echo t('Copy locale pack.', 'Copy the definitions from a locale pack to the Locale Developer. The definitions will be put in the <code>copied.php</code> file.');
+         echo $Form->label('Choose a locale pack', 'LocalePackForCopy');
+         echo $Form->dropDown('LocalePackForCopy', $this->data('LocalePacks'));
+         echo $Form->button('Copy');
       ?>
    </li>
    <li>
       <?php
-         echo T('Capture locale pack changes.', 'Capture the changes between one of your locale packs and the Locale Developer. It will be put in the <code>changes.php</code> file.');
-         echo $Form->Label('Choose a locale pack', 'LocalePackForChanges');
-         echo $Form->DropDown('LocalePackForChanges', $this->Data('LocalePacks'));
-         echo $Form->Button('Generate', ['Name' => 'Form/GenerateChanges']);
+         echo t('Capture locale pack changes.', 'Capture the changes between one of your locale packs and the Locale Developer. It will be put in the <code>changes.php</code> file.');
+         echo $Form->label('Choose a locale pack', 'LocalePackForChanges');
+         echo $Form->dropDown('LocalePackForChanges', $this->data('LocalePacks'));
+         echo $Form->button('Generate', ['Name' => 'Form/GenerateChanges']);
       ?>
    </li>
    <li>
       <?php
-         echo '<div>', T('Remove locale developer files.', 'Remove the locale deveoper files and reset your changes.'), '</div>';
-         echo $Form->Button('Remove');
+         echo '<div>', t('Remove locale developer files.', 'Remove the locale deveoper files and reset your changes.'), '</div>';
+         echo $Form->button('Remove');
       ?>
    </li>
 </ul>
-<?php echo $Form->Close(); ?>
+<?php echo $Form->close(); ?>

--- a/plugins/MathJax/class.mathjax.plugin.php
+++ b/plugins/MathJax/class.mathjax.plugin.php
@@ -27,7 +27,7 @@ class MathJaxPlugin extends Gdn_Plugin {
      *
      * @param DiscussionController $sender
      */
-    public function DiscussionController_Render_Before($sender) {
+    public function discussionController_render_before($sender) {
 
         // Add basic MathJax configuration
         $mathJaxConfig = <<<MATHJAX

--- a/plugins/MessageLink/class.messagelink.plugin.php
+++ b/plugins/MessageLink/class.messagelink.plugin.php
@@ -4,16 +4,16 @@ class MessageLinkPlugin extends Gdn_Plugin {
    /**
     * Add 'Send Message' option to Discussion.
     */
-   public function Base_AfterFlag_Handler($sender, $args) {
-      if (CheckPermission('Conversations.Conversations.Add'))
-         $this->AddSendMessageButton($sender, $args);
+   public function base_afterFlag_handler($sender, $args) {
+      if (checkPermission('Conversations.Conversations.Add'))
+         $this->addSendMessageButton($sender, $args);
    }
 
    /**
     * Output Send Message link.
     */
-   protected function AddSendMessageButton($sender, $args) {
-      if (!Gdn::Session()->UserID) return;
+   protected function addSendMessageButton($sender, $args) {
+      if (!Gdn::session()->UserID) return;
       if (isset($args['Comment'])) {
          $object = $args['Comment'];
          $objectID = 'Comment_'.$args['Comment']->CommentID;
@@ -22,6 +22,6 @@ class MessageLinkPlugin extends Gdn_Plugin {
          $objectID = 'Discussion_'.$args['Discussion']->DiscussionID;
       } else return;
 
-      echo Anchor(Sprite('ReactMessage', 'ReactSprite').T('Send Message'), Url("/messages/add/{$object->InsertName}",TRUE), 'ReactButton Visible SendMessage').' ';
+      echo anchor(sprite('ReactMessage', 'ReactSprite').t('Send Message'), url("/messages/add/{$object->InsertName}",TRUE), 'ReactButton Visible SendMessage').' ';
    }
 }

--- a/plugins/Minify/class.minify.plugin.php
+++ b/plugins/Minify/class.minify.plugin.php
@@ -18,12 +18,12 @@ class MinifyPlugin extends Gdn_Plugin {
     *
     * @param HeadModule $head
     */
-   public function HeadModule_BeforeToString_Handler($head) {
+   public function headModule_beforeToString_handler($head) {
       // Set BasePath for the plugin
-      $this->BasePath = Gdn::Request()->WebRoot();
+      $this->BasePath = Gdn::request()->webRoot();
       
       // Get current tags
-      $tags = $head->Tags();
+      $tags = $head->tags();
 
       // Grab all of the CSS
       $cssToCache = [];
@@ -39,15 +39,15 @@ class MinifyPlugin extends Gdn_Plugin {
       
       // Process all tags, finding JS & CSS files
       foreach ($tags as $index => $tag) {
-         $isJs = GetValue(HeadModule::TAG_KEY, $tag) == 'script';
-         $isCss = (GetValue(HeadModule::TAG_KEY, $tag) == 'link' && GetValue('rel', $tag) == 'stylesheet');
+         $isJs = getValue(HeadModule::TAG_KEY, $tag) == 'script';
+         $isCss = (getValue(HeadModule::TAG_KEY, $tag) == 'link' && getValue('rel', $tag) == 'stylesheet');
          if (!$isJs && !$isCss)
             continue;
 
          if ($isCss)
-            $href = GetValue('href', $tag, '!');
+            $href = getValue('href', $tag, '!');
          else
-            $href = GetValue('src', $tag, '!');
+            $href = getValue('src', $tag, '!');
          
          // Skip the rest if path doesn't start with a slash
          if ($href[0] != '/')
@@ -87,25 +87,25 @@ class MinifyPlugin extends Gdn_Plugin {
       $url = 'plugins/Minify/min/?' . ($this->BasePath != '' ? "b={$this->BasePath}&" : '');
       
       // Update HeadModule's $Tags
-      $head->Tags($tags);
+      $head->tags($tags);
       
       // Add minified CSS to HeadModule.
       $token = $this->_PrepareToken($cssToCache, ".css");
       if (file_exists(PATH_CACHE."/Minify/minify_$token")) {
-         $head->AddCss("/cache/Minify/minify_$token", 'screen', FALSE);
+         $head->addCss("/cache/Minify/minify_$token", 'screen', FALSE);
       } else {
-         $head->AddCss($url.'token='.urlencode($token), 'screen', FALSE);
+         $head->addCss($url.'token='.urlencode($token), 'screen', FALSE);
       }
       
       // Add global minified JS separately (and first)
-      $head->AddScript($url . 'g=globaljs', 'text/javascript', -100);
+      $head->addScript($url . 'g=globaljs', 'text/javascript', -100);
       
       // Add other minified JS to HeadModule.
       $token = $this->_PrepareToken($jsToCache, '.js');
       if (file_exists(PATH_CACHE."/Minify/minify_$token")) {
-         $head->AddScript("/cache/Minify/minify_$token", 'text/javascript', NULL, FALSE);
+         $head->addScript("/cache/Minify/minify_$token", 'text/javascript', NULL, FALSE);
       } else {
-         $head->AddScript($url . 'token=' . $token, 'text/javascript', NULL, FALSE);
+         $head->addScript($url . 'token=' . $token, 'text/javascript', NULL, FALSE);
       }
    }
    
@@ -137,7 +137,7 @@ class MinifyPlugin extends Gdn_Plugin {
    /**
     * Create 'Minify' cache folder.
     */
-   public function Setup() {
+   public function setup() {
       $folder = PATH_CACHE.'/Minify';
       if (!file_exists($folder))
          @mkdir($folder);
@@ -146,16 +146,16 @@ class MinifyPlugin extends Gdn_Plugin {
    /**
     * Empty cache when disabling this plugin.
     */ 
-   public function OnDisable() { $this->_EmptyCache(); }
+   public function onDisable() { $this->_EmptyCache(); }
    
    /** 
     * Empty cache when enabling or disabling any other plugin, application, or theme.
     */
-   public function SettingsController_AfterEnablePlugin_Handler() { $this->_EmptyCache(); }
-   public function SettingsController_AfterDisablePlugin_Handler() { $this->_EmptyCache(); }
-   public function SettingsController_AfterEnableApplication_Handler() { $this->_EmptyCache(); }
-   public function SettingsController_AfterDisableApplication_Handler() { $this->_EmptyCache(); }
-   public function SettingsController_AfterEnableTheme_Handler() { $this->_EmptyCache(); }
+   public function settingsController_afterEnablePlugin_handler() { $this->_EmptyCache(); }
+   public function settingsController_afterDisablePlugin_handler() { $this->_EmptyCache(); }
+   public function settingsController_afterEnableApplication_handler() { $this->_EmptyCache(); }
+   public function settingsController_afterDisableApplication_handler() { $this->_EmptyCache(); }
+   public function settingsController_afterEnableTheme_handler() { $this->_EmptyCache(); }
    
    /**
     * Empty Minify's cache.

--- a/plugins/Minify/min/groupsConfig.php
+++ b/plugins/Minify/min/groupsConfig.php
@@ -39,7 +39,7 @@ return [
     /*'js2' => array(
         dirname(__FILE__) . '/../min_unit_tests/_test_files/js/before.js',
         // do NOT process this file
-        new Minify_Source(array(
+        new minify_Source(array(
             'filepath' => dirname(__FILE__) . '/../min_unit_tests/_test_files/js/before.js',
             'minifier' => create_function('$a', 'return $a;')
         ))
@@ -48,7 +48,7 @@ return [
     /*'js3' => array(
         dirname(__FILE__) . '/../min_unit_tests/_test_files/js/before.js',
         // do NOT process this file
-        new Minify_Source(array(
+        new minify_Source(array(
             'filepath' => dirname(__FILE__) . '/../min_unit_tests/_test_files/js/before.js',
             'minifier' => array('Minify_Packer', 'minify')
         ))

--- a/plugins/Minify/min/lib/FirePHP.php
+++ b/plugins/Minify/min/lib/FirePHP.php
@@ -1125,7 +1125,7 @@ class FirePHP {
   * encodes an arbitrary variable into JSON format
   *
   * @param    mixed   $var    any number, boolean, string, array, or object to be encoded.
-  *                           see argument 1 to Services_JSON() above for array-parsing behavior.
+  *                           see argument 1 to services_JSON() above for array-parsing behavior.
   *                           if var is a strng, note that encode() always expects it
   *                           to be in ASCII or UTF-8 format!
   *

--- a/plugins/Minify/min/lib/HTTP/ConditionalGet.php
+++ b/plugins/Minify/min/lib/HTTP/ConditionalGet.php
@@ -11,7 +11,7 @@
  * E.g. Content from DB with update time:
  * <code>
  * list($updateTime, $content) = getDbUpdateAndContent();
- * $cg = new HTTP_ConditionalGet(array(
+ * $cg = new hTTP_ConditionalGet(array(
  *     'lastModifiedTime' => $updateTime
  *     ,'isPublic' => true
  * ));
@@ -31,7 +31,7 @@
  * E.g. Content from DB with no update time:
  * <code>
  * $content = getContentFromDB();
- * $cg = new HTTP_ConditionalGet(array(
+ * $cg = new hTTP_ConditionalGet(array(
  *     'contentHash' => md5($content)
  * ));
  * $cg->sendHeaders();
@@ -44,7 +44,7 @@
  * E.g. Static content with some static includes:
  * <code>
  * // before content
- * $cg = new HTTP_ConditionalGet(array(
+ * $cg = new hTTP_ConditionalGet(array(
  *     'lastUpdateTime' => max(
  *         filemtime(__FILE__)
  *         ,filemtime('/path/to/header.inc')

--- a/plugins/Minify/min/lib/HTTP/Encoder.php
+++ b/plugins/Minify/min/lib/HTTP/Encoder.php
@@ -13,7 +13,7 @@
  *
  * <code>
  * // Send a CSS file, compressed if possible
- * $he = new HTTP_Encoder(array(
+ * $he = new hTTP_Encoder(array(
  *     'content' => file_get_contents($cssFile)
  *     ,'type' => 'text/css'
  * ));

--- a/plugins/Minify/min/lib/Minify/Build.php
+++ b/plugins/Minify/min/lib/Minify/Build.php
@@ -18,8 +18,8 @@ require_once 'Minify/Source.php';
  * )
  * 
  * // during HTML generation
- * $jsBuild = new Minify_Build($groupSources['js']);
- * $cssBuild = new Minify_Build($groupSources['css']);
+ * $jsBuild = new minify_Build($groupSources['js']);
+ * $cssBuild = new minify_Build($groupSources['css']);
  * 
  * $script = "<script type='text/javascript' src='"
  *     . $jsBuild->uri('/min.php/js') . "'></script>";

--- a/plugins/Minify/min/lib/Minify/Cache/APC.php
+++ b/plugins/Minify/min/lib/Minify/Cache/APC.php
@@ -8,7 +8,7 @@
  * APC-based cache class for Minify
  * 
  * <code>
- * Minify::setCache(new Minify_Cache_APC());
+ * Minify::setCache(new minify_Cache_APC());
  * </code>
  * 
  * @package Minify

--- a/plugins/Minify/min/lib/Minify/Cache/Memcache.php
+++ b/plugins/Minify/min/lib/Minify/Cache/Memcache.php
@@ -11,7 +11,7 @@
  * // fall back to disk caching if memcache can't connect
  * $memcache = new Memcache;
  * if ($memcache->connect('localhost', 11211)) {
- *     Minify::setCache(new Minify_Cache_Memcache($memcache));
+ *     Minify::setCache(new minify_Cache_Memcache($memcache));
  * } else {
  *     Minify::setCache();
  * }

--- a/plugins/Minify/min/utils.php
+++ b/plugins/Minify/min/utils.php
@@ -14,8 +14,8 @@ require_once 'Minify/Build.php';
  * Get a timestamped URI to a minified resource using the default Minify install
  *
  * <code>
- * <link rel="stylesheet" type="text/css" href="<?php echo Minify_groupUri('css'); ?>" />
- * <script type="text/javascript" src="<?php echo Minify_groupUri('js'); ?>"></script>
+ * <link rel="stylesheet" type="text/css" href="<?php echo minify_groupUri('css'); ?>" />
+ * <script type="text/javascript" src="<?php echo minify_groupUri('js'); ?>"></script>
  * </code>
  *
  * If you do not want ampersands as HTML entities, set Minify_Build::$ampersand = "&" 
@@ -27,7 +27,7 @@ require_once 'Minify/Build.php';
  * more cacheable by proxies.
  * @return string
  */ 
-function Minify_groupUri($group, $forceAmpersand = false)
+function minify_groupUri($group, $forceAmpersand = false)
 {
     $path = $forceAmpersand
         ? "/g={$group}"
@@ -43,15 +43,15 @@ function Minify_groupUri($group, $forceAmpersand = false)
  * Get the last modification time of the source js/css files used by Minify to
  * build the page.
  * 
- * If you're caching the output of Minify_groupUri(), you'll want to rebuild 
+ * If you're caching the output of minify_groupUri(), you'll want to rebuild 
  * the cache if it's older than this timestamp.
  * 
  * <code>
  * // simplistic HTML cache system
  * $file = '/path/to/cache/file';
- * if (! file_exists($file) || filemtime($file) < Minify_groupsMtime(array('js', 'css'))) {
+ * if (! file_exists($file) || filemtime($file) < minify_groupsMtime(array('js', 'css'))) {
  *     // (re)build cache
- *     $page = buildPage(); // this calls Minify_groupUri() for js and css
+ *     $page = buildPage(); // this calls minify_groupUri() for js and css
  *     file_put_contents($file, $page);
  *     echo $page;
  *     exit();
@@ -62,7 +62,7 @@ function Minify_groupUri($group, $forceAmpersand = false)
  * @param array $groups an array of keys from groupsConfig.php
  * @return int Unix timestamp of the latest modification
  */ 
-function Minify_groupsMtime($groups)
+function minify_groupsMtime($groups)
 {
     $max = 0;
     foreach ((array)$groups as $group) {

--- a/plugins/Mollom/class.mollom.php
+++ b/plugins/Mollom/class.mollom.php
@@ -676,7 +676,7 @@ abstract class Mollom {
     * Used to parse an XML response from Mollom servers into a PHP array. For
     * example:
     * @code
-    * $elements = new SimpleXmlIterator($response_body);
+    * $elements = new simpleXmlIterator($response_body);
     * $parsed_response = $this->parseXML($elements);
     * @endcode
     *

--- a/plugins/Mollom/class.mollomvanilla.php
+++ b/plugins/Mollom/class.mollomvanilla.php
@@ -8,19 +8,19 @@
 class MollomVanilla extends Mollom {
 
    public function loadConfiguration($name) {
-      return C('Plugins.Mollom.'.$name, NULL);
+      return c('Plugins.Mollom.'.$name, NULL);
    }
 
    public function saveConfiguration($name, $value) {
-      SaveToConfig('Plugins.Mollom.'.$name, $value);
+      saveToConfig('Plugins.Mollom.'.$name, $value);
    }
 
    public function deleteConfiguration($name) {
-      RemoveFromConfig('Plugins.Mollom.'.$name);
+      removeFromConfig('Plugins.Mollom.'.$name);
    }
 
    public function getClientInformation() {
-      $pluginInfo = Gdn::PluginManager()->AvailablePlugins();
+      $pluginInfo = Gdn::pluginManager()->availablePlugins();
       return [
          'platformName' => 'Vanilla',
          'platformVersion' => APPLICATION_VERSION,
@@ -31,7 +31,7 @@ class MollomVanilla extends Mollom {
 
    protected function request($method, $server, $path, $query = NULL, array $headers = []) {
       $request = new ProxyRequest();
-      $request->Request(
+      $request->request(
          ['Method' => $method,
             'URL' => trim($server,'/').trim($path,'/'),
             //'Debug' => TRUE

--- a/plugins/Multilingual/modules/class.localechoosermodule.php
+++ b/plugins/Multilingual/modules/class.localechoosermodule.php
@@ -17,9 +17,9 @@ class LocaleChooserModule extends Gdn_Module {
      * Build footer link to change locale.
      */
     public function buildLocaleLink($name, $urlCode) {
-        $url = 'profile/setlocale/'.$urlCode.'/'.Gdn::Session()->TransientKey();
+        $url = 'profile/setlocale/'.$urlCode.'/'.Gdn::session()->transientKey();
 
-        return Wrap(Anchor($name, $url), 'span', ['class' => 'LocaleOption '.$name.'Locale']);
+        return wrap(anchor($name, $url), 'span', ['class' => 'LocaleOption '.$name.'Locale']);
     }
 
     /**
@@ -32,7 +32,7 @@ class LocaleChooserModule extends Gdn_Module {
 
         $links = '';
         foreach ($locales as $code => $name) {
-            $links .= $this->BuildLocaleLink($name, $code);
+            $links .= $this->buildLocaleLink($name, $code);
         }
 
         return $links;
@@ -45,8 +45,8 @@ class LocaleChooserModule extends Gdn_Module {
      */
     public function toString() {
         if (!$this->Links)
-            $this->Links = $this->BuildLocales();
+            $this->Links = $this->buildLocales();
 
-        echo Wrap($this->Links, 'div', ['class' => 'LocaleOptions']);
+        echo wrap($this->Links, 'div', ['class' => 'LocaleOptions']);
     }
 }

--- a/plugins/NBBC/class.nbbc.plugin.php
+++ b/plugins/NBBC/class.nbbc.plugin.php
@@ -8,7 +8,7 @@
   Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
  */
 
-Gdn::FactoryInstall('BBCodeFormatter', 'NBBCPlugin', __FILE__, Gdn::FactorySingleton);
+Gdn::factoryInstall('BBCodeFormatter', 'NBBCPlugin', __FILE__, Gdn::FactorySingleton);
 
 class NBBCPlugin extends Gdn_Plugin {
 
@@ -23,36 +23,36 @@ class NBBCPlugin extends Gdn_Plugin {
    /// PROPERTIES ///
    /// METHODS ///
 
-   public function DoAttachment($bbcode, $action, $name, $default, $params, $content) {
-      $Medias = $this->Media();
+   public function doAttachment($bbcode, $action, $name, $default, $params, $content) {
+      $Medias = $this->media();
       $MediaID = $content;
       if (isset($Medias[$MediaID])) {
          $Media = $Medias[$MediaID];
 //         decho($Media, 'Media');
 
-         $Src = htmlspecialchars(Gdn_Upload::Url(GetValue('Path', $Media)));
-         $Name = htmlspecialchars(GetValue('Name', $Media));
+         $Src = htmlspecialchars(Gdn_Upload::url(getValue('Path', $Media)));
+         $Name = htmlspecialchars(getValue('Name', $Media));
 
-         if (GetValue('ImageWidth', $Media)) {
+         if (getValue('ImageWidth', $Media)) {
             return <<<EOT
 <div class="Attachment Image"><img src="$Src" alt="$Name" /></div>
 EOT;
          } else {
-            return Anchor($Name, $Src, 'Attachment File');
+            return anchor($Name, $Src, 'Attachment File');
          }
       }
 
-      return Anchor(T('Attachment not found.'), '#', 'Attachment NotFound');
+      return anchor(t('Attachment not found.'), '#', 'Attachment NotFound');
    }
 
-   function DoImage($bbcode, $action, $name, $default, $params, $content) {
+   function doImage($bbcode, $action, $name, $default, $params, $content) {
       if ($action == BBCODE_CHECK)
          return true;
-      $content = trim($bbcode->UnHTMLEncode(strip_tags($content)));
+      $content = trim($bbcode->unHTMLEncode(strip_tags($content)));
       if (!$content && $default)
          $content = $default;
 
-      if ($bbcode->IsValidUrl($content, false))
+      if ($bbcode->isValidUrl($content, false))
          return "<img src=\"" . htmlspecialchars($content) . "\" alt=\""
             . htmlspecialchars(basename($content)) . "\" class=\"bbcode_img\" />";
 
@@ -69,7 +69,7 @@ EOT;
 //                  . htmlspecialchars($info[1]) . "\" class=\"bbcode_img\" />";
 //               }
 //            }
-//         } else if ($bbcode->IsValidURL($content, false)) {
+//         } else if ($bbcode->isValidURL($content, false)) {
 //            return "<img src=\"" . htmlspecialchars($content) . "\" alt=\""
 //            . htmlspecialchars(basename($content)) . "\" class=\"bbcode_img\" />";
 //         }
@@ -77,8 +77,8 @@ EOT;
       return htmlspecialchars($params['_tag']) . htmlspecialchars($content) . htmlspecialchars($params['_endtag']);
    }
 
-   function DoVideo($bbcode, $action, $name, $default, $params, $content) {
-      list($width, $height) = Gdn_Format::GetEmbedSize();
+   function doVideo($bbcode, $action, $name, $default, $params, $content) {
+      list($width, $height) = Gdn_Format::getEmbedSize();
       list($type, $code) = explode(';', $default);
       switch ($type) {
          case 'youtube':
@@ -88,15 +88,15 @@ EOT;
       }
    }
 
-   function DoYoutube($bbcode, $action, $name, $default, $params, $content) {
+   function doYoutube($bbcode, $action, $name, $default, $params, $content) {
        if ($action == BBCODE_CHECK) return true;
 
-       $videoId = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
+       $videoId = is_string($default) ? $default : $bbcode->unHTMLEncode(strip_tags($content));
 
        return '<div class="Video P"><iframe width="560" height="315" src="https://www.youtube.com/embed/' . $videoId . '" frameborder="0" allowfullscreen></iframe></div>';
    }
 
-   function DoQuote($bbcode, $action, $name, $default, $params, $content) {
+   function doQuote($bbcode, $action, $name, $default, $params, $content) {
       if ($action == BBCODE_CHECK)
          return true;
 
@@ -117,17 +117,17 @@ EOT;
          $username = trim($params['name']);
          $username = html_entity_decode($username, ENT_QUOTES, 'UTF-8');
 
-         $User = Gdn::UserModel()->GetByUsername($username);
+         $User = Gdn::userModel()->getByUsername($username);
          if ($User)
-            $UserAnchor = UserAnchor($User);
+            $UserAnchor = userAnchor($User);
          else
-            $UserAnchor = Anchor(htmlspecialchars($username, NULL, 'UTF-8'), '/profile/' . rawurlencode($username));
+            $UserAnchor = anchor(htmlspecialchars($username, NULL, 'UTF-8'), '/profile/' . rawurlencode($username));
 
-         $title = ConcatSep(' ', $title, $UserAnchor, T('Quote wrote', 'wrote'));
+         $title = concatSep(' ', $title, $UserAnchor, t('Quote wrote', 'wrote'));
       }
 
       if (isset($params['date']))
-         $title = ConcatSep(' ', $title, T('Quote on', 'on'), htmlspecialchars(trim($params['date'])));
+         $title = concatSep(' ', $title, t('Quote on', 'on'), htmlspecialchars(trim($params['date'])));
 
       if ($title)
          $title = $title . ':';
@@ -137,11 +137,11 @@ EOT;
 
          if (is_numeric($url))
             $url = "/discussion/comment/$url#Comment_{$url}";
-         elseif (!$bbcode->IsValidURL($url))
+         elseif (!$bbcode->isValidURL($url))
             $url = '';
 
          if ($url)
-            $title = ConcatSep(' ', $title, Anchor('<span class="ArrowLink">»</span>', $url, ['class' => 'QuoteLink']));
+            $title = concatSep(' ', $title, anchor('<span class="ArrowLink">»</span>', $url, ['class' => 'QuoteLink']));
       }
 
       if ($title)
@@ -199,12 +199,12 @@ EOT;
        return "<span style=\"font-size:$size\">$content</span>";
    }
 
-   function DoURL($bbcode, $action, $name, $default, $params, $content) {
+   function doURL($bbcode, $action, $name, $default, $params, $content) {
       if ($action == BBCODE_CHECK) return true;
 
-      $url = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
+      $url = is_string($default) ? $default : $bbcode->unHTMLEncode(strip_tags($content));
 
-      if ($bbcode->IsValidURL($url)) {
+      if ($bbcode->isValidURL($url)) {
          if ($bbcode->debug)
             print "ISVALIDURL<br />";
          if ($bbcode->url_targetable !== false && isset($params['target']))
@@ -220,18 +220,18 @@ EOT;
          return htmlspecialchars($params['_tag']) . $content . htmlspecialchars($params['_endtag']);
    }
 
-   public function Format($result) {
+   public function format($result) {
       $result = str_replace(['[CODE]', '[/CODE]'], ['[code]', '[/code]'], $result);
-      $result = $this->NBBC()->Parse($result);
+      $result = $this->nBBC()->parse($result);
       return $result;
    }
 
    protected $_Media = NULL;
-   public function Media() {
+   public function media() {
       if ($this->_Media === NULL) {
          try {
-            $i = Gdn::PluginManager()->GetPluginInstance('FileUploadPlugin', Gdn_PluginManager::ACCESS_CLASSNAME);
-            $m = $i->MediaCache();
+            $i = Gdn::pluginManager()->getPluginInstance('FileUploadPlugin', Gdn_PluginManager::ACCESS_CLASSNAME);
+            $m = $i->mediaCache();
          } catch (Exception $ex) {
             $m = [];
          }
@@ -252,14 +252,14 @@ EOT;
     *
     * @return BBCode
     */
-   public function NBBC() {
+   public function nBBC() {
       if ($this->_NBBC === NULL) {
          require_once(dirname(__FILE__) . '/nbbc/nbbc.php');
-         $BBCode = new $this->Class();
+         $BBCode = new $this->class();
          $BBCode->enable_smileys = false;
-         $BBCode->SetAllowAmpersand(TRUE);
+         $BBCode->setAllowAmpersand(TRUE);
 
-         $BBCode->AddRule('attach', [
+         $BBCode->addRule('attach', [
             'mode' => BBCODE_MODE_CALLBACK,
             'method' => [$this, "DoAttachment"],
             'class' => 'image',
@@ -270,7 +270,7 @@ EOT;
             'plain_content' => [],
             ]);
 
-         $BBCode->AddRule('code', [
+         $BBCode->addRule('code', [
              'mode' => BBCODE_MODE_ENHANCED,
              'template' => "\n<pre>{\$_content/v}\n</pre>\n",
              'class' => 'code',
@@ -285,7 +285,7 @@ EOT;
          ]);
 
 
-         $BBCode->AddRule('quote', ['mode' => BBCODE_MODE_CALLBACK,
+         $BBCode->addRule('quote', ['mode' => BBCODE_MODE_CALLBACK,
              'method' => [$this, "DoQuote"],
              'allow_in' => ['listitem', 'block', 'columns'],
              'before_tag' => "sns",
@@ -296,7 +296,7 @@ EOT;
              'plain_end' => "\n",
          ]);
 //
-         $BBCode->AddRule('spoiler', [
+         $BBCode->addRule('spoiler', [
              'mode' => BBCODE_MODE_CALLBACK,
              'method' => [$this, "doSpoiler"],
              'allow_in' => ['listitem', 'block', 'columns'],
@@ -308,7 +308,7 @@ EOT;
              'plain_end' => "\n"
              ]);
 
-         $BBCode->AddRule('img', [
+         $BBCode->addRule('img', [
             'mode' => BBCODE_MODE_CALLBACK,
             'method' => [$this, "DoImage"],
             'class' => 'image',
@@ -319,9 +319,9 @@ EOT;
             'plain_content' => [],
             ]);
 
-         $BBCode->AddRule('snapback', [
+         $BBCode->addRule('snapback', [
              'mode' => BBCODE_MODE_ENHANCED,
-             'template' => ' <a href="'.Url('/discussion/comment/{$_content/v}#Comment_{$_content/v}', TRUE).'" class="SnapBack">»</a> ',
+             'template' => ' <a href="'.url('/discussion/comment/{$_content/v}#Comment_{$_content/v}', TRUE).'" class="SnapBack">»</a> ',
              'class' => 'code',
              'allow_in' => ['listitem', 'block', 'columns'],
              'content' => BBCODE_VERBATIM,
@@ -333,7 +333,7 @@ EOT;
              'plain_end' => "\n",
          ]);
 
-         $BBCode->AddRule('video', ['mode' => BBCODE_MODE_CALLBACK,
+         $BBCode->addRule('video', ['mode' => BBCODE_MODE_CALLBACK,
              'method' => [$this, "DoVideo"],
              'allow_in' => ['listitem', 'block', 'columns'],
              'before_tag' => "sns",
@@ -344,7 +344,7 @@ EOT;
              'plain_end' => "\n",
          ]);
 
-          $BBCode->AddRule('youtube', [
+          $BBCode->addRule('youtube', [
               'mode' => BBCODE_MODE_CALLBACK,
               'method' => [$this, 'DoYouTube'],
               'class' => 'link',
@@ -356,7 +356,7 @@ EOT;
               'plain_link' => ['_default', '_content']
           ]);
 
-          $BBCode->AddRule('hr', [
+          $BBCode->addRule('hr', [
               'simple_start' => "",
               'simple_end' => "",
               'allow_in' => ['listitem', 'block', 'columns'],
@@ -368,7 +368,7 @@ EOT;
               'plain_end' => "\n"
           ]);
 
-          $BBCode->AddRule('attachment', [
+          $BBCode->addRule('attachment', [
               'mode' => BBCODE_MODE_CALLBACK,
               'method' => [$this, "RemoveAttachment"],
               'class' => 'image',
@@ -380,7 +380,7 @@ EOT;
           ]);
 
 
-          $BBCode->AddRule('url', [
+          $BBCode->addRule('url', [
              'mode' => BBCODE_MODE_CALLBACK,
              'method' => [$this, 'DoURL'],
              'class' => 'link',
@@ -405,23 +405,23 @@ EOT;
           ]);
 
           // Prevent unsupported tags from displaying
-          $BBCode->AddRule('table', []);
-          $BBCode->AddRule('tr', []);
-          $BBCode->AddRule('td', []);
+          $BBCode->addRule('table', []);
+          $BBCode->addRule('tr', []);
+          $BBCode->addRule('td', []);
 
          $this->EventArguments['BBCode'] = $BBCode;
-         $this->FireEvent('AfterNBBCSetup');
+         $this->fireEvent('AfterNBBCSetup');
          $this->_NBBC = $BBCode;
       }
       return $this->_NBBC;
    }
 
-   public function RemoveAttachment() {
+   public function removeAttachment() {
        // We dont need this since we show attachments.
        return '<!-- PhpBB Attachments -->';
    }
 
-   public function Setup() {
+   public function setup() {
 
    }
 

--- a/plugins/NBBC/nbbc/nbbc.php
+++ b/plugins/NBBC/nbbc/nbbc.php
@@ -80,7 +80,7 @@ var $pat_main;
 var $pat_comment;
 var $pat_comment2;
 var $pat_wiki;
-function BBCodeLexer($string, $tagmarker = '[') {
+function bBCodeLexer($string, $tagmarker = '[') {
 $regex_beginmarkers = [ '[' => '\[', '<' => '<', '{' => '\{', '(' => '\(' ];
 $regex_endmarkers = [ '[' => '\]', '<' => '>', '{' => '\}', '(' => '\)' ];
 $endmarkers = [ '[' => ']', '<' => '>', '{' => '}', '(' => ')' ];
@@ -114,7 +114,7 @@ $this->token = BBCODE_EOI;
 $this->tag = false;
 $this->text = "";
 }
-function GuessTextLength() {
+function guessTextLength() {
 $length = 0;
 $ptr = 0;
 $state = BBCODE_LEXSTATE_TEXT;
@@ -146,7 +146,7 @@ break;
 }
 return $length;
 }
-function NextToken() {
+function nextToken() {
 if ($this->unget) {
 $this->unget = false;
 return $this->token;
@@ -235,24 +235,24 @@ $this->tag = ['_name' => 'wiki', '_endtag' => false,
 $this->state = BBCODE_LEXSTATE_TEXT;
 return $this->token = BBCODE_TAG;
 }
-$this->tag = $this->Internal_DecodeTag($this->text);
+$this->tag = $this->internal_DecodeTag($this->text);
 $this->state = BBCODE_LEXSTATE_TEXT;
 return $this->token = ($this->tag['_end'] ? BBCODE_ENDTAG : BBCODE_TAG);
 }
 }
 }
 }
-function UngetToken() {
+function ungetToken() {
 if ($this->token !== BBCODE_EOI)
 $this->unget = true;
 }
-function PeekToken() {
-$result = $this->NextToken();
+function peekToken() {
+$result = $this->nextToken();
 if ($this->token !== BBCODE_EOI)
 $this->unget = true;
 return $result;
 }
-function SaveState() {
+function saveState() {
 return [
 'token' => $this->token,
 'text' => $this->text,
@@ -264,7 +264,7 @@ return [
 'verbatim' => $this->verbatim
 ];
 }
-function RestoreState($state) {
+function restoreState($state) {
 if (!is_array($state)) return;
 $this->token = @$state['token'];
 $this->text = @$state['text'];
@@ -275,14 +275,14 @@ $this->ptr = @$state['ptr'];
 $this->unget = @$state['unget'];
 $this->verbatim = @$state['verbatim'];
 }
-function Internal_StripQuotes($string) {
+function internal_StripQuotes($string) {
 if (preg_match("/^\\\"(.*)\\\"$/", $string, $matches))
 return $matches[1];
 else if (preg_match("/^\\'(.*)\\'$/", $string, $matches))
 return $matches[1];
 else return $string;
 }
-function Internal_ClassifyPiece($ptr, $pieces) {
+function internal_ClassifyPiece($ptr, $pieces) {
 if ($ptr >= count($pieces)) return -1;
 $piece = $pieces[$ptr];
 if ($piece == '=') return '=';
@@ -290,7 +290,7 @@ else if (preg_match("/^[\\'\\\"]/", $piece)) return '"';
 else if (preg_match("/^[\\x00-\\x20]+$/", $piece)) return ' ';
 else return 'A';
 }
-function Internal_DecodeTag($tag) {
+function internal_DecodeTag($tag) {
 $result = ['_tag' => $tag, '_endtag' => '', '_name' => '',
 '_hasend' => false, '_end' => false, '_default' => false];
 $tag = substr($tag, 1, strlen($tag)-2);
@@ -308,7 +308,7 @@ else {
 $result['_name'] = strtolower($pieces[$ptr++]);
 $result['_end'] = false;
 }
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 $ptr++;
 $params = [];
 if ($type != '=') {
@@ -317,14 +317,14 @@ $params[] = ['key' => '', 'value' => ''];
 }
 else {
 $ptr++;
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 $ptr++;
 if ($type == "\"")
-$value = $this->Internal_StripQuotes($pieces[$ptr++]);
+$value = $this->internal_StripQuotes($pieces[$ptr++]);
 else {
 $after_space = false;
 $start = $ptr;
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1) {
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) != -1) {
 if ($type == ' ') $after_space = true;
 if ($type == '=' && $after_space) break;
 $ptr++;
@@ -332,16 +332,16 @@ $ptr++;
 if ($type == -1) $ptr--;
 if ($type == '=') {
 $ptr--;
-while ($ptr > $start && $this->Internal_ClassifyPiece($ptr, $pieces) == ' ')
+while ($ptr > $start && $this->internal_ClassifyPiece($ptr, $pieces) == ' ')
 $ptr--;
-while ($ptr > $start && $this->Internal_ClassifyPiece($ptr, $pieces) != ' ')
+while ($ptr > $start && $this->internal_ClassifyPiece($ptr, $pieces) != ' ')
 $ptr--;
 }
 $value = "";
 for (; $start <= $ptr; $start++) {
-if ($this->Internal_ClassifyPiece($start, $pieces) == ' ')
+if ($this->internal_ClassifyPiece($start, $pieces) == ' ')
 $value .= " ";
-else $value .= $this->Internal_StripQuotes($pieces[$start]);
+else $value .= $this->internal_StripQuotes($pieces[$start]);
 }
 $value = trim($value);
 $ptr++;
@@ -349,32 +349,32 @@ $ptr++;
 $result['_default'] = $value;
 $params[] = ['key' => '', 'value' => $value];
 }
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1) {
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) != -1) {
 while ($type == ' ') {
 $ptr++;
-$type = $this->Internal_ClassifyPiece($ptr, $pieces);
+$type = $this->internal_ClassifyPiece($ptr, $pieces);
 }
 if ($type == 'A' || $type == '"')
-$key = strtolower($this->Internal_StripQuotes(@$pieces[$ptr++]));
+$key = strtolower($this->internal_StripQuotes(@$pieces[$ptr++]));
 else if ($type == '=') {
 $ptr++;
 continue;
 }
 else if ($type == -1) break;
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 $ptr++;
 if ($type != '=')
-$value = $this->Internal_StripQuotes($key);
+$value = $this->internal_StripQuotes($key);
 else {
 $ptr++;
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 $ptr++;
 if ($type == '"') {
-$value = $this->Internal_StripQuotes($pieces[$ptr++]);
+$value = $this->internal_StripQuotes($pieces[$ptr++]);
 }
 else if ($type != -1) {
 $value = $pieces[$ptr++];
-while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1
+while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) != -1
 && $type != ' ')
 $value .= $pieces[$ptr++];
 }
@@ -718,10 +718,10 @@ var $default_tag_rules = [
 'plain_end' => "\n",
 ],
 ];
-function DoURL($bbcode, $action, $name, $default, $params, $content) {
+function doURL($bbcode, $action, $name, $default, $params, $content) {
 if ($action == BBCODE_CHECK) return true;
-$url = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
-if ($bbcode->IsValidURL($url)) {
+$url = is_string($default) ? $default : $bbcode->unHTMLEncode(strip_tags($content));
+if ($bbcode->isValidURL($url)) {
 if ($bbcode->debug)
 print "ISVALIDURL<br />";
 if ($bbcode->url_targetable !== false && isset($params['target']))
@@ -734,14 +734,14 @@ return '<a href="' . htmlspecialchars($url) . '" class="bbcode_url"' . $target .
 }
 else return htmlspecialchars($params['_tag']) . $content . htmlspecialchars($params['_endtag']);
 }
-function DoEmail($bbcode, $action, $name, $default, $params, $content) {
+function doEmail($bbcode, $action, $name, $default, $params, $content) {
 if ($action == BBCODE_CHECK) return true;
-$email = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
-if ($bbcode->IsValidEmail($email))
+$email = is_string($default) ? $default : $bbcode->unHTMLEncode(strip_tags($content));
+if ($bbcode->isValidEmail($email))
 return '<a href="mailto:' . htmlspecialchars($email) . '" class="bbcode_email">' . $content . '</a>';
 else return htmlspecialchars($params['_tag']) . $content . htmlspecialchars($params['_endtag']);
 }
-function DoSize($bbcode, $action, $name, $default, $params, $content) {
+function doSize($bbcode, $action, $name, $default, $params, $content) {
 switch ($default) {
 case '0': $size = '.5em'; break;
 case '1': $size = '.67em'; break;
@@ -755,7 +755,7 @@ case '7': $size = '2.5em'; break;
 }
 return "<span style=\"font-size:$size\">$content</span>";
 }
-function DoFont($bbcode, $action, $name, $default, $params, $content) {
+function doFont($bbcode, $action, $name, $default, $params, $content) {
 $fonts = explode(",", $default);
 $result = "";
 $special_fonts = [
@@ -782,8 +782,8 @@ $result .= "'$font'";
 }
 return "<span style=\"font-family:$result\">$content</span>";
 }
-function DoWiki($bbcode, $action, $name, $default, $params, $content) {
-$name = $bbcode->Wikify($default);
+function doWiki($bbcode, $action, $name, $default, $params, $content) {
+$name = $bbcode->wikify($default);
 if ($action == BBCODE_CHECK)
 return strlen($name) > 0;
 $title = trim(@$params['title']);
@@ -791,9 +791,9 @@ if (strlen($title) <= 0) $title = trim($default);
 return "<a href=\"{$bbcode->wiki_url}$name\" class=\"bbcode_wiki\">"
 . htmlspecialchars($title) . "</a>";
 }
-function DoImage($bbcode, $action, $name, $default, $params, $content) {
+function doImage($bbcode, $action, $name, $default, $params, $content) {
 if ($action == BBCODE_CHECK) return true;
-$content = trim($bbcode->UnHTMLEncode(strip_tags($content)));
+$content = trim($bbcode->unHTMLEncode(strip_tags($content)));
 if (preg_match("/\\.(?:gif|jpeg|jpg|jpe|png)$/i", $content)) {
 if (preg_match("/^[a-zA-Z0-9_][^:]+$/", $content)) {
 if (!preg_match("/(?:\\/\\.\\.\\/)|(?:^\\.\\.\\/)|(?:^\\/)/", $content)) {
@@ -807,18 +807,18 @@ return "<img src=\""
 }
 }
 }
-else if ($bbcode->IsValidURL($content, false)) {
+else if ($bbcode->isValidURL($content, false)) {
 return "<img src=\"" . htmlspecialchars($content) . "\" alt=\""
 . htmlspecialchars(basename($content)) . "\" class=\"bbcode_img\" />";
 }
 }
 return htmlspecialchars($params['_tag']) . htmlspecialchars($content) . htmlspecialchars($params['_endtag']);
 }
-function DoRule($bbcode, $action, $name, $default, $params, $content) {
+function doRule($bbcode, $action, $name, $default, $params, $content) {
 if ($action == BBCODE_CHECK) return true;
 else return $bbcode->rule_html;
 }
-function DoQuote($bbcode, $action, $name, $default, $params, $content) {
+function doQuote($bbcode, $action, $name, $default, $params, $content) {
 if ($action == BBCODE_CHECK) return true;
 if (isset($params['name'])) {
 $title = htmlspecialchars(trim($params['name'])) . " wrote";
@@ -827,7 +827,7 @@ $title .= " on " . htmlspecialchars(trim($params['date']));
 $title .= ":";
 if (isset($params['url'])) {
 $url = trim($params['url']);
-if ($bbcode->IsValidURL($url))
+if ($bbcode->isValidURL($url))
 $title = "<a href=\"" . htmlspecialchars($params['url']) . "\">" . $title . "</a>";
 }
 }
@@ -838,7 +838,7 @@ return "\n<div class=\"bbcode_quote\">\n<div class=\"bbcode_quote_head\">"
 . $title . "</div>\n<div class=\"bbcode_quote_body\">"
 . $content . "</div>\n</div>\n";
 }
-function DoList($bbcode, $action, $name, $default, $params, $content) {
+function doList($bbcode, $action, $name, $default, $params, $content) {
 $list_styles = [
 '1' => 'decimal',
 '01' => 'decimal-leading-zero',
@@ -1011,18 +1011,18 @@ var $rule_html;
 var $pre_trim;
 var $post_trim;
 var $debug;
-function BBCode() {
+function bBCode() {
 $this->defaults = new BBCodeLibrary;
 $this->tag_rules = $this->defaults->default_tag_rules;
 $this->smileys = $this->defaults->default_smileys;
 $this->enable_smileys = true;
 $this->smiley_regex = false;
-$this->smiley_dir = $this->GetDefaultSmileyDir();
-$this->smiley_url = $this->GetDefaultSmileyURL();
-$this->wiki_url = $this->GetDefaultWikiURL();
-$this->local_img_dir = $this->GetDefaultLocalImgDir();
-$this->local_img_url = $this->GetDefaultLocalImgURL();
-$this->rule_html = $this->GetDefaultRuleHTML();
+$this->smiley_dir = $this->getDefaultSmileyDir();
+$this->smiley_url = $this->getDefaultSmileyURL();
+$this->wiki_url = $this->getDefaultWikiURL();
+$this->local_img_dir = $this->getDefaultLocalImgDir();
+$this->local_img_url = $this->getDefaultLocalImgURL();
+$this->rule_html = $this->getDefaultRuleHTML();
 $this->pre_trim = "";
 $this->post_trim = "";
 $this->root_class = 'block';
@@ -1043,87 +1043,87 @@ $this->url_pattern = '<a href="{$url/h}">{$text/h}</a>';
 $this->url_targetable = false;
 $this->url_target = false;
 }
-function SetPreTrim($trim = "a") { $this->pre_trim = $trim; }
-function GetPreTrim() { return $this->pre_trim; }
-function SetPostTrim($trim = "a") { $this->post_trim = $trim; }
-function GetPostTrim() { return $this->post_trim; }
-function SetRoot($class = 'block') { $this->root_class = $class; }
-function SetRootInline() { $this->root_class = 'inline'; }
-function SetRootBlock() { $this->root_class = 'block'; }
-function GetRoot() { return $this->root_class; }
-function SetDebug($enable = true) { $this->debug = $enable; }
-function GetDebug() { return $this->debug; }
-function SetAllowAmpersand($enable = true) { $this->allow_ampersand = $enable; }
-function GetAllowAmpersand() { return $this->allow_ampersand; }
-function SetTagMarker($marker = '[') { $this->tag_marker = $marker; }
-function GetTagMarker() { return $this->tag_marker; }
-function SetIgnoreNewlines($ignore = true) { $this->ignore_newlines = $ignore; }
-function GetIgnoreNewlines() { return $this->ignore_newlines; }
-function SetLimit($limit = 0) { $this->output_limit = $limit; }
-function GetLimit() { return $this->output_limit; }
-function SetLimitTail($tail = "...") { $this->limit_tail = $tail; }
-function GetLimitTail() { return $this->limit_tail; }
-function SetLimitPrecision($prec = 0.15) { $this->limit_precision = $prec; }
-function GetLimitPrecision() { return $this->limit_precision; }
-function WasLimited() { return $this->was_limited; }
-function SetPlainMode($enable = true) { $this->plain_mode = $enable; }
-function GetPlainMode() { return $this->plain_mode; }
-function SetDetectURLs($enable = true) { $this->detect_urls = $enable; }
-function GetDetectURLs() { return $this->detect_urls; }
-function SetURLPattern($pattern) { $this->url_pattern = $pattern; }
-function GetURLPattern() { return $this->url_pattern; }
-function SetURLTargetable($enable) { $this->url_targetable = $enable; }
-function GetURLTargetable() { return $this->url_targetable; }
-function SetURLTarget($target) { $this->url_target = $target; }
-function GetURLTarget() { return $this->url_target; }
-function AddRule($name, $rule) { $this->tag_rules[$name] = $rule; }
-function RemoveRule($name) { unset($this->tag_rules[$name]); }
-function GetRule($name) { return isset($this->tag_rules[$name])
+function setPreTrim($trim = "a") { $this->pre_trim = $trim; }
+function getPreTrim() { return $this->pre_trim; }
+function setPostTrim($trim = "a") { $this->post_trim = $trim; }
+function getPostTrim() { return $this->post_trim; }
+function setRoot($class = 'block') { $this->root_class = $class; }
+function setRootInline() { $this->root_class = 'inline'; }
+function setRootBlock() { $this->root_class = 'block'; }
+function getRoot() { return $this->root_class; }
+function setDebug($enable = true) { $this->debug = $enable; }
+function getDebug() { return $this->debug; }
+function setAllowAmpersand($enable = true) { $this->allow_ampersand = $enable; }
+function getAllowAmpersand() { return $this->allow_ampersand; }
+function setTagMarker($marker = '[') { $this->tag_marker = $marker; }
+function getTagMarker() { return $this->tag_marker; }
+function setIgnoreNewlines($ignore = true) { $this->ignore_newlines = $ignore; }
+function getIgnoreNewlines() { return $this->ignore_newlines; }
+function setLimit($limit = 0) { $this->output_limit = $limit; }
+function getLimit() { return $this->output_limit; }
+function setLimitTail($tail = "...") { $this->limit_tail = $tail; }
+function getLimitTail() { return $this->limit_tail; }
+function setLimitPrecision($prec = 0.15) { $this->limit_precision = $prec; }
+function getLimitPrecision() { return $this->limit_precision; }
+function wasLimited() { return $this->was_limited; }
+function setPlainMode($enable = true) { $this->plain_mode = $enable; }
+function getPlainMode() { return $this->plain_mode; }
+function setDetectURLs($enable = true) { $this->detect_urls = $enable; }
+function getDetectURLs() { return $this->detect_urls; }
+function setURLPattern($pattern) { $this->url_pattern = $pattern; }
+function getURLPattern() { return $this->url_pattern; }
+function setURLTargetable($enable) { $this->url_targetable = $enable; }
+function getURLTargetable() { return $this->url_targetable; }
+function setURLTarget($target) { $this->url_target = $target; }
+function getURLTarget() { return $this->url_target; }
+function addRule($name, $rule) { $this->tag_rules[$name] = $rule; }
+function removeRule($name) { unset($this->tag_rules[$name]); }
+function getRule($name) { return isset($this->tag_rules[$name])
 ? $this->tag_rules[$name] : false; }
-function ClearRules() { $this->tag_rules = []; }
-function GetDefaultRule($name) { return isset($this->defaults->default_tag_rules[$name])
+function clearRules() { $this->tag_rules = []; }
+function getDefaultRule($name) { return isset($this->defaults->default_tag_rules[$name])
 ? $this->defaults->default_tag_rules[$name] : false; }
-function SetDefaultRule($name) { if (isset($this->defaults->default_tag_rules[$name]))
-$this->AddRule($name, $this->defaults->default_tag_rules[$name]);
-else $this->RemoveRule($name); }
-function GetDefaultRules() { return $this->defaults->default_tag_rules; }
-function SetDefaultRules() { $this->tag_rules = $this->defaults->default_tag_rules; }
-function SetWikiURL($url) { $this->wiki_url = $url; }
-function GetWikiURL($url) { return $this->wiki_url; }
-function GetDefaultWikiURL() { return '/?page='; }
-function SetLocalImgDir($path) { $this->local_img_dir = $path; }
-function GetLocalImgDir() { return $this->local_img_dir; }
-function GetDefaultLocalImgDir() { return "img"; }
-function SetLocalImgURL($path) { $this->local_img_url = $path; }
-function GetLocalImgURL() { return $this->local_img_url; }
-function GetDefaultLocalImgURL() { return "img"; }
-function SetRuleHTML($html) { $this->rule_html = $html; }
-function GetRuleHTML() { return $this->rule_html; }
-function GetDefaultRuleHTML() { return "\n<hr class=\"bbcode_rule\" />\n"; }
-function AddSmiley($code, $image) { $this->smileys[$code] = $image; $this->smiley_regex = false; }
-function RemoveSmiley($code) { unset($this->smileys[$code]); $this->smiley_regex = false; }
-function GetSmiley($code) { return isset($this->smileys[$code])
+function setDefaultRule($name) { if (isset($this->defaults->default_tag_rules[$name]))
+$this->addRule($name, $this->defaults->default_tag_rules[$name]);
+else $this->removeRule($name); }
+function getDefaultRules() { return $this->defaults->default_tag_rules; }
+function setDefaultRules() { $this->tag_rules = $this->defaults->default_tag_rules; }
+function setWikiURL($url) { $this->wiki_url = $url; }
+function getWikiURL($url) { return $this->wiki_url; }
+function getDefaultWikiURL() { return '/?page='; }
+function setLocalImgDir($path) { $this->local_img_dir = $path; }
+function getLocalImgDir() { return $this->local_img_dir; }
+function getDefaultLocalImgDir() { return "img"; }
+function setLocalImgURL($path) { $this->local_img_url = $path; }
+function getLocalImgURL() { return $this->local_img_url; }
+function getDefaultLocalImgURL() { return "img"; }
+function setRuleHTML($html) { $this->rule_html = $html; }
+function getRuleHTML() { return $this->rule_html; }
+function getDefaultRuleHTML() { return "\n<hr class=\"bbcode_rule\" />\n"; }
+function addSmiley($code, $image) { $this->smileys[$code] = $image; $this->smiley_regex = false; }
+function removeSmiley($code) { unset($this->smileys[$code]); $this->smiley_regex = false; }
+function getSmiley($code) { return isset($this->smileys[$code])
 ? $this->smileys[$code] : false; }
-function ClearSmileys() { $this->smileys = []; $this->smiley_regex = false; }
-function GetDefaultSmiley($code) { return isset($this->defaults->default_smileys[$code])
+function clearSmileys() { $this->smileys = []; $this->smiley_regex = false; }
+function getDefaultSmiley($code) { return isset($this->defaults->default_smileys[$code])
 ? $this->defaults->default_smileys[$code] : false; }
-function SetDefaultSmiley($code) { $this->smileys[$code] = @$this->defaults->default_smileys[$code];
+function setDefaultSmiley($code) { $this->smileys[$code] = @$this->defaults->default_smileys[$code];
 $this->smiley_regex = false; }
-function GetDefaultSmileys() { return $this->defaults->default_smileys; }
-function SetDefaultSmileys() { $this->smileys = $this->defaults->default_smileys;
+function getDefaultSmileys() { return $this->defaults->default_smileys; }
+function setDefaultSmileys() { $this->smileys = $this->defaults->default_smileys;
 $this->smiley_regex = false; }
-function SetSmileyDir($path) { $this->smiley_dir = $path; }
-function GetSmileyDir() { return $this->smiley_dir; }
-function GetDefaultSmileyDir() { return "smileys"; }
-function SetSmileyURL($path) { $this->smiley_url = $path; }
-function GetSmileyURL() { return $this->smiley_url; }
-function GetDefaultSmileyURL() { return "smileys"; }
-function SetEnableSmileys($enable = true) { $this->enable_smileys = $enable; }
-function GetEnableSmileys() { return $this->enable_smileys; }
+function setSmileyDir($path) { $this->smiley_dir = $path; }
+function getSmileyDir() { return $this->smiley_dir; }
+function getDefaultSmileyDir() { return "smileys"; }
+function setSmileyURL($path) { $this->smiley_url = $path; }
+function getSmileyURL() { return $this->smiley_url; }
+function getDefaultSmileyURL() { return "smileys"; }
+function setEnableSmileys($enable = true) { $this->enable_smileys = $enable; }
+function getEnableSmileys() { return $this->enable_smileys; }
 function nl2br($string) {
 return preg_replace("/\\x0A|\\x0D|\\x0A\\x0D|\\x0D\\x0A/", "<br />\n", $string);
 }
-function UnHTMLEncode($string) {
+function unHTMLEncode($string) {
 if (function_exists("html_entity_decode"))
 return html_entity_decode($string);
 $string = preg_replace_callback(
@@ -1144,11 +1144,11 @@ $trans_tbl = get_html_translation_table(HTML_ENTITIES);
 $trans_tbl = array_flip($trans_tbl);
 return strtr($string, $trans_tbl);
 }
-function Wikify($string) {
+function wikify($string) {
 return rawurlencode(str_replace(" ", "_",
 trim(preg_replace("/[!?;@#\$%\\^&*<>=+`~\\x00-\\x20_-]+/", " ", $string))));
 }
-function IsValidURL($string, $email_too = true) {
+function isValidURL($string, $email_too = true) {
 if (preg_match("/^
 (?:https?|ftp):\\/\\/
 (?:
@@ -1172,10 +1172,10 @@ if (preg_match("/^[^:]+([\\/\\\\?#][^\\r\\n]*)?$/D", $string))
 return true;
 if ($email_too)
 if (substr($string, 0, 7) == "mailto:")
-return $this->IsValidEmail(substr($string, 7));
+return $this->isValidEmail(substr($string, 7));
 return false;
 }
-function IsValidEmail($string) {
+function isValidEmail($string) {
 $validator = new BBCodeEmailAddressValidator;
 return $validator->check_email_address($string);
 /*
@@ -1205,24 +1205,24 @@ return preg_match("/^
 $/Dx", $string);
 */
 }
-function HTMLEncode($string) {
+function hTMLEncode($string) {
 if (!$this->allow_ampersand)
 return htmlspecialchars($string);
 else return str_replace(['<', '>'], //, '"'),
 ['&lt;', '&gt;'], $string); //, '&quot;'), $string);
 }
-function FixupOutput($string) {
+function fixupOutput($string) {
 if (!$this->detect_urls) {
-$output = $this->Internal_ProcessSmileys($string);
+$output = $this->internal_ProcessSmileys($string);
 }
 else {
-$chunks = $this->Internal_AutoDetectURLs($string);
+$chunks = $this->internal_AutoDetectURLs($string);
 $output = [];
 if (count($chunks)) {
 $is_a_url = false;
 foreach ($chunks as $index => $chunk) {
 if (!$is_a_url) {
-$chunk = $this->Internal_ProcessSmileys($chunk);
+$chunk = $this->internal_ProcessSmileys($chunk);
 }
 $output[] = $chunk;
 $is_a_url = !$is_a_url;
@@ -1232,24 +1232,24 @@ $output = implode("", $output);
 }
 return $output;
 }
-function Internal_ProcessSmileys($string) {
+function internal_ProcessSmileys($string) {
 if (!$this->enable_smileys || $this->plain_mode) {
-$output = $this->HTMLEncode($string);
+$output = $this->hTMLEncode($string);
 }
 else {
 if ($this->smiley_regex === false) {
-$this->Internal_RebuildSmileys();
+$this->internal_RebuildSmileys();
 }
 $tokens = preg_split($this->smiley_regex, $string, -1, PREG_SPLIT_DELIM_CAPTURE);
 if (count($tokens) <= 1) {
-$output = $this->HTMLEncode($string);
+$output = $this->hTMLEncode($string);
 }
 else {
 $output = "";
 $is_a_smiley = false;
 foreach ($tokens as $token) {
 if (!$is_a_smiley) {
-$output .= $this->HTMLEncode($token);
+$output .= $this->hTMLEncode($token);
 }
 else {
 if (isset($this->smiley_info[$token])) {
@@ -1270,7 +1270,7 @@ $is_a_smiley = !$is_a_smiley;
 }
 return $output;
 }
-function Internal_RebuildSmileys() {
+function internal_RebuildSmileys() {
 $regex = ["/(?<![\\w])("];
 $first = true;
 foreach ($this->smileys as $code => $filename) {
@@ -1281,7 +1281,7 @@ $first = false;
 $regex[] = ")(?![\\w])/";
 $this->smiley_regex = implode("", $regex);
 }
-function Internal_AutoDetectURLs($string) {
+function internal_AutoDetectURLs($string) {
 $output = preg_split("/( (?:
 (?:https?|ftp) : \\/*
 (?:
@@ -1349,14 +1349,14 @@ if (!is_array($params)) $params = [];
 $params['url'] = $url;
 $params['link'] = $url;
 $params['text'] = $token;
-$output[$index] = $this->FillTemplate($this->url_pattern, $params);
+$output[$index] = $this->fillTemplate($this->url_pattern, $params);
 }
 $is_a_url = !$is_a_url;
 }
 }
 return $output;
 }
-function FillTemplate($template, $insert_array, $default_array = []) {
+function fillTemplate($template, $insert_array, $default_array = []) {
 $pieces = preg_split('/(\{\$[a-zA-Z0-9_.:\/-]+\})/', $template,
 -1, PREG_SPLIT_DELIM_CAPTURE);
 if (count($pieces) <= 1)
@@ -1400,8 +1400,8 @@ if (isset($flags['w']))
 $value = preg_replace("/[\\x00-\\x09\\x0B-\x0C\x0E-\\x20]+/", " ", $value);
 if (isset($flags['t'])) $value = trim($value);
 if (isset($flags['b'])) $value = basename($value);
-if (isset($flags['e'])) $value = $this->HTMLEncode($value);
-else if (isset($flags['k'])) $value = $this->Wikify($value);
+if (isset($flags['e'])) $value = $this->hTMLEncode($value);
+else if (isset($flags['k'])) $value = $this->wikify($value);
 else if (isset($flags['h'])) $value = htmlspecialchars($value);
 else if (isset($flags['u'])) $value = urlencode($value);
 if (isset($flags['n'])) $value = $this->nl2br($value);
@@ -1412,7 +1412,7 @@ $is_an_insert = !$is_an_insert;
 }
 return implode("", $result);
 }
-function Internal_CollectText($array, $start = 0) {
+function internal_CollectText($array, $start = 0) {
 ob_start();
 for ($start = intval($start), $end = count($array); $start < $end; $start++)
 print $array[$start][BBCODE_STACK_TEXT];
@@ -1420,7 +1420,7 @@ $output = ob_get_contents();
 ob_end_clean();
 return $output;
 }
-function Internal_CollectTextReverse($array, $start = 0, $end = 0) {
+function internal_CollectTextReverse($array, $start = 0, $end = 0) {
 ob_start();
 for ($start = intval($start); $start >= $end; $start--)
 print $array[$start][BBCODE_STACK_TEXT];
@@ -1428,7 +1428,7 @@ $output = ob_get_contents();
 ob_end_clean();
 return $output;
 }
-function Internal_GenerateOutput($pos) {
+function internal_GenerateOutput($pos) {
 $output = [];
 while (count($this->stack) > $pos) {
 $token = array_pop($this->stack);
@@ -1453,12 +1453,12 @@ BBCODE_STACK_CLASS => $this->current_class,
 else {
 if ($end_tag == BBCODE_REQUIRED)
 @$this->lost_start_tags[$name] += 1;
-$end = $this->Internal_CleanupWSByIteratingPointer(@$rule['before_endtag'], 0, $output);
-$this->Internal_CleanupWSByPoppingStack(@$rule['after_tag'], $output);
-$tag_body = $this->Internal_CollectTextReverse($output, count($output)-1, $end);
-$this->Internal_CleanupWSByPoppingStack(@$rule['before_tag'], $this->stack);
-$this->Internal_UpdateParamsForMissingEndTag(@$token[BBCODE_STACK_TAG]);
-$tag_output = $this->DoTag(BBCODE_OUTPUT, $name,
+$end = $this->internal_CleanupWSByIteratingPointer(@$rule['before_endtag'], 0, $output);
+$this->internal_CleanupWSByPoppingStack(@$rule['after_tag'], $output);
+$tag_body = $this->internal_CollectTextReverse($output, count($output)-1, $end);
+$this->internal_CleanupWSByPoppingStack(@$rule['before_tag'], $this->stack);
+$this->internal_UpdateParamsForMissingEndTag(@$token[BBCODE_STACK_TAG]);
+$tag_output = $this->doTag(BBCODE_OUTPUT, $name,
 @$token[BBCODE_STACK_TAG]['_default'], @$token[BBCODE_STACK_TAG], $tag_body);
 $output = [[
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
@@ -1469,10 +1469,10 @@ BBCODE_STACK_CLASS => $this->current_class
 }
 }
 }
-$this->Internal_ComputeCurrentClass();
+$this->internal_ComputeCurrentClass();
 return $output;
 }
-function Internal_RewindToClass($class_list) {
+function internal_RewindToClass($class_list) {
 $pos = count($this->stack) - 1;
 while ($pos >= 0 && !in_array($this->stack[$pos][BBCODE_STACK_CLASS], $class_list))
 $pos--;
@@ -1480,7 +1480,7 @@ if ($pos < 0) {
 if (!in_array($this->root_class, $class_list))
 return false;
 }
-$output = $this->Internal_GenerateOutput($pos+1);
+$output = $this->internal_GenerateOutput($pos+1);
 while (count($output)) {
 $token = array_pop($output);
 $token[BBCODE_STACK_CLASS] = $this->current_class;
@@ -1488,7 +1488,7 @@ $this->stack[] = $token;
 }
 return true;
 }
-function Internal_FinishTag($tag_name) {
+function internal_FinishTag($tag_name) {
 if (strlen($tag_name) <= 0)
 return false;
 if (isset($this->start_tags[$tag_name])
@@ -1496,24 +1496,24 @@ if (isset($this->start_tags[$tag_name])
 $pos = array_pop($this->start_tags[$tag_name]);
 else $pos = -1;
 if ($pos < 0) return false;
-$newpos = $this->Internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['after_tag'],
+$newpos = $this->internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['after_tag'],
 $pos+1, $this->stack);
 $delta = $newpos - ($pos+1);
-$output = $this->Internal_GenerateOutput($newpos);
-$newend = $this->Internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['before_endtag'],
+$output = $this->internal_GenerateOutput($newpos);
+$newend = $this->internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['before_endtag'],
 0, $output);
-$output = $this->Internal_CollectTextReverse($output, count($output) - 1, $newend);
+$output = $this->internal_CollectTextReverse($output, count($output) - 1, $newend);
 while ($delta-- > 0)
 array_pop($this->stack);
-$this->Internal_ComputeCurrentClass();
+$this->internal_ComputeCurrentClass();
 return $output;
 }
-function Internal_ComputeCurrentClass() {
+function internal_ComputeCurrentClass() {
 if (count($this->stack) > 0)
 $this->current_class = $this->stack[count($this->stack)-1][BBCODE_STACK_CLASS];
 else $this->current_class = $this->root_class;
 }
-function Internal_DumpStack($array = false, $raw = false) {
+function internal_DumpStack($array = false, $raw = false) {
 if (!$raw) $string = "<span style='color: #00C;'>";
 else $string = "";
 if ($array === false)
@@ -1540,7 +1540,7 @@ break;
 if (!$raw) $string .= "</span>";
 return $string;
 }
-function Internal_CleanupWSByPoppingStack($pattern, &$array) {
+function internal_CleanupWSByPoppingStack($pattern, &$array) {
 if (strlen($pattern) <= 0) return;
 $oldlen = count($array);
 foreach (str_split($pattern) as $char) {
@@ -1562,36 +1562,36 @@ break;
 }
 }
 if (count($array) != $oldlen) {
-$this->Internal_ComputeCurrentClass();
+$this->internal_ComputeCurrentClass();
 }
 }
-function Internal_CleanupWSByEatingInput($pattern) {
+function internal_CleanupWSByEatingInput($pattern) {
 if (strlen($pattern) <= 0) return;
 foreach (str_split($pattern) as $char) {
 switch ($char) {
 case 's':
-$token_type = $this->lexer->NextToken();
+$token_type = $this->lexer->nextToken();
 while ($token_type == BBCODE_WS) {
-$token_type = $this->lexer->NextToken();
+$token_type = $this->lexer->nextToken();
 }
-$this->lexer->UngetToken();
+$this->lexer->ungetToken();
 break;
 case 'n':
-$token_type = $this->lexer->NextToken();
+$token_type = $this->lexer->nextToken();
 if ($token_type != BBCODE_NL)
-$this->lexer->UngetToken();
+$this->lexer->ungetToken();
 break;
 case 'a':
-$token_type = $this->lexer->NextToken();
+$token_type = $this->lexer->nextToken();
 while ($token_type == BBCODE_WS || $token_type == BBCODE_NL) {
-$token_type = $this->lexer->NextToken();
+$token_type = $this->lexer->nextToken();
 }
-$this->lexer->UngetToken();
+$this->lexer->ungetToken();
 break;
 }
 }
 }
-function Internal_CleanupWSByIteratingPointer($pattern, $pos, $array) {
+function internal_CleanupWSByIteratingPointer($pattern, $pos, $array) {
 if (strlen($pattern) <= 0) return $pos;
 foreach (str_split($pattern) as $char) {
 switch ($char) {
@@ -1612,7 +1612,7 @@ break;
 }
 return $pos;
 }
-function Internal_LimitText($string, $limit) {
+function internal_LimitText($string, $limit) {
 $chunks = preg_split("/([\\x00-\\x20]+)/", $string, -1, PREG_SPLIT_DELIM_CAPTURE);
 $output = "";
 foreach ($chunks as $chunk) {
@@ -1623,8 +1623,8 @@ $output .= $chunk;
 $output = rtrim($output);
 return $output;
 }
-function Internal_DoLimit() {
-$this->Internal_CleanupWSByPoppingStack("a", $this->stack);
+function internal_DoLimit() {
+$this->internal_CleanupWSByPoppingStack("a", $this->stack);
 if (strlen($this->limit_tail) > 0) {
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
@@ -1635,7 +1635,7 @@ BBCODE_STACK_CLASS => $this->current_class,
 }
 $this->was_limited = true;
 }
-function DoTag($action, $tag_name, $default_value, $params, $contents) {
+function doTag($action, $tag_name, $default_value, $params, $contents) {
 $tag_rule = @$this->tag_rules[$tag_name];
 switch ($action) {
 case BBCODE_CHECK:
@@ -1705,7 +1705,7 @@ $link = $possible_content = "";
 foreach ($tag_rule['plain_link'] as $possible_content) {
 if ($possible_content == '_content'
 && strlen($contents) > 0) {
-$link = $this->UnHTMLEncode(strip_tags($contents));
+$link = $this->unHTMLEncode(strip_tags($contents));
 break;
 }
 if (isset($params[$possible_content])
@@ -1718,8 +1718,8 @@ $params = @parse_url($link);
 if (!is_array($params)) $params = [];
 $params['link'] = $link;
 $params['url'] = $link;
-$start = $this->FillTemplate($start, $params);
-$end = $this->FillTemplate($end, $params);
+$start = $this->fillTemplate($start, $params);
+$end = $this->fillTemplate($end, $params);
 }
 return $start . $result . $end;
 }
@@ -1729,7 +1729,7 @@ case BBCODE_MODE_SIMPLE:
 $result = @$tag_rule['simple_start'] . $contents . @$tag_rule['simple_end'];
 break;
 case BBCODE_MODE_ENHANCED:
-$result = $this->Internal_DoEnhancedTag($tag_rule, $params, $contents);
+$result = $this->internal_DoEnhancedTag($tag_rule, $params, $contents);
 break;
 case BBCODE_MODE_INTERNAL:
 $result = @call_user_func([$this, @$tag_rule['method']], BBCODE_OUTPUT,
@@ -1749,12 +1749,12 @@ default:
 return false;
 }
 }
-function Internal_DoEnhancedTag($tag_rule, $params, $contents) {
+function internal_DoEnhancedTag($tag_rule, $params, $contents) {
 $params['_content'] = $contents;
 $params['_defaultcontent'] = strlen(@$params['_default']) ? $params['_default'] : $contents;
-return $this->FillTemplate(@$tag_rule['template'], $params, @$tag_rule['default']);
+return $this->fillTemplate(@$tag_rule['template'], $params, @$tag_rule['default']);
 }
-function Internal_UpdateParamsForMissingEndTag(&$params) {
+function internal_UpdateParamsForMissingEndTag(&$params) {
 switch ($this->tag_marker) {
 case '[': $tail_marker = ']'; break;
 case '<': $tail_marker = '>'; break;
@@ -1764,19 +1764,19 @@ default: $tail_marker = $this->tag_marker; break;
 }
 $params['_endtag'] = $this->tag_marker . '/' . $params['_name'] . $tail_marker;
 }
-function Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule) {
-if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
+function internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule) {
+if (!$this->doTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 return;
 }
-$this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
-$output = $this->DoTag(BBCODE_OUTPUT, $tag_name, @$tag_params['_default'], $tag_params, "");
-$this->Internal_CleanupWSByEatingInput(@$tag_rule['after_tag']);
+$this->internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
+$output = $this->doTag(BBCODE_OUTPUT, $tag_name, @$tag_params['_default'], $tag_params, "");
+$this->internal_CleanupWSByEatingInput(@$tag_rule['after_tag']);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $output,
@@ -1784,30 +1784,30 @@ BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 }
-function Internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule) {
-$state = $this->lexer->SaveState();
+function internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule) {
+$state = $this->lexer->saveState();
 $end_tag = $this->lexer->tagmarker . "/" . $tag_name . $this->lexer->end_tagmarker;
 $start = count($this->stack);
 $this->lexer->verbatim = true;
-while (($token_type = $this->lexer->NextToken()) != BBCODE_EOI) {
+while (($token_type = $this->lexer->nextToken()) != BBCODE_EOI) {
 if ($this->lexer->text == $end_tag) {
 $end_tag_params = $this->lexer->tag;
 break;
 }
 if ($this->output_limit > 0
 && $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-$text = $this->Internal_LimitText($this->lexer->text,
+$text = $this->internal_LimitText($this->lexer->text,
 $this->output_limit - $this->text_length);
 if (strlen($text) > 0) {
 $this->text_length += strlen($text);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($text),
+BBCODE_STACK_TEXT => $this->fixupOutput($text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 }
-$this->Internal_DoLimit();
+$this->internal_DoLimit();
 break;
 }
 $this->text_length += strlen($this->lexer->text);
@@ -1820,25 +1820,25 @@ BBCODE_STACK_CLASS => $this->current_class,
 }
 $this->lexer->verbatim = false;
 if ($token_type == BBCODE_EOI) {
-$this->lexer->RestoreState($state);
+$this->lexer->restoreState($state);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 return;
 }
-$newstart = $this->Internal_CleanupWSByIteratingPointer(@$tag_rule['after_tag'], $start, $this->stack);
-$this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_endtag'], $this->stack);
-$this->Internal_CleanupWSByEatingInput(@$tag_rule['after_endtag']);
-$content = $this->Internal_CollectText($this->stack, $newstart);
+$newstart = $this->internal_CleanupWSByIteratingPointer(@$tag_rule['after_tag'], $start, $this->stack);
+$this->internal_CleanupWSByPoppingStack(@$tag_rule['before_endtag'], $this->stack);
+$this->internal_CleanupWSByEatingInput(@$tag_rule['after_endtag']);
+$content = $this->internal_CollectText($this->stack, $newstart);
 array_splice($this->stack, $start);
-$this->Internal_ComputeCurrentClass();
-$this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
+$this->internal_ComputeCurrentClass();
+$this->internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
 $tag_params['_endtag'] = $end_tag_params['_tag'];
 $tag_params['_hasend'] = true;
-$output = $this->DoTag(BBCODE_OUTPUT, $tag_name,
+$output = $this->doTag(BBCODE_OUTPUT, $tag_name,
 @$tag_params['_default'], $tag_params, $content);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
@@ -1847,13 +1847,13 @@ BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 }
-function Internal_ParseStartTagToken() {
+function internal_ParseStartTagToken() {
 $tag_params = $this->lexer->tag;
 $tag_name = @$tag_params['_name'];
 if (!isset($this->tag_rules[$tag_name])) {
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
@@ -1863,10 +1863,10 @@ $tag_rule = $this->tag_rules[$tag_name];
 $allow_in = is_array($tag_rule['allow_in'])
 ? $tag_rule['allow_in'] : [$this->root_class];
 if (!in_array($this->current_class, $allow_in)) {
-if (!$this->Internal_RewindToClass($allow_in)) {
+if (!$this->internal_RewindToClass($allow_in)) {
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
@@ -1875,20 +1875,20 @@ return;
 }
 $end_tag = isset($tag_rule['end_tag']) ? $tag_rule['end_tag'] : BBCODE_REQUIRED;
 if ($end_tag == BBCODE_PROHIBIT) {
-$this->Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule);
+$this->internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule);
 return;
 }
-if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
+if (!$this->doTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 return;
 }
 if (@$tag_rule['content'] == BBCODE_VERBATIM) {
-$this->Internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule);
+$this->internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule);
 return;
 }
 if (isset($tag_rule['class']))
@@ -1896,7 +1896,7 @@ $newclass = $tag_rule['class'];
 else $newclass = $this->root_class;
 $this->stack[] = [
 BBCODE_STACK_TOKEN => $this->lexer->token,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => $this->lexer->tag,
 BBCODE_STACK_CLASS => ($this->current_class = $newclass),
 ];
@@ -1904,10 +1904,10 @@ if (!isset($this->start_tags[$tag_name]))
 $this->start_tags[$tag_name] = [count($this->stack)-1];
 else $this->start_tags[$tag_name][] = count($this->stack)-1;
 }
-function Internal_ParseEndTagToken() {
+function internal_ParseEndTagToken() {
 $tag_params = $this->lexer->tag;
 $tag_name = @$tag_params['_name'];
-$contents = $this->Internal_FinishTag($tag_name);
+$contents = $this->internal_FinishTag($tag_name);
 if ($contents === false) {
 if (@$this->lost_start_tags[$tag_name] > 0) {
 $this->lost_start_tags[$tag_name]--;
@@ -1915,7 +1915,7 @@ $this->lost_start_tags[$tag_name]--;
 else {
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
@@ -1924,13 +1924,13 @@ return;
 }
 $start_tag_node = array_pop($this->stack);
 $start_tag_params = $start_tag_node[BBCODE_STACK_TAG];
-$this->Internal_ComputeCurrentClass();
-$this->Internal_CleanupWSByPoppingStack(@$this->tag_rules[$tag_name]['before_tag'], $this->stack);
+$this->internal_ComputeCurrentClass();
+$this->internal_CleanupWSByPoppingStack(@$this->tag_rules[$tag_name]['before_tag'], $this->stack);
 $start_tag_params['_endtag'] = $tag_params['_tag'];
 $start_tag_params['_hasend'] = true;
-$output = $this->DoTag(BBCODE_OUTPUT, $tag_name, @$start_tag_params['_default'],
+$output = $this->doTag(BBCODE_OUTPUT, $tag_name, @$start_tag_params['_default'],
 $start_tag_params, $contents);
-$this->Internal_CleanupWSByEatingInput(@$this->tag_rules[$tag_name]['after_endtag']);
+$this->internal_CleanupWSByEatingInput(@$this->tag_rules[$tag_name]['after_endtag']);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
 BBCODE_STACK_TEXT => $output,
@@ -1938,7 +1938,7 @@ BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 }
-function Parse($string) {
+function parse($string) {
 $this->lexer = new BBCodeLexer($string, $this->tag_marker);
 $this->lexer->debug = $this->debug;
 $old_output_limit = $this->output_limit;
@@ -1947,7 +1947,7 @@ if (strlen($string) < $this->output_limit) {
 $this->output_limit = 0;
 }
 else if ($this->limit_precision > 0) {
-$guess_length = $this->lexer->GuessTextLength();
+$guess_length = $this->lexer->guessTextLength();
 if ($guess_length < $this->output_limit * ($this->limit_precision + 1.0)) {
 $this->output_limit = 0;
 }
@@ -1961,34 +1961,34 @@ $this->lost_start_tags = [];
 $this->text_length = 0;
 $this->was_limited = false;
 if (strlen($this->pre_trim) > 0)
-$this->Internal_CleanupWSByEatingInput($this->pre_trim);
+$this->internal_CleanupWSByEatingInput($this->pre_trim);
 $newline = $this->plain_mode ? "\n" : "<br />\n";
 while (true) {
-if (($token_type = $this->lexer->NextToken()) == BBCODE_EOI) {
+if (($token_type = $this->lexer->nextToken()) == BBCODE_EOI) {
 break;
 }
 switch ($token_type) {
 case BBCODE_TEXT:
 if ($this->output_limit > 0
 && $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-$text = $this->Internal_LimitText($this->lexer->text,
+$text = $this->internal_LimitText($this->lexer->text,
 $this->output_limit - $this->text_length);
 if (strlen($text) > 0) {
 $this->text_length += strlen($text);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($text),
+BBCODE_STACK_TEXT => $this->fixupOutput($text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
 }
-$this->Internal_DoLimit();
+$this->internal_DoLimit();
 break 2;
 }
 $this->text_length += strlen($this->lexer->text);
 $this->stack[] = [
 BBCODE_STACK_TOKEN => BBCODE_TEXT,
-BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
@@ -1996,7 +1996,7 @@ break;
 case BBCODE_WS:
 if ($this->output_limit > 0
 && $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-$this->Internal_DoLimit();
+$this->internal_DoLimit();
 break 2;
 }
 $this->text_length += strlen($this->lexer->text);
@@ -2011,7 +2011,7 @@ case BBCODE_NL:
 if ($this->ignore_newlines) {
 if ($this->output_limit > 0
 && $this->text_length + 1 >= $this->output_limit) {
-$this->Internal_DoLimit();
+$this->internal_DoLimit();
 break 2;
 }
 $this->text_length += 1;
@@ -2023,10 +2023,10 @@ BBCODE_STACK_CLASS => $this->current_class,
 ];
 }
 else {
-$this->Internal_CleanupWSByPoppingStack("s", $this->stack);
+$this->internal_CleanupWSByPoppingStack("s", $this->stack);
 if ($this->output_limit > 0
 && $this->text_length + 1 >= $this->output_limit) {
-$this->Internal_DoLimit();
+$this->internal_DoLimit();
 break 2;
 }
 $this->text_length += 1;
@@ -2036,23 +2036,23 @@ BBCODE_STACK_TEXT => $newline,
 BBCODE_STACK_TAG => false,
 BBCODE_STACK_CLASS => $this->current_class,
 ];
-$this->Internal_CleanupWSByEatingInput("s");
+$this->internal_CleanupWSByEatingInput("s");
 }
 break;
 case BBCODE_TAG:
-$this->Internal_ParseStartTagToken();
+$this->internal_ParseStartTagToken();
 break;
 case BBCODE_ENDTAG:
-$this->Internal_ParseEndTagToken();
+$this->internal_ParseEndTagToken();
 break;
 default:
 break;
 }
 }
 if (strlen($this->post_trim) > 0)
-$this->Internal_CleanupWSByPoppingStack($this->post_trim, $this->stack);
-$result = $this->Internal_GenerateOutput(0);
-$result = $this->Internal_CollectTextReverse($result, count($result) - 1);
+$this->internal_CleanupWSByPoppingStack($this->post_trim, $this->stack);
+$result = $this->internal_GenerateOutput(0);
+$result = $this->internal_CollectTextReverse($result, count($result) - 1);
 $this->output_limit = $old_output_limit;
 if ($this->plain_mode) {
 $result = preg_replace("/[\\x00-\\x09\\x0B-\\x20]+/", " ", $result);

--- a/plugins/NBBC/nbbc/src/nbbc_lex.php
+++ b/plugins/NBBC/nbbc/src/nbbc_lex.php
@@ -71,7 +71,7 @@
 		var $pat_comment2;	// Pattern for matching comments.
 		var $pat_wiki;		// Pattern for matching wiki-links.
 
-		function BBCodeLexer($string, $tagmarker = '[') {
+		function bBCodeLexer($string, $tagmarker = '[') {
 			// First thing we do is to split the input string into tuples of
 			// text and tags.  This will make it easy to tokenize.  We define a tag as
 			// anything starting with a [, ending with a ], and containing no [ or ] in
@@ -152,7 +152,7 @@
 		// This is optimized for speed, not accuracy, so it'll get some stuff like
 		// horizontal rules and weird whitespace characters wrong, but it's only supposed
 		// to provide a rough quick guess, not a hard fact.
-		function GuessTextLength() {
+		function guessTextLength() {
 			$length = 0;
 			$ptr = 0;
 			$state = BBCODE_LEXSTATE_TEXT;
@@ -195,7 +195,7 @@
 		//
 		// If this is a BBCODE_TAG token, $this->tag will be an array computed from
 		// the tag's contents, like this:
-		//    Array(
+		//    array(
 		//       '_name' => tag_name,
 		//       '_end' => true if this is an end tag (i.e., the name starts with a /)
 		//       '_default' => default value (for example, in [url=foo], this is "foo").
@@ -203,7 +203,7 @@
 		//       ...all other key => value parameters given in the tag...
 		//       ...
 		//    )
-		function NextToken() {
+		function nextToken() {
 		
 			// Handle ungets; if the last token has been "ungotten", just return it again.
 			if ($this->unget) {
@@ -324,7 +324,7 @@
 						}
 						
 						// Not a comment, so parse it like a tag.
-						$this->tag = $this->Internal_DecodeTag($this->text);
+						$this->tag = $this->internal_DecodeTag($this->text);
 						$this->state = BBCODE_LEXSTATE_TEXT;
 						return $this->token = ($this->tag['_end'] ? BBCODE_ENDTAG : BBCODE_TAG);
 					}
@@ -332,19 +332,19 @@
 			}
 		}
 		
-		// Ungets the last token read so that a subsequent call to NextToken() will
-		// return it.  Note that UngetToken() does not switch states when you switch
+		// Ungets the last token read so that a subsequent call to nextToken() will
+		// return it.  Note that ungetToken() does not switch states when you switch
 		// between verbatim mode and standard mode:  For example, if you read a tag,
 		// unget the tag, switch to verbatim mode, and then get the next token, you'll
 		// get back a BBCODE_TAG --- exactly what you ungot, not a BBCODE_TEXT token.
-		function UngetToken() {
+		function ungetToken() {
 			if ($this->token !== BBCODE_EOI)
 				$this->unget = true;
 		}
 
 		// Peek at the next token, but don't remove it.
-		function PeekToken() {
-			$result = $this->NextToken();
+		function peekToken() {
+			$result = $this->nextToken();
 			if ($this->token !== BBCODE_EOI)
 				$this->unget = true;
 			return $result;
@@ -354,7 +354,7 @@
 		// value from this should be considered opaque.  Because PHP uses copy-on-write
 		// references, the total cost of the returned state is relatively small, and
 		// the running time of this function (and RestoreState) is very fast.
-		function SaveState() {
+		function saveState() {
 			return [
 				'token' => $this->token,
 				'text' => $this->text,
@@ -368,7 +368,7 @@
 		}
 		
 		// Restore the state of this lexer from a saved previous state.
-		function RestoreState($state) {
+		function restoreState($state) {
 			if (!is_array($state)) return;
 			$this->token = @$state['token'];
 			$this->text = @$state['text'];
@@ -381,7 +381,7 @@
 		}
 
 		// Given a string, if it's surrounded by "quotes" or 'quotes', remove them.
-		function Internal_StripQuotes($string) {
+		function internal_StripQuotes($string) {
 			if (preg_match("/^\\\"(.*)\\\"$/", $string, $matches))
 				return $matches[1];
 			else if (preg_match("/^\\'(.*)\\'$/", $string, $matches))
@@ -396,7 +396,7 @@
 		//    ' '   Token is whitespace.
 		//    '"'   Token is quoted text.
 		//    'A'   Token is unquoted text.
-		function Internal_ClassifyPiece($ptr, $pieces) {
+		function internal_ClassifyPiece($ptr, $pieces) {
 			if ($ptr >= count($pieces)) return -1;	// EOI.
 			$piece = $pieces[$ptr];
 			if ($piece == '=') return '=';
@@ -407,7 +407,7 @@
 
 		// Given a string containing a complete [tag] (including its brackets), break
 		// it down into its components and return them as an array.
-		function Internal_DecodeTag($tag) {
+		function internal_DecodeTag($tag) {
 
 			if ($this->debug) {
 				print "<b>Lexer::InternalDecodeTag:</b> input: " . htmlspecialchars($tag) . "<br />\n";
@@ -444,7 +444,7 @@
 			}
 
 			// Skip whitespace after the tag name.
-			while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+			while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 				$ptr++;
 
 			$params = [];
@@ -458,13 +458,13 @@
 				$ptr++;
 
 				// Skip whitespace after the initial equal-sign.
-				while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+				while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 					$ptr++;
 
 				// Examine the next (real) piece, and see if it's quoted; if not, we need to
 				// use heuristics to guess where the default value begins and ends.
 				if ($type == "\"")
-					$value = $this->Internal_StripQuotes($pieces[$ptr++]);
+					$value = $this->internal_StripQuotes($pieces[$ptr++]);
 				else {
 					// Collect pieces going forward until we reach an = sign or the end of the
 					// tag; then rewind before whatever comes before the = sign, and everything
@@ -476,7 +476,7 @@
 					// to behave in a way that makes (tolerable) sense.
 					$after_space = false;
 					$start = $ptr;
-					while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1) {
+					while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) != -1) {
 						if ($type == ' ') $after_space = true;
 						if ($type == '=' && $after_space) break;
 						$ptr++;
@@ -491,19 +491,19 @@
 						// Rewind before = sign.
 						$ptr--;
 						// Rewind before any whitespace before = sign.
-						while ($ptr > $start && $this->Internal_ClassifyPiece($ptr, $pieces) == ' ')
+						while ($ptr > $start && $this->internal_ClassifyPiece($ptr, $pieces) == ' ')
 							$ptr--;
 						// Rewind before any text elements before that.
-						while ($ptr > $start && $this->Internal_ClassifyPiece($ptr, $pieces) != ' ')
+						while ($ptr > $start && $this->internal_ClassifyPiece($ptr, $pieces) != ' ')
 							$ptr--;
 					}
 
 					// The default value is everything from $start to $ptr, inclusive.
 					$value = "";
 					for (; $start <= $ptr; $start++) {
-						if ($this->Internal_ClassifyPiece($start, $pieces) == ' ')
+						if ($this->internal_ClassifyPiece($start, $pieces) == ' ')
 							$value .= " ";
-						else $value .= $this->Internal_StripQuotes($pieces[$start]);
+						else $value .= $this->internal_StripQuotes($pieces[$start]);
 					}
 					$value = trim($value);
 					
@@ -517,17 +517,17 @@
 			// The rest of the tag is composed of either floating keys or key=value pairs, so walk through
 			// the tag and collect them all.  Again, we have the nasty special case where an equal sign
 			// in a parameter but before whitespace counts as part of that parameter.
-			while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1) {
+			while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) != -1) {
 
 				// Skip whitespace before the next key name.
 				while ($type == ' ') {
 					$ptr++;
-					$type = $this->Internal_ClassifyPiece($ptr, $pieces);
+					$type = $this->internal_ClassifyPiece($ptr, $pieces);
 				}
 
 				// Decode the key name.
 				if ($type == 'A' || $type == '"')
-					$key = strtolower($this->Internal_StripQuotes(@$pieces[$ptr++]));
+					$key = strtolower($this->internal_StripQuotes(@$pieces[$ptr++]));
 				else if ($type == '=') {
 					$ptr++;
 					continue;
@@ -535,27 +535,27 @@
 				else if ($type == -1) break;
 
 				// Skip whitespace after the key name.
-				while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+				while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 					$ptr++;
 
 				// If an equal-sign follows, we need to collect a value.  Otherwise, we
 				// take the key itself as the value.
 				if ($type != '=')
-					$value = $this->Internal_StripQuotes($key);
+					$value = $this->internal_StripQuotes($key);
 				else {
 					$ptr++;
 					// Skip whitespace after the equal sign.
-					while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) == ' ')
+					while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) == ' ')
 						$ptr++;
 					if ($type == '"') {
 						// If we get a quoted value, take that as the only value.
-						$value = $this->Internal_StripQuotes($pieces[$ptr++]);
+						$value = $this->internal_StripQuotes($pieces[$ptr++]);
 					}
 					else if ($type != -1) {
 						// If we get a non-quoted value, consume non-quoted values
 						// until we reach whitespace.
 						$value = $pieces[$ptr++];
-						while (($type = $this->Internal_ClassifyPiece($ptr, $pieces)) != -1
+						while (($type = $this->internal_ClassifyPiece($ptr, $pieces)) != -1
 							&& $type != ' ')
 							$value .= $pieces[$ptr++];
 					}

--- a/plugins/NBBC/nbbc/src/nbbc_lib.php
+++ b/plugins/NBBC/nbbc/src/nbbc_lib.php
@@ -52,8 +52,8 @@
 	//  manually afterward:
 	//
 	//    $bbcode = new BBCode;
-	//    $bbcode->AddRule(...);
-	//    $bbcode->AddSmiley(...);
+	//    $bbcode->addRule(...);
+	//    $bbcode->addSmiley(...);
 	//
 	//-----------------------------------------------------------------------------
 
@@ -405,13 +405,13 @@
 
 		// Format a [url] tag by producing an <a>...</a> element.
 		// The URL only allows http, https, mailto, and ftp protocols for safety.
-		function DoURL($bbcode, $action, $name, $default, $params, $content) {
+		function doURL($bbcode, $action, $name, $default, $params, $content) {
 			// We can't check this with BBCODE_CHECK because we may have no URL before the content
 			// has been processed.
 			if ($action == BBCODE_CHECK) return true;
 
-			$url = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
-			if ($bbcode->IsValidURL($url)) {
+			$url = is_string($default) ? $default : $bbcode->unHTMLEncode(strip_tags($content));
+			if ($bbcode->isValidURL($url)) {
 				if ($bbcode->debug)
 					print "ISVALIDURL<br />";
 				if ($bbcode->url_targetable !== false && isset($params['target']))
@@ -428,19 +428,19 @@
 		// Format an [email] tag by producing an <a>...</a> element.
 		// The e-mail address must be a valid address including at least a '@' and a valid domain
 		// name or IPv4 or IPv6 address after the '@'.
-		function DoEmail($bbcode, $action, $name, $default, $params, $content) {
+		function doEmail($bbcode, $action, $name, $default, $params, $content) {
 			// We can't check this with BBCODE_CHECK because we may have no URL before the content
 			// has been processed.
 			if ($action == BBCODE_CHECK) return true;
 
-			$email = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
-			if ($bbcode->IsValidEmail($email))
+			$email = is_string($default) ? $default : $bbcode->unHTMLEncode(strip_tags($content));
+			if ($bbcode->isValidEmail($email))
 				return '<a href="mailto:' . htmlspecialchars($email) . '" class="bbcode_email">' . $content . '</a>';
 			else return htmlspecialchars($params['_tag']) . $content . htmlspecialchars($params['_endtag']);
 		}
 		
 		// Format a [size] tag by producing a <span> with a style with a different font-size.
-		function DoSize($bbcode, $action, $name, $default, $params, $content) {
+		function doSize($bbcode, $action, $name, $default, $params, $content) {
 			switch ($default) {
 			case '0': $size = '.5em'; break;
 			case '1': $size = '.67em'; break;
@@ -458,7 +458,7 @@
 		// Format a [font] tag by producing a <span> with a style with a different font-family.
 		// This is complicated by the fact that we have to recognize the five special font
 		// names and quote all the others.
-		function DoFont($bbcode, $action, $name, $default, $params, $content) {
+		function doFont($bbcode, $action, $name, $default, $params, $content) {
 			$fonts = explode(",", $default);
 			$result = "";
 			$special_fonts = [
@@ -487,8 +487,8 @@
 		}
 
 		// Format a [wiki] tag by producing an <a>...</a> element.
-		function DoWiki($bbcode, $action, $name, $default, $params, $content) {
-			$name = $bbcode->Wikify($default);
+		function doWiki($bbcode, $action, $name, $default, $params, $content) {
+			$name = $bbcode->wikify($default);
 			if ($action == BBCODE_CHECK)
 				return strlen($name) > 0;
 			$title = trim(@$params['title']);
@@ -498,11 +498,11 @@
 		}
 
 		// Format an [img] tag.  The URL only allows http, https, and ftp protocols for safety.
-		function DoImage($bbcode, $action, $name, $default, $params, $content) {
+		function doImage($bbcode, $action, $name, $default, $params, $content) {
 			// We can't validate this until we have its content.
 			if ($action == BBCODE_CHECK) return true;
 
-			$content = trim($bbcode->UnHTMLEncode(strip_tags($content)));
+			$content = trim($bbcode->unHTMLEncode(strip_tags($content)));
 			if (preg_match("/\\.(?:gif|jpeg|jpg|jpe|png)$/", $content)) {
 				if (preg_match("/^[a-zA-Z0-9_][^:]+$/", $content)) {
 					// No protocol, so the image is in our local image directory, or somewhere under it.
@@ -517,7 +517,7 @@
 						}
 					}
 				}
-				else if ($bbcode->IsValidURL($content, false)) {
+				else if ($bbcode->isValidURL($content, false)) {
 					// Remote URL, or at least we don't know where it is.
 					return "<img src=\"" . htmlspecialchars($content) . "\" alt=\""
 						. htmlspecialchars(basename($content)) . "\" class=\"bbcode_img\" />";
@@ -529,7 +529,7 @@
 
 		// Format a [rule] tag.  This substitutes the content provided by the BBCode
 		// object, whatever that may be.
-		function DoRule($bbcode, $action, $name, $default, $params, $content) {
+		function doRule($bbcode, $action, $name, $default, $params, $content) {
 			if ($action == BBCODE_CHECK) return true;
 			else return $bbcode->rule_html;
 		}
@@ -547,7 +547,7 @@
 		//  [quote name="Tom" date="July 4, 1776 3:48 PM" url="http://www.constitution.gov"]...[/quote]
 		//
 		// The URL only allows http, https, mailto, gopher, ftp, and feed protocols for safety.
-		function DoQuote($bbcode, $action, $name, $default, $params, $content) {
+		function doQuote($bbcode, $action, $name, $default, $params, $content) {
 			if ($action == BBCODE_CHECK) return true;
 
 			if (isset($params['name'])) {
@@ -557,7 +557,7 @@
 				$title .= ":";
 				if (isset($params['url'])) {
 					$url = trim($params['url']);
-					if ($bbcode->IsValidURL($url))
+					if ($bbcode->isValidURL($url))
 						$title = "<a href=\"" . htmlspecialchars($params['url']) . "\">" . $title . "</a>";
 				}
 			}
@@ -584,7 +584,7 @@
 		//   [list=i]         Ordered list, lowercase Roman numerals, starting at i
 		//   [list=greek]     Ordered list, lowercase Greek letters, starting at alpha
 		//   [list=01]        Ordered list, two-digit numeric with 0-padding, starting at 01
-		function DoList($bbcode, $action, $name, $default, $params, $content) {
+		function doList($bbcode, $action, $name, $default, $params, $content) {
 
 			// Allowed list styles, striaght from the CSS 2.1 spec.  The only prohibited
 			// list style is that with image-based markers, which often slows down web sites.

--- a/plugins/NBBC/nbbc/src/nbbc_main.php
+++ b/plugins/NBBC/nbbc/src/nbbc_main.php
@@ -92,26 +92,26 @@
 	class BBCode_Profiler {
 		var $start_time, $total_times;
 		
-		function BBCode_Profiler()
+		function bBCode_Profiler()
 			{ $start_time = []; $total_times = []; }
 
-		function Now()
+		function now()
 			{ list($usec, $sec) = explode(" ", microtime());
 				return ((float)$usec + (float)$sec); }
 
-		function Begin($group)
-			{ $this->start_time[$group] = $this->Now(); }
-		function End($group)
-			{ $time = $this->Now() - $this->start_time[$group];
+		function begin($group)
+			{ $this->start_time[$group] = $this->now(); }
+		function end($group)
+			{ $time = $this->now() - $this->start_time[$group];
 				if (!isset($this->total_times[$group]))
 					$this->total_times[$group] = $time;
 				else $this->total_times[$group] += $time; }
-		function Reset($group)
+		function reset($group)
 			{ $this->total_times[$group] = 0; }
-		function Total($group)
+		function total($group)
 			{ return @$this->total_times[$group]; }
 
-		function DumpAllGroups() {
+		function dumpAllGroups() {
 			print "<div>Profiled times:\n<ul>\n";
 			ksort($this->total_times);
 			foreach ($this->total_times as $name => $time) {

--- a/plugins/NBBC/nbbc/src/nbbc_parse.php
+++ b/plugins/NBBC/nbbc/src/nbbc_parse.php
@@ -44,7 +44,7 @@
 	//-----------------------------------------------------------------------------
 	//
 	//  This file implements the New BBCode parser.  Usage is simple:  Just create
-	//  a BBCode object, and then call $bbcode->Parse() with a string containing
+	//  a BBCode object, and then call $bbcode->parse() with a string containing
 	//  BBCode, and it returns HTML.
 	//
 	//  Internally, this constructs and validates a syntax tree for the BBCode,
@@ -125,18 +125,18 @@
 		//-----------------------------------------------------------------------------
 		// Constructor.
 
-		function BBCode() {
+		function bBCode() {
 			$this->defaults = new BBCodeLibrary;
 			$this->tag_rules = $this->defaults->default_tag_rules;
 			$this->smileys = $this->defaults->default_smileys;
 			$this->enable_smileys = true;
 			$this->smiley_regex = false;
-			$this->smiley_dir = $this->GetDefaultSmileyDir();
-			$this->smiley_url = $this->GetDefaultSmileyURL();
-			$this->wiki_url = $this->GetDefaultWikiURL();
-			$this->local_img_dir = $this->GetDefaultLocalImgDir();
-			$this->local_img_url = $this->GetDefaultLocalImgURL();
-			$this->rule_html = $this->GetDefaultRuleHTML();
+			$this->smiley_dir = $this->getDefaultSmileyDir();
+			$this->smiley_url = $this->getDefaultSmileyURL();
+			$this->wiki_url = $this->getDefaultWikiURL();
+			$this->local_img_dir = $this->getDefaultLocalImgDir();
+			$this->local_img_url = $this->getDefaultLocalImgURL();
+			$this->rule_html = $this->getDefaultRuleHTML();
 			$this->pre_trim = "";
 			$this->post_trim = "";
 			$this->root_class = 'block';
@@ -161,113 +161,113 @@
 		//-----------------------------------------------------------------------------
 		// State control.
 
-		function SetPreTrim($trim = "a") { $this->pre_trim = $trim; }
-		function GetPreTrim()          { return $this->pre_trim; }
-		function SetPostTrim($trim = "a") { $this->post_trim = $trim; }
-		function GetPostTrim()         { return $this->post_trim; }
+		function setPreTrim($trim = "a") { $this->pre_trim = $trim; }
+		function getPreTrim()          { return $this->pre_trim; }
+		function setPostTrim($trim = "a") { $this->post_trim = $trim; }
+		function getPostTrim()         { return $this->post_trim; }
 
-		function SetRoot($class = 'block') { $this->root_class = $class; }
-		function SetRootInline()       { $this->root_class = 'inline'; }
-		function SetRootBlock()        { $this->root_class = 'block'; }
-		function GetRoot()             { return $this->root_class; }
+		function setRoot($class = 'block') { $this->root_class = $class; }
+		function setRootInline()       { $this->root_class = 'inline'; }
+		function setRootBlock()        { $this->root_class = 'block'; }
+		function getRoot()             { return $this->root_class; }
 
-		function SetDebug($enable = true) { $this->debug = $enable; }
-		function GetDebug()            { return $this->debug; }
+		function setDebug($enable = true) { $this->debug = $enable; }
+		function getDebug()            { return $this->debug; }
 
-		function SetAllowAmpersand($enable = true) { $this->allow_ampersand = $enable; }
-		function GetAllowAmpersand()   { return $this->allow_ampersand; }
-		function SetTagMarker($marker = '[') { $this->tag_marker = $marker; }
-		function GetTagMarker()        { return $this->tag_marker; }
+		function setAllowAmpersand($enable = true) { $this->allow_ampersand = $enable; }
+		function getAllowAmpersand()   { return $this->allow_ampersand; }
+		function setTagMarker($marker = '[') { $this->tag_marker = $marker; }
+		function getTagMarker()        { return $this->tag_marker; }
 
-		function SetIgnoreNewlines($ignore = true) { $this->ignore_newlines = $ignore; }
-		function GetIgnoreNewlines()   { return $this->ignore_newlines; }
+		function setIgnoreNewlines($ignore = true) { $this->ignore_newlines = $ignore; }
+		function getIgnoreNewlines()   { return $this->ignore_newlines; }
 
-		function SetLimit($limit = 0)  { $this->output_limit = $limit; }
-		function GetLimit()            { return $this->output_limit; }
-		function SetLimitTail($tail = "...") { $this->limit_tail = $tail; }
-		function GetLimitTail()        { return $this->limit_tail; }
-		function SetLimitPrecision($prec = 0.15) { $this->limit_precision = $prec; }
-		function GetLimitPrecision()   { return $this->limit_precision; }
-		function WasLimited()          { return $this->was_limited; }
+		function setLimit($limit = 0)  { $this->output_limit = $limit; }
+		function getLimit()            { return $this->output_limit; }
+		function setLimitTail($tail = "...") { $this->limit_tail = $tail; }
+		function getLimitTail()        { return $this->limit_tail; }
+		function setLimitPrecision($prec = 0.15) { $this->limit_precision = $prec; }
+		function getLimitPrecision()   { return $this->limit_precision; }
+		function wasLimited()          { return $this->was_limited; }
 
-		function SetPlainMode($enable = true) { $this->plain_mode = $enable; }
-		function GetPlainMode()        { return $this->plain_mode; }
+		function setPlainMode($enable = true) { $this->plain_mode = $enable; }
+		function getPlainMode()        { return $this->plain_mode; }
 
-		function SetDetectURLs($enable = true) { $this->detect_urls = $enable; }
-		function GetDetectURLs()       { return $this->detect_urls; }
-		function SetURLPattern($pattern) { $this->url_pattern = $pattern; }
-		function GetURLPattern()       { return $this->url_pattern; }
+		function setDetectURLs($enable = true) { $this->detect_urls = $enable; }
+		function getDetectURLs()       { return $this->detect_urls; }
+		function setURLPattern($pattern) { $this->url_pattern = $pattern; }
+		function getURLPattern()       { return $this->url_pattern; }
 
-		function SetURLTargetable($enable) { $this->url_targetable = $enable; }
-		function GetURLTargetable()    { return $this->url_targetable; }
+		function setURLTargetable($enable) { $this->url_targetable = $enable; }
+		function getURLTargetable()    { return $this->url_targetable; }
 
-		function SetURLTarget($target) { $this->url_target = $target; }
-		function GetURLTarget()        { return $this->url_target; }
+		function setURLTarget($target) { $this->url_target = $target; }
+		function getURLTarget()        { return $this->url_target; }
 
 		//-----------------------------------------------------------------------------
 		// Rule-management:  You can add your own custom tag rules, or use the defaults.
 		// These are basically getter/setter functions that exist for convenience.
 
-		function AddRule($name, $rule) { $this->tag_rules[$name] = $rule; }
-		function RemoveRule($name)     { unset($this->tag_rules[$name]); }
-		function GetRule($name)        { return isset($this->tag_rules[$name])
+		function addRule($name, $rule) { $this->tag_rules[$name] = $rule; }
+		function removeRule($name)     { unset($this->tag_rules[$name]); }
+		function getRule($name)        { return isset($this->tag_rules[$name])
 		                                   ? $this->tag_rules[$name] : false; }
-		function ClearRules()          { $this->tag_rules = []; }
-		function GetDefaultRule($name) { return isset($this->defaults->default_tag_rules[$name])
+		function clearRules()          { $this->tag_rules = []; }
+		function getDefaultRule($name) { return isset($this->defaults->default_tag_rules[$name])
 		                                   ? $this->defaults->default_tag_rules[$name] : false; }
-		function SetDefaultRule($name) { if (isset($this->defaults->default_tag_rules[$name]))
-		                                    $this->AddRule($name, $this->defaults->default_tag_rules[$name]);
-		                                 else $this->RemoveRule($name); }
-		function GetDefaultRules()     { return $this->defaults->default_tag_rules; }
-		function SetDefaultRules()     { $this->tag_rules = $this->defaults->default_tag_rules; }
+		function setDefaultRule($name) { if (isset($this->defaults->default_tag_rules[$name]))
+		                                    $this->addRule($name, $this->defaults->default_tag_rules[$name]);
+		                                 else $this->removeRule($name); }
+		function getDefaultRules()     { return $this->defaults->default_tag_rules; }
+		function setDefaultRules()     { $this->tag_rules = $this->defaults->default_tag_rules; }
 
 		//-----------------------------------------------------------------------------
 		// Handling for [[wiki]] and [[wiki|Wiki]] links and other replaced items.
 		// These are basically getter/setter functions that exist for convenience.
 
-		function SetWikiURL($url)      { $this->wiki_url = $url; }
-		function GetWikiURL($url)      { return $this->wiki_url; }
-		function GetDefaultWikiURL()   { return '/?page='; }
+		function setWikiURL($url)      { $this->wiki_url = $url; }
+		function getWikiURL($url)      { return $this->wiki_url; }
+		function getDefaultWikiURL()   { return '/?page='; }
 
-		function SetLocalImgDir($path) { $this->local_img_dir = $path; }
-		function GetLocalImgDir()      { return $this->local_img_dir; }
-		function GetDefaultLocalImgDir() { return "img"; }
-		function SetLocalImgURL($path) { $this->local_img_url = $path; }
-		function GetLocalImgURL()      { return $this->local_img_url; }
-		function GetDefaultLocalImgURL() { return "img"; }
+		function setLocalImgDir($path) { $this->local_img_dir = $path; }
+		function getLocalImgDir()      { return $this->local_img_dir; }
+		function getDefaultLocalImgDir() { return "img"; }
+		function setLocalImgURL($path) { $this->local_img_url = $path; }
+		function getLocalImgURL()      { return $this->local_img_url; }
+		function getDefaultLocalImgURL() { return "img"; }
 
-		function SetRuleHTML($html)    { $this->rule_html = $html; }
-		function GetRuleHTML()         { return $this->rule_html; }
-		function GetDefaultRuleHTML()  { return "\n<hr class=\"bbcode_rule\" />\n"; }
+		function setRuleHTML($html)    { $this->rule_html = $html; }
+		function getRuleHTML()         { return $this->rule_html; }
+		function getDefaultRuleHTML()  { return "\n<hr class=\"bbcode_rule\" />\n"; }
 
 		//-----------------------------------------------------------------------------
 		// Smiley management.  You can use the default smileys, or add your own.
 		// These are *mostly* getter/setter functions, but they also affect the
 		// caching of the smiley-processing rules.
 
-		function AddSmiley($code, $image) { $this->smileys[$code] = $image; $this->smiley_regex = false; }
-		function RemoveSmiley($code)      { unset($this->smileys[$code]); $this->smiley_regex = false; }
-		function GetSmiley($code)         { return isset($this->smileys[$code])
+		function addSmiley($code, $image) { $this->smileys[$code] = $image; $this->smiley_regex = false; }
+		function removeSmiley($code)      { unset($this->smileys[$code]); $this->smiley_regex = false; }
+		function getSmiley($code)         { return isset($this->smileys[$code])
 		                                      ? $this->smileys[$code] : false; }
-		function ClearSmileys()           { $this->smileys = []; $this->smiley_regex = false; }
+		function clearSmileys()           { $this->smileys = []; $this->smiley_regex = false; }
 
-		function GetDefaultSmiley($code)  { return isset($this->defaults->default_smileys[$code])
+		function getDefaultSmiley($code)  { return isset($this->defaults->default_smileys[$code])
 		                                      ? $this->defaults->default_smileys[$code] : false; }
-		function SetDefaultSmiley($code)  { $this->smileys[$code] = @$this->defaults->default_smileys[$code];
+		function setDefaultSmiley($code)  { $this->smileys[$code] = @$this->defaults->default_smileys[$code];
 		                                     $this->smiley_regex = false; }
-		function GetDefaultSmileys()      { return $this->defaults->default_smileys; }
-		function SetDefaultSmileys()      { $this->smileys = $this->defaults->default_smileys;
+		function getDefaultSmileys()      { return $this->defaults->default_smileys; }
+		function setDefaultSmileys()      { $this->smileys = $this->defaults->default_smileys;
 		                                     $this->smiley_regex = false; }
 
-		function SetSmileyDir($path)      { $this->smiley_dir = $path; }
-		function GetSmileyDir()           { return $this->smiley_dir; }
-		function GetDefaultSmileyDir()    { return "smileys"; }
-		function SetSmileyURL($path)      { $this->smiley_url = $path; }
-		function GetSmileyURL()           { return $this->smiley_url; }
-		function GetDefaultSmileyURL()    { return "smileys"; }
+		function setSmileyDir($path)      { $this->smiley_dir = $path; }
+		function getSmileyDir()           { return $this->smiley_dir; }
+		function getDefaultSmileyDir()    { return "smileys"; }
+		function setSmileyURL($path)      { $this->smiley_url = $path; }
+		function getSmileyURL()           { return $this->smiley_url; }
+		function getDefaultSmileyURL()    { return "smileys"; }
 
-		function SetEnableSmileys($enable = true) { $this->enable_smileys = $enable; }
-		function GetEnableSmileys()       { return $this->enable_smileys; }
+		function setEnableSmileys($enable = true) { $this->enable_smileys = $enable; }
+		function getEnableSmileys()       { return $this->enable_smileys; }
 
 		//-----------------------------------------------------------------------------
 		//  Smiley, URL, and HTML-conversion support routines.
@@ -282,7 +282,7 @@
 		// This function comes straight from the PHP documentation on html_entity_decode,
 		// and performs exactly the same function.  Unlike html_entity_decode, it
 		// works on older versions of PHP (prior to 4.3.0).
-		function UnHTMLEncode($string) {
+		function unHTMLEncode($string) {
 			// Use the (faster!) built-in if it's available.
 			if (function_exists("html_entity_decode"))
 				return html_entity_decode($string);
@@ -316,7 +316,7 @@
 		// trailing _ characters.  So, for example, [[Washington, D.C.]] would become
 		// "Washington_D.C.", safe to pass through a URL or anywhere else.  All characters
 		// in the extended-character range (0x7F-0xFF) will be URL-encoded.
-		function Wikify($string) {
+		function wikify($string) {
 			return rawurlencode(str_replace(" ", "_",
 				trim(preg_replace("/[!?;@#\$%\\^&*<>=+`~\\x00-\\x20_-]+/", " ", $string))));
 		}
@@ -332,7 +332,7 @@
 		//
 		//    mailto : name @ domain
 		//
-		function IsValidURL($string, $email_too = true) {
+		function isValidURL($string, $email_too = true) {
 			// Check for anything that uses http, https, or ftp, with the general
 			// structure being:  protocol :// domain [:port] [/] [any single-line string]
 			// For security reasons, we disallow username/password inclusion in URLs.
@@ -364,7 +364,7 @@
 			// Match mail addresses.
 			if ($email_too)
 				if (substr($string, 0, 7) == "mailto:")
-					return $this->IsValidEmail(substr($string, 7));
+					return $this->isValidEmail(substr($string, 7));
 
 			// Reject all other protocols.
 			return false;
@@ -372,7 +372,7 @@
 
 		// Returns true if the given string is a valid e-mail address.  This allows
 		// everything that RFC821 allows, including e-mail addresses that make no sense.
-		function IsValidEmail($string) {
+		function isValidEmail($string) {
 			$validator = new BBCodeEmailAddressValidator;
 			return $validator->check_email_address($string);
 		/*
@@ -412,7 +412,7 @@
 		//
 		// Note that htmlspecialchars() is still used directly for doing things like
 		// cleaning up URLs in tags; this function is applied to *plain* *text* *only*.
-		function HTMLEncode($string) {
+		function hTMLEncode($string) {
 			if (!$this->allow_ampersand)
 				return htmlspecialchars($string);
 			else return str_replace(['<', '>', '"'],
@@ -423,18 +423,18 @@
 		// Replace < and > and & and " with HTML-safe equivalents, and replace
 		// smileys like :-) with <img /> tags, and replace any embedded URLs
 		// with <a href=...>...</a> links.
-		function FixupOutput($string) {
+		function fixupOutput($string) {
 			global $BBCode_Profiler;
-			$BBCode_Profiler->Begin('FixupOutput');
+			$BBCode_Profiler->begin('FixupOutput');
 
 			if ($this->debug)
 				print "<b>FixupOutput:</b> input: <tt>" . htmlspecialchars($string) . "</tt><br />\n";
 
 			if (!$this->detect_urls) {
 				// Easy case:  No URL-decoding, so don't take the time to do it.
-				$BBCode_Profiler->End('FixupOutput');
-				$output = $this->Internal_ProcessSmileys($string);
-				$BBCode_Profiler->Begin('FixupOutput');
+				$BBCode_Profiler->end('FixupOutput');
+				$output = $this->internal_ProcessSmileys($string);
+				$BBCode_Profiler->begin('FixupOutput');
 			}
 			else {
 				// Extract out any embedded URLs, and then process smileys and such on
@@ -446,15 +446,15 @@
 				// will likely capture those before the smiley decoder ever has a chance
 				// at them.  But then you didn't want a smiley named "foo.com" anyway,
 				// did you?)
-				$chunks = $this->Internal_AutoDetectURLs($string);
+				$chunks = $this->internal_AutoDetectURLs($string);
 				$output = [];
 				if (count($chunks)) {
 					$is_a_url = false;
 					foreach ($chunks as $index => $chunk) {
 						if (!$is_a_url) {
-							$BBCode_Profiler->End('FixupOutput');
-							$chunk = $this->Internal_ProcessSmileys($chunk);
-							$BBCode_Profiler->Begin('FixupOutput');
+							$BBCode_Profiler->end('FixupOutput');
+							$chunk = $this->internal_ProcessSmileys($chunk);
+							$BBCode_Profiler->begin('FixupOutput');
 						}
 						$output[] = $chunk;
 						$is_a_url = !$is_a_url;
@@ -466,7 +466,7 @@
 			if ($this->debug)
 				print "<b>FixupOutput:</b> output: <tt>" . htmlspecialchars($output) . "</tt><br />\n";
 
-			$BBCode_Profiler->End('FixupOutput');
+			$BBCode_Profiler->end('FixupOutput');
 
 			return $output;
 		}
@@ -474,35 +474,35 @@
 		// Go through a string containing plain text and do two things on it:
 		// Replace < and > and & and " with HTML-safe equivalents, and replace
 		// smileys like :-) with <img /> tags.
-		function Internal_ProcessSmileys($string) {
+		function internal_ProcessSmileys($string) {
 			global $BBCode_Profiler;
-			$BBCode_Profiler->Begin('ProcessSmileys:other');
+			$BBCode_Profiler->begin('ProcessSmileys:other');
 
 			if (!$this->enable_smileys || $this->plain_mode) {
 				// If smileys are turned off, don't convert them.
-				$output = $this->HTMLEncode($string);
+				$output = $this->hTMLEncode($string);
 			}
 			else {
 				// If the smileys need to be computed, process them now.
 				if ($this->smiley_regex === false) {
-					$BBCode_Profiler->End('ProcessSmileys:other');
-					$BBCode_Profiler->Begin('ProcessSmileys:rebuild');
-					$this->Internal_RebuildSmileys();
-					$BBCode_Profiler->End('ProcessSmileys:rebuild');
-					$BBCode_Profiler->Begin('ProcessSmileys:other');
+					$BBCode_Profiler->end('ProcessSmileys:other');
+					$BBCode_Profiler->begin('ProcessSmileys:rebuild');
+					$this->internal_RebuildSmileys();
+					$BBCode_Profiler->end('ProcessSmileys:rebuild');
+					$BBCode_Profiler->begin('ProcessSmileys:other');
 				}
 
 				// Split the string so that it consists of alternating pairs of smileys and non-smileys.
-				$BBCode_Profiler->End('ProcessSmileys:other');
-				$BBCode_Profiler->Begin('ProcessSmileys:split');
+				$BBCode_Profiler->end('ProcessSmileys:other');
+				$BBCode_Profiler->begin('ProcessSmileys:split');
 				$tokens = preg_split($this->smiley_regex, $string, -1, PREG_SPLIT_DELIM_CAPTURE);
-				$BBCode_Profiler->End('ProcessSmileys:split');
-				$BBCode_Profiler->Begin('ProcessSmileys:other');
+				$BBCode_Profiler->end('ProcessSmileys:split');
+				$BBCode_Profiler->begin('ProcessSmileys:other');
 
 				if (count($tokens) <= 1) {
 					// Special (common) case:  This skips the smiley constructor if there
 					// were no smileys found, which is most of the time.
-					$output = $this->HTMLEncode($string);
+					$output = $this->hTMLEncode($string);
 				}
 				else {
 					$output = "";
@@ -510,7 +510,7 @@
 					foreach ($tokens as $token) {
 						if (!$is_a_smiley) {
 							// For non-smiley text, we just pass it through htmlspecialchars.
-							$output .= $this->HTMLEncode($token);
+							$output .= $this->hTMLEncode($token);
 						}
 						else {
 							if (isset($this->smiley_info[$token])) {
@@ -531,15 +531,15 @@
 				}
 			}
 
-			$BBCode_Profiler->End('ProcessSmileys:other');
+			$BBCode_Profiler->end('ProcessSmileys:other');
 
 			return $output;
 		}
 
-		function Internal_RebuildSmileys() {
+		function internal_RebuildSmileys() {
 			// Construct the $this->smiley_regex that can recognize all
 			// of the smileys.  This will save us a lot of computation time
-			// in $this->Parse() if multiple BBCode strings are being
+			// in $this->parse() if multiple BBCode strings are being
 			// processed by the same script.
 			$regex = ["/(?<![\\w])("];
 			$first = true;
@@ -577,9 +577,9 @@
 		//
 		// Note that the input string is plain text, not HTML or BBCode.  The return value
 		// must be an array of alternating pairs of plain text (even indexes) and HTML (odd indexes).
-		function Internal_AutoDetectURLs($string) {
+		function internal_AutoDetectURLs($string) {
 			global $BBCode_Profiler;
-			$BBCode_Profiler->Begin('AutoDetectURLs');
+			$BBCode_Profiler->begin('AutoDetectURLs');
 
 			$output = preg_split("/( (?:
 					(?:https?|ftp) : \\/*
@@ -659,14 +659,14 @@
 						$params['url'] = $url;
 						$params['link'] = $url;
 						$params['text'] = $token;
-						$output[$index] = $this->FillTemplate($this->url_pattern, $params);
+						$output[$index] = $this->fillTemplate($this->url_pattern, $params);
 					}
 
 					$is_a_url = !$is_a_url;
 				}
 			}
 
-			$BBCode_Profiler->End('AutoDetectURLs');
+			$BBCode_Profiler->end('AutoDetectURLs');
 
 			return $output;
 		}
@@ -691,14 +691,14 @@
 		//   w - Clean up whitespace.  This causes all non-newline whitespace, such as
 		//        control codes and tabs, to be collapsed into individual space characters.
 		//
-		//   e - Apply HTMLEncode().
+		//   e - Apply hTMLEncode().
 		//   h - Apply htmlspecialchars().
-		//   k - Apply Wikify().
+		//   k - Apply wikify().
 		//   u - Apply urlencode().
 		//
 		// Note that only one of the e, h, k, or u "formatting flags" may be specified;
 		// these flags are mutually-exclusive.
-		function FillTemplate($template, $insert_array, $default_array = []) {
+		function fillTemplate($template, $insert_array, $default_array = []) {
 			$pieces = preg_split('/(\{\$[a-zA-Z0-9_.:\/-]+\})/', $template,
 				-1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -766,8 +766,8 @@
 							$value = preg_replace("/[\\x00-\\x09\\x0B-\x0C\x0E-\\x20]+/", " ", $value);
 						if      (isset($flags['t'])) $value = trim($value);
 						if      (isset($flags['b'])) $value = basename($value);
-						if      (isset($flags['e'])) $value = $this->HTMLEncode($value);
-						else if (isset($flags['k'])) $value = $this->Wikify($value);
+						if      (isset($flags['e'])) $value = $this->hTMLEncode($value);
+						else if (isset($flags['k'])) $value = $this->wikify($value);
 						else if (isset($flags['h'])) $value = htmlspecialchars($value);
 						else if (isset($flags['u'])) $value = urlencode($value);
 						if      (isset($flags['n'])) $value = $this->nl2br($value);
@@ -794,9 +794,9 @@
 		// Collect a series of text strings from a token stack and return them as a
 		// single string.  We use output buffering because it seems to produce slightly
 		// more efficient string concatenation.
-		function Internal_CollectText($array, $start = 0) {
+		function internal_CollectText($array, $start = 0) {
 			global $BBCode_Profiler;
-			$BBCode_Profiler->Begin('CollectText');
+			$BBCode_Profiler->begin('CollectText');
 
 			ob_start();
 			for ($start = intval($start), $end = count($array); $start < $end; $start++)
@@ -804,13 +804,13 @@
 			$output = ob_get_contents();
 			ob_end_clean();
 
-			$BBCode_Profiler->End('CollectText');
+			$BBCode_Profiler->end('CollectText');
 
 			return $output;
 		}
-		function Internal_CollectTextReverse($array, $start = 0, $end = 0) {
+		function internal_CollectTextReverse($array, $start = 0, $end = 0) {
 			global $BBCode_Profiler;
-			$BBCode_Profiler->Begin('CollectTextReverse');
+			$BBCode_Profiler->begin('CollectTextReverse');
 
 			ob_start();
 			for ($start = intval($start); $start >= $end; $start--)
@@ -818,7 +818,7 @@
 			$output = ob_get_contents();
 			ob_end_clean();
 
-			$BBCode_Profiler->End('CollectTextReverse');
+			$BBCode_Profiler->end('CollectTextReverse');
 
 			return $output;
 		}
@@ -829,15 +829,15 @@
 		// they're not to be outputted as plain text:  They're fully legit, and
 		// need to be processed with the plain text after them as their body.
 		// This returns a list of tokens in the REVERSE of output order.
-		function Internal_GenerateOutput($pos) {
+		function internal_GenerateOutput($pos) {
 			global $BBCode_Profiler;
-			$BBCode_Profiler->Begin('GenerateOutput');
+			$BBCode_Profiler->begin('GenerateOutput');
 
 			if ($this->debug) {
 				print "<b>Internal_GenerateOutput:</b> from=$pos len=" . (count($this->stack) - $pos)
 					. "<br />\n"
 					. "<b>Internal_GenerateOutput:</b> Stack contents: <tt>"
-					. $this->Internal_DumpStack() . "</tt><br />\n";
+					. $this->internal_DumpStack() . "</tt><br />\n";
 			}
 			$output = [];
 			while (count($this->stack) > $pos) {
@@ -893,23 +893,23 @@
 						if ($end_tag == BBCODE_REQUIRED)
 							@$this->lost_start_tags[$name] += 1;
 
-						$end = $this->Internal_CleanupWSByIteratingPointer(@$rule['before_endtag'], 0, $output);
-						$this->Internal_CleanupWSByPoppingStack(@$rule['after_tag'], $output);
-						$tag_body = $this->Internal_CollectTextReverse($output, count($output)-1, $end);
+						$end = $this->internal_CleanupWSByIteratingPointer(@$rule['before_endtag'], 0, $output);
+						$this->internal_CleanupWSByPoppingStack(@$rule['after_tag'], $output);
+						$tag_body = $this->internal_CollectTextReverse($output, count($output)-1, $end);
 
 						// Note:  We don't process 'after_endtag' because the invisible end tag
 						// always butts up against another tag, so there's *never* any whitespace
 						// after it.  Attempting to process 'after_endtag' would just be a waste
 						// of time because it'd never match.  But 'before_tag' is useful, though.
-						$this->Internal_CleanupWSByPoppingStack(@$rule['before_tag'], $this->stack);
+						$this->internal_CleanupWSByPoppingStack(@$rule['before_tag'], $this->stack);
 
 						if ($this->debug) {
 							print "<b>Internal_GenerateOutput:</b> optional-tag's content: <tt>"
 								. htmlspecialchars($tag_body) . "</tt><br />\n";
 						}
 
-						$this->Internal_UpdateParamsForMissingEndTag(@$token[BBCODE_STACK_TAG]);
-						$tag_output = $this->DoTag(BBCODE_OUTPUT, $name,
+						$this->internal_UpdateParamsForMissingEndTag(@$token[BBCODE_STACK_TAG]);
+						$tag_output = $this->doTag(BBCODE_OUTPUT, $name,
 							@$token[BBCODE_STACK_TAG]['_default'], @$token[BBCODE_STACK_TAG], $tag_body);
 
 						if ($this->debug) {
@@ -928,13 +928,13 @@
 			}
 			if ($this->debug) {
 				print "<b>Internal_GenerateOutput:</b> done; output contains " . count($output) . " items: <tt>"
-					. $this->Internal_DumpStack($output) . "</tt><br />\n";
-				$noutput = $this->Internal_CollectTextReverse($output, count($output) - 1);
+					. $this->internal_DumpStack($output) . "</tt><br />\n";
+				$noutput = $this->internal_CollectTextReverse($output, count($output) - 1);
 				print "<b>Internal_GenerateOutput:</b> output: <tt>" . htmlspecialchars($noutput) . "</tt><br />\n";
-				print "<b>Internal_GenerateOutput:</b> Stack contents: <tt>" . $this->Internal_DumpStack() . "</tt><br />\n";
+				print "<b>Internal_GenerateOutput:</b> Stack contents: <tt>" . $this->internal_DumpStack() . "</tt><br />\n";
 			}
-			$this->Internal_ComputeCurrentClass();
-			$BBCode_Profiler->End('GenerateOutput');
+			$this->internal_ComputeCurrentClass();
+			$BBCode_Profiler->end('GenerateOutput');
 			return $output;
 		}
 
@@ -951,7 +951,7 @@
 		//
 		// This returns true if the stack could be rewound to a safe state, or false
 		// if no such "safe state" existed.
-		function Internal_RewindToClass($class_list) {
+		function internal_RewindToClass($class_list) {
 			if ($this->debug) {
 				print "<b>Internal_RewindToClass:</b> stack has " . count($this->stack)
 					. " items; allowed classes are: <tt>";
@@ -975,7 +975,7 @@
 			// Convert any tags on the stack from $pos+1 to the top, inclusive, to
 			// plain text tokens, possibly processing any tags where the end tags
 			// are optional.
-			$output = $this->Internal_GenerateOutput($pos+1);
+			$output = $this->internal_GenerateOutput($pos+1);
 
 			// Push the clean tokens back onto the stack.
 			while (count($output)) {
@@ -994,7 +994,7 @@
 
 		// We've found an end tag with the given name, so walk backward until we
 		// find the start tag, and then output the contents.
-		function Internal_FinishTag($tag_name) {
+		function internal_FinishTag($tag_name) {
 			if ($this->debug) {
 				print "<b>Internal_FinishTag:</b> stack has " . count($this->stack)
 					. " items; searching for start tag for <tt>[/"
@@ -1012,8 +1012,8 @@
 			// need to search:  We already know where the start tag is.  So we look up
 			// the location of the start tag and rewind right to that spot.  This is really
 			// only a constant-time speedup, since in the non-degenerate cases,
-			// Internal_FinishTag() still runs in O(n) time.  (Internal_GenerateOutput()
-			// runs in O(n) time, and Internal_FinishTag() calls it.  But in the degenerate
+			// internal_FinishTag() still runs in o(n) time.  (internal_GenerateOutput()
+			// runs in o(n) time, and internal_FinishTag() calls it.  But in the degenerate
 			// case, where there's an end tag with no start tag, this is significantly
 			// faster, for whatever that's worth.)  But even a constant-time speedup is a
 			// speedup, so this is overall a win.
@@ -1034,7 +1034,7 @@
 			// do end-tag cleanup by popping, and we do start-tag cleanup by skipping
 			// $pos forward.  (We add one because we've actually rewound the stack
 			// to the start tag itself.)
-			$newpos = $this->Internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['after_tag'],
+			$newpos = $this->internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['after_tag'],
 				$pos+1, $this->stack);
 			$delta = $newpos - ($pos+1);
 
@@ -1047,12 +1047,12 @@
 			// Output everything on the stack from $pos to the top, inclusive, as
 			// plain text, and then return it as a string, leaving the start tag on
 			// the top of the stack.
-			$output = $this->Internal_GenerateOutput($newpos);
+			$output = $this->internal_GenerateOutput($newpos);
 
 			// Clean off any whitespace before the end tag that doesn't belong there.
-			$newend = $this->Internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['before_endtag'],
+			$newend = $this->internal_CleanupWSByIteratingPointer(@$this->tag_rules[$tag_name]['before_endtag'],
 				0, $output);
-			$output = $this->Internal_CollectTextReverse($output, count($output) - 1, $newend);
+			$output = $this->internal_CollectTextReverse($output, count($output) - 1, $newend);
 
 			if ($this->debug)
 				print "<b>Internal_FinishTag:</b> whitespace cleanup: popping $delta items<br />\n";
@@ -1060,7 +1060,7 @@
 			// Clean up any 'after_tag' whitespace we skipped.
 			while ($delta-- > 0)
 				array_pop($this->stack);
-			$this->Internal_ComputeCurrentClass();
+			$this->internal_ComputeCurrentClass();
 
 			if ($this->debug)
 				print "<b>Internal_FinishTag:</b> output: <tt>" . htmlspecialchars($output) . "</tt><br />\n";
@@ -1069,7 +1069,7 @@
 		}
 
 		// Recompute the current class, based on the class of the stack's top element.
-		function Internal_ComputeCurrentClass() {
+		function internal_ComputeCurrentClass() {
 			if (count($this->stack) > 0)
 				$this->current_class = $this->stack[count($this->stack)-1][BBCODE_STACK_CLASS];
 			else $this->current_class = $this->root_class;
@@ -1081,7 +1081,7 @@
 
 		// Given a stack of tokens in $array, write it to a string (possibly with HTML
 		// color and style encodings for readability, if $raw is false).
-		function Internal_DumpStack($array = false, $raw = false) {
+		function internal_DumpStack($array = false, $raw = false) {
 			if (!$raw) $string = "<span style='color: #00C;'>";
 			else $string = "";
 			if ($array === false)
@@ -1114,7 +1114,7 @@
 
 		// Walk down from the top of the stack, and remove whitespace/newline tokens from
 		// the top according to the rules in the given pattern.
-		function Internal_CleanupWSByPoppingStack($pattern, &$array) {
+		function internal_CleanupWSByPoppingStack($pattern, &$array) {
 			if ($this->debug) {
 				print "<b>Internal_CleanupWSByPoppingStack:</b> array has " . count($array)
 					. " items; pattern=\"<tt>"
@@ -1145,19 +1145,19 @@
 
 			if ($this->debug) {
 				print "<b>Internal_CleanupWSByPoppingStack:</b> array now has " . count($array) . " items<br />\n";
-				print "<b>Internal_CleanupWSByPoppingStack:</b> array: <tt>" . $this->Internal_DumpStack($array)
+				print "<b>Internal_CleanupWSByPoppingStack:</b> array: <tt>" . $this->internal_DumpStack($array)
 					. "</tt><br />\n";
 			}
 
 			if (count($array) != $oldlen) {
 				// We only recompute the class if something actually changed.
-				$this->Internal_ComputeCurrentClass();
+				$this->internal_ComputeCurrentClass();
 			}
 		}
 
 		// Read tokens from the input, and remove whitespace/newline tokens from the input
 		// according to the rules in the given pattern.
-		function Internal_CleanupWSByEatingInput($pattern) {
+		function internal_CleanupWSByEatingInput($pattern) {
 			global $BBCode_Profiler;
 
 			if ($this->debug) {
@@ -1171,33 +1171,33 @@
 			foreach (str_split($pattern) as $char) {
 				switch ($char) {
 				case 's':
-					$BBCode_Profiler->Begin('Lexer:NextToken');
-					$token_type = $this->lexer->NextToken();
-					$BBCode_Profiler->End('Lexer:NextToken');
+					$BBCode_Profiler->begin('Lexer:NextToken');
+					$token_type = $this->lexer->nextToken();
+					$BBCode_Profiler->end('Lexer:NextToken');
 					while ($token_type == BBCODE_WS) {
-						$BBCode_Profiler->Begin('Lexer:NextToken');
-						$token_type = $this->lexer->NextToken();
-						$BBCode_Profiler->End('Lexer:NextToken');
+						$BBCode_Profiler->begin('Lexer:NextToken');
+						$token_type = $this->lexer->nextToken();
+						$BBCode_Profiler->end('Lexer:NextToken');
 					}
-					$this->lexer->UngetToken();
+					$this->lexer->ungetToken();
 					break;
 				case 'n':
-					$BBCode_Profiler->Begin('Lexer:NextToken');
-					$token_type = $this->lexer->NextToken();
-					$BBCode_Profiler->End('Lexer:NextToken');
+					$BBCode_Profiler->begin('Lexer:NextToken');
+					$token_type = $this->lexer->nextToken();
+					$BBCode_Profiler->end('Lexer:NextToken');
 					if ($token_type != BBCODE_NL)
-						$this->lexer->UngetToken();
+						$this->lexer->ungetToken();
 					break;
 				case 'a':
-					$BBCode_Profiler->Begin('Lexer:NextToken');
-					$token_type = $this->lexer->NextToken();
-					$BBCode_Profiler->End('Lexer:NextToken');
+					$BBCode_Profiler->begin('Lexer:NextToken');
+					$token_type = $this->lexer->nextToken();
+					$BBCode_Profiler->end('Lexer:NextToken');
 					while ($token_type == BBCODE_WS || $token_type == BBCODE_NL) {
-						$BBCode_Profiler->Begin('Lexer:NextToken');
-						$token_type = $this->lexer->NextToken();
-						$BBCode_Profiler->End('Lexer:NextToken');
+						$BBCode_Profiler->begin('Lexer:NextToken');
+						$token_type = $this->lexer->nextToken();
+						$BBCode_Profiler->end('Lexer:NextToken');
 					}
-					$this->lexer->UngetToken();
+					$this->lexer->ungetToken();
 					break;
 				}
 			}
@@ -1208,7 +1208,7 @@
 
 		// Read tokens from the given position in the stack, going forward as we match
 		// the rules in the given pattern.  Returns the first position *after* the pattern.
-		function Internal_CleanupWSByIteratingPointer($pattern, $pos, $array) {
+		function internal_CleanupWSByIteratingPointer($pattern, $pos, $array) {
 			if ($this->debug) {
 				print "<b>Internal_CleanupWSByIteratingPointer:</b> pointer is $pos; pattern=\"<tt>"
 					. htmlspecialchars($pattern) . "</tt>\"<br />\n";
@@ -1236,7 +1236,7 @@
 			if ($this->debug) {
 				print "<b>Internal_CleanupWSByIteratingPointer:</b> pointer is now $pos<br />\n"
 					. "<b>Internal_CleanupWSByIteratingPointer:</b> array: <tt>"
-					. $this->Internal_DumpStack($array) . "</tt><br />\n";
+					. $this->internal_DumpStack($array) . "</tt><br />\n";
 			}
 			return $pos;
 		}
@@ -1244,7 +1244,7 @@
 		// We have a string that's too long, so chop it off at a suitable break so that it's
 		// no longer than $limit characters, if at all possible (if there's nowhere to break
 		// before that, we just chop at $limit).
-		function Internal_LimitText($string, $limit) {
+		function internal_LimitText($string, $limit) {
 			if ($this->debug) {
 				print "<b>Internal_LimitText:</b> chopping string of length "
 					. strlen($string) . " at $limit.<br />\n";
@@ -1264,8 +1264,8 @@
 
 		// If we've reached the text limit, clean up the stack, push the limit tail,
 		// set the we-hit-the-limit flag, and return.
-		function Internal_DoLimit() {
-			$this->Internal_CleanupWSByPoppingStack("a", $this->stack);
+		function internal_DoLimit() {
+			$this->internal_CleanupWSByPoppingStack("a", $this->stack);
 
 			if (strlen($this->limit_tail) > 0) {
 				$this->stack[] = [
@@ -1296,7 +1296,7 @@
 		//        This value has NOT been passed through htmlspecialchars().
 		//
 		//   $params is an array of key => value parameters associated with the tag; for example,
-		//        in [smiley src=smile alt=:-)], it's Array('src' => "smile", 'alt' => ":-)").
+		//        in [smiley src=smile alt=:-)], it's array('src' => "smile", 'alt' => ":-)").
 		//        These keys and values have NOT beel passed through htmlspecialchars().
 		//
 		//   $contents is the body of the tag during BBCODE_OUTPUT.  For example, in
@@ -1305,7 +1305,7 @@
 		// For BBCODE_CHECK, this must return true (if the tag definition is valid) or false
 		// (if the tag definition is not valid); for BBCODE_OUTPUT, this function must return
 		// HTML output.
-		function DoTag($action, $tag_name, $default_value, $params, $contents) {
+		function doTag($action, $tag_name, $default_value, $params, $contents) {
 			$tag_rule = @$this->tag_rules[$tag_name];
 
 			switch ($action) {
@@ -1426,7 +1426,7 @@
 						foreach ($tag_rule['plain_link'] as $possible_content) {
 							if ($possible_content == '_content'
 								&& strlen($contents) > 0) {
-								$link = $this->UnHTMLEncode(strip_tags($contents));
+								$link = $this->unHTMLEncode(strip_tags($contents));
 								break;
 							}
 							if (isset($params[$possible_content])
@@ -1439,8 +1439,8 @@
 						if (!is_array($params)) $params = [];
 						$params['link'] = $link;
 						$params['url'] = $link;
-						$start = $this->FillTemplate($start, $params);
-						$end = $this->FillTemplate($end, $params);
+						$start = $this->fillTemplate($start, $params);
+						$end = $this->fillTemplate($end, $params);
 					}
 
 					// Construct the plain output using the available content.
@@ -1455,7 +1455,7 @@
 					break;
 
 				case BBCODE_MODE_ENHANCED:
-					$result = $this->Internal_DoEnhancedTag($tag_rule, $params, $contents);
+					$result = $this->internal_DoEnhancedTag($tag_rule, $params, $contents);
 					break;
 
 				case BBCODE_MODE_INTERNAL:
@@ -1496,14 +1496,14 @@
 		// default value, '_name' for its name, and '_content' for its contents (body).
 		// Note that in enhanced mode, the tag parameters' keys must match [a-zA-Z0-9_:-]+,
 		// that is, alphanumeric, with underscore, colon, or hyphen.
-		function Internal_DoEnhancedTag($tag_rule, $params, $contents) {
+		function internal_DoEnhancedTag($tag_rule, $params, $contents) {
 
 			// Set up the special "_content" and "_defaultcontent" parameters.
 			$params['_content'] = $contents;
 			$params['_defaultcontent'] = strlen(@$params['_default']) ? $params['_default'] : $contents;
 
 			// Now use common template-formatting logic.
-			return $this->FillTemplate(@$tag_rule['template'], $params, @$tag_rule['default']);
+			return $this->fillTemplate(@$tag_rule['template'], $params, @$tag_rule['default']);
 		}
 
 		//-----------------------------------------------------------------------------
@@ -1512,7 +1512,7 @@
 		// If an end-tag is required/optional but missing, we simulate it here so that the
 		// rule handlers still see a valid '_endtag' parameter.  This way, all rules always
 		// see valid '_endtag' parameters except for rules for isolated tags.
-		function Internal_UpdateParamsForMissingEndTag(&$params) {
+		function internal_UpdateParamsForMissingEndTag(&$params) {
 			switch ($this->tag_marker) {
 			case '[': $tail_marker = ']'; break;
 			case '<': $tail_marker = '>'; break;
@@ -1524,7 +1524,7 @@
 		}
 
 		// Process an isolated tag, a tag that is not allowed to have an end tag.
-		function Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule) {
+		function internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule) {
 			if ($this->debug) {
 				print "<b>ProcessIsolatedTag:</b> tag <tt>[" . htmlspecialchars($tag_name)
 					. "]</tt> is isolated: no end tag allowed, so processing immediately.<br />\n";
@@ -1532,23 +1532,23 @@
 
 			// Ask this tag if its attributes are valid; this gives the tag
 			// the option to say, no, I'm broken, don't try to process me.
-			if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
+			if (!$this->doTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
 				if ($this->debug) {
 					print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars($tag_name)
 						. "]</tt> rejected its parameters; outputting as text after fixup.<br />\n";
 				}
 				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
-					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+					BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
 				];
 				return;
 			}
 
-			$this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
-			$output = $this->DoTag(BBCODE_OUTPUT, $tag_name, @$tag_params['_default'], $tag_params, "");
-			$this->Internal_CleanupWSByEatingInput(@$tag_rule['after_tag']);
+			$this->internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
+			$output = $this->doTag(BBCODE_OUTPUT, $tag_name, @$tag_params['_default'], $tag_params, "");
+			$this->internal_CleanupWSByEatingInput(@$tag_rule['after_tag']);
 
 			if ($this->debug) {
 				print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars($tag_name)
@@ -1564,14 +1564,14 @@
 		}
 
 		// Process a verbatim tag, a tag whose contents (body) must not be processed at all.
-		function Internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule) {
+		function internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule) {
 
 			// This tag is a special type that disallows all other formatting
 			// tags within it and wants its contents reproduced verbatim until
 			// its matching end tag.  We save the state of the lexer in case
 			// we can't find an end tag, in which case we'll have to reject the
 			// start tag as broken.
-			$state = $this->lexer->SaveState();
+			$state = $this->lexer->saveState();
 
 			$end_tag = $this->lexer->tagmarker . "/" . $tag_name . $this->lexer->end_tagmarker;
 
@@ -1583,7 +1583,7 @@
 			// Push tokens until we find a matching end tag or end-of-input.
 			$start = count($this->stack);
 			$this->lexer->verbatim = true;
-			while (($token_type = $this->lexer->NextToken()) != BBCODE_EOI) {
+			while (($token_type = $this->lexer->nextToken()) != BBCODE_EOI) {
 				if ($this->lexer->text == $end_tag) {
 					// Found the end tag, so we're done.
 					$end_tag_params = $this->lexer->tag;
@@ -1598,18 +1598,18 @@
 				// boundary, add as much as we can, and then abort.
 				if ($this->output_limit > 0
 					&& $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-					$text = $this->Internal_LimitText($this->lexer->text,
+					$text = $this->internal_LimitText($this->lexer->text,
 						$this->output_limit - $this->text_length);
 					if (strlen($text) > 0) {
 						$this->text_length += strlen($text);
 						$this->stack[] = [
 							BBCODE_STACK_TOKEN => BBCODE_TEXT,
-							BBCODE_STACK_TEXT => $this->FixupOutput($text),
+							BBCODE_STACK_TEXT => $this->fixupOutput($text),
 							BBCODE_STACK_TAG => false,
 							BBCODE_STACK_CLASS => $this->current_class,
 						];
 					}
-					$this->Internal_DoLimit();
+					$this->internal_DoLimit();
 					break;
 				}
 				$this->text_length += strlen($this->lexer->text);
@@ -1632,10 +1632,10 @@
 					print "<b>Internal_ProcessVerbatimTag:</b> no end tag; reached EOI, so rewind"
 						. " and push start tag as text after fixup.<br />\n";
 				}
-				$this->lexer->RestoreState($state);
+				$this->lexer->restoreState($state);
 				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
-					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+					BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
 				];
@@ -1646,23 +1646,23 @@
 				print "<b>Internal_ProcessVerbatimTag:</b> found end tag.<br />\n";
 
 			// Clean up whitespace everywhere except before the start tag.
-			$newstart = $this->Internal_CleanupWSByIteratingPointer(@$tag_rule['after_tag'], $start, $this->stack);
-			$this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_endtag'], $this->stack);
-			$this->Internal_CleanupWSByEatingInput(@$tag_rule['after_endtag']);
+			$newstart = $this->internal_CleanupWSByIteratingPointer(@$tag_rule['after_tag'], $start, $this->stack);
+			$this->internal_CleanupWSByPoppingStack(@$tag_rule['before_endtag'], $this->stack);
+			$this->internal_CleanupWSByEatingInput(@$tag_rule['after_endtag']);
 
 			// Collect the output from $newstart to the top of the stack, and then
 			// quickly pop off all of those tokens.
-			$content = $this->Internal_CollectText($this->stack, $newstart);
+			$content = $this->internal_CollectText($this->stack, $newstart);
 			if ($this->debug) {
 				print "<b>Internal_ProcessVerbatimTag:</b> removing stack elements starting at $start (stack has "
 					. count($this->stack) . " elements).<br />\n";
 			}
 			array_splice($this->stack, $start);
-			$this->Internal_ComputeCurrentClass();
+			$this->internal_ComputeCurrentClass();
 
 			// Clean up whitespace before the start tag (the tag was never pushed
 			// onto the stack itself, so we don't need to remove it).
-			$this->Internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
+			$this->internal_CleanupWSByPoppingStack(@$tag_rule['before_tag'], $this->stack);
 
 			// Found the end tag, so process this tag immediately with
 			// the contents collected between them.  Note that we do NOT
@@ -1671,7 +1671,7 @@
 			// verbatim contents, so they're going to get it.
 			$tag_params['_endtag'] = $end_tag_params['_tag'];
 			$tag_params['_hasend'] = true;
-			$output = $this->DoTag(BBCODE_OUTPUT, $tag_name,
+			$output = $this->doTag(BBCODE_OUTPUT, $tag_name,
 				@$tag_params['_default'], $tag_params, $content);
 
 			if ($this->debug) {
@@ -1689,7 +1689,7 @@
 		}
 
 		// Called when the parser has read a BBCODE_TAG token.
-		function Internal_ParseStartTagToken() {
+		function internal_ParseStartTagToken() {
 
 			// Tags are somewhat complicated, because they have to do several things
 			// all at once.  First, let's look up what we know about the tag we've
@@ -1711,7 +1711,7 @@
 				// though it was plain text.
 				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
-					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+					BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
 				];
@@ -1731,14 +1731,14 @@
 						. "]</tt> is disallowed inside class <tt>" . htmlspecialchars($this->current_class)
 						. "</tt>; rewinding stack to a safe class.<br />\n";
 				}
-				if (!$this->Internal_RewindToClass($allow_in)) {
+				if (!$this->internal_RewindToClass($allow_in)) {
 					if ($this->debug) {
 						print "<b>Internal_ParseStartTagToken:</b> no safe class exists; rejecting"
 							. " this tag as text after fixup.<br />\n";
 					}
 					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_TEXT,
-						BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+						BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
 					];
@@ -1755,7 +1755,7 @@
 
 			if ($end_tag == BBCODE_PROHIBIT) {
 				// No end tag, so process this tag RIGHT NOW.
-				$this->Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule);
+				$this->internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule);
 				return;
 			}
 
@@ -1769,14 +1769,14 @@
 
 			// Ask this tag if its attributes are valid; this gives the tag the option
 			// to say, no, I'm broken, don't try to process me.
-			if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
+			if (!$this->doTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
 				if ($this->debug) {
 					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars($tag_name)
 						. "]</tt> rejected its parameters; outputting as text after fixup.<br />\n";
 				}
 				$this->stack[] = [
 					BBCODE_STACK_TOKEN => BBCODE_TEXT,
-					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+					BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 					BBCODE_STACK_TAG => false,
 					BBCODE_STACK_CLASS => $this->current_class,
 				];
@@ -1786,7 +1786,7 @@
 			if (@$tag_rule['content'] == BBCODE_VERBATIM) {
 				// Verbatim tags have to be handled specially, since they consume successive
 				// input immediately.
-				$this->Internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule);
+				$this->internal_ProcessVerbatimTag($tag_name, $tag_params, $tag_rule);
 				return;
 			}
 
@@ -1806,7 +1806,7 @@
 
 			$this->stack[] = [
 				BBCODE_STACK_TOKEN => $this->lexer->token,
-				BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+				BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 				BBCODE_STACK_TAG => $this->lexer->tag,
 				BBCODE_STACK_CLASS => ($this->current_class = $newclass),
 			];
@@ -1817,7 +1817,7 @@
 		}
 
 		// Called when the parser has read a BBCODE_ENDTAG token.
-		function Internal_ParseEndTagToken() {
+		function internal_ParseEndTagToken() {
 
 			$tag_params = $this->lexer->tag;
 			$tag_name = @$tag_params['_name'];
@@ -1830,7 +1830,7 @@
 			// start tag for it anywhere.  If we find one, we pack everything between
 			// them as output HTML, and then have the tag format itself with that
 			// content.
-			$contents = $this->Internal_FinishTag($tag_name);
+			$contents = $this->internal_FinishTag($tag_name);
 			if ($contents === false) {
 				// There's no start tag for this --- unless there was and it was in a bad
 				// place.  If there's a start tag we can't reach, then swallow this end tag;
@@ -1845,7 +1845,7 @@
 				else {
 					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_TEXT,
-						BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+						BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
 					];
@@ -1859,14 +1859,14 @@
 			// done when the tag was pushed onto the stack.
 			$start_tag_node = array_pop($this->stack);
 			$start_tag_params = $start_tag_node[BBCODE_STACK_TAG];
-			$this->Internal_ComputeCurrentClass();
+			$this->internal_ComputeCurrentClass();
 
-			$this->Internal_CleanupWSByPoppingStack(@$this->tag_rules[$tag_name]['before_tag'], $this->stack);
+			$this->internal_CleanupWSByPoppingStack(@$this->tag_rules[$tag_name]['before_tag'], $this->stack);
 			$start_tag_params['_endtag'] = $tag_params['_tag'];
 			$start_tag_params['_hasend'] = true;
-			$output = $this->DoTag(BBCODE_OUTPUT, $tag_name, @$start_tag_params['_default'],
+			$output = $this->doTag(BBCODE_OUTPUT, $tag_name, @$start_tag_params['_default'],
 				$start_tag_params, $contents);
-			$this->Internal_CleanupWSByEatingInput(@$this->tag_rules[$tag_name]['after_endtag']);
+			$this->internal_CleanupWSByEatingInput(@$this->tag_rules[$tag_name]['after_endtag']);
 
 			if ($this->debug) {
 				print "<b>Internal_ParseEndTagToken:</b> end tag <tt>[/"
@@ -1886,11 +1886,11 @@
 		//  Core parser.  This is where all the magic begins and ends.
 
 		// Core parsing routine.  Call with a BBCode string, and it returns an HTML string.
-		function Parse($string) {
+		function parse($string) {
 			global $BBCode_Profiler;
 
 			$BBCode_Profiler = new BBCode_Profiler;
-			$BBCode_Profiler->Begin('_Parse');
+			$BBCode_Profiler->begin('_Parse');
 
 			if ($this->debug) {
 				print "<b>Parse Begin:</b> input string is " . strlen($string) . " characters long:<br />\n"
@@ -1898,7 +1898,7 @@
 					. "</tt><br />\n";
 			}
 
-			$BBCode_Profiler->Begin('Lexer:Split');
+			$BBCode_Profiler->begin('Lexer:Split');
 
 			// The lexer is responsible for converting individual characters to tokens,
 			// and uses preg_split to do most of its magic.  Because it uses preg_split
@@ -1908,7 +1908,7 @@
 			$this->lexer = new BBCodeLexer($string, $this->tag_marker);
 			$this->lexer->debug = $this->debug;
 
-			$BBCode_Profiler->End('Lexer:Split');
+			$BBCode_Profiler->end('Lexer:Split');
 
 			// If we're fuzzily limiting the text length, see if we need to actually
 			// cut it off, or if it's close enough to not be worth the effort.
@@ -1927,7 +1927,7 @@
 					// We're using fuzzy precision, so make a guess as to how long the text is,
 					// and then decide whether we can let this string slide through based on the
 					// limit precision.
-					$guess_length = $this->lexer->GuessTextLength();
+					$guess_length = $this->lexer->guessTextLength();
 					if ($this->debug)
 						print "<b>Parse:</b> Maybe not:  Fuzzy limiting enabled, and approximate text length is $guess_length.<br />\n";
 					if ($guess_length < $this->output_limit * ($this->limit_precision + 1.0)) {
@@ -1959,23 +1959,23 @@
 
 			// Remove any initial whitespace in pre-trim mode.
 			if (strlen($this->pre_trim) > 0)
-				$this->Internal_CleanupWSByEatingInput($this->pre_trim);
+				$this->internal_CleanupWSByEatingInput($this->pre_trim);
 
 			// In plain mode, we generate newlines instead of <br /> tags.
 			$newline = $this->plain_mode ? "\n" : "<br />\n";
 
-			// This is a fairly straightforward push-down automaton operating in LL(1) mode.  For
+			// This is a fairly straightforward push-down automaton operating in lL(1) mode.  For
 			// clarity's sake, we break the tag-processing code into separate functions, but we
 			// keep the text/whitespace/newline code here for performance reasons.
 			while (true) {
-				$BBCode_Profiler->Begin('Lexer:NextToken');
-				if (($token_type = $this->lexer->NextToken()) == BBCODE_EOI) {
-					$BBCode_Profiler->End('Lexer:NextToken');
+				$BBCode_Profiler->begin('Lexer:NextToken');
+				if (($token_type = $this->lexer->nextToken()) == BBCODE_EOI) {
+					$BBCode_Profiler->end('Lexer:NextToken');
 					break;
 				}
 
 				if ($this->debug)
-					print "<b>Parse:</b> Stack contents: <tt>" . $this->Internal_DumpStack() . "</tt><br />\n";
+					print "<b>Parse:</b> Stack contents: <tt>" . $this->internal_DumpStack() . "</tt><br />\n";
 
 				switch ($token_type) {
 
@@ -1991,18 +1991,18 @@
 					// boundary, add as much as we can, and then abort.
 					if ($this->output_limit > 0
 						&& $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-						$text = $this->Internal_LimitText($this->lexer->text,
+						$text = $this->internal_LimitText($this->lexer->text,
 							$this->output_limit - $this->text_length);
 						if (strlen($text) > 0) {
 							$this->text_length += strlen($text);
 							$this->stack[] = [
 								BBCODE_STACK_TOKEN => BBCODE_TEXT,
-								BBCODE_STACK_TEXT => $this->FixupOutput($text),
+								BBCODE_STACK_TEXT => $this->fixupOutput($text),
 								BBCODE_STACK_TAG => false,
 								BBCODE_STACK_CLASS => $this->current_class,
 							];
 						}
-						$this->Internal_DoLimit();
+						$this->internal_DoLimit();
 						break 2;
 					}
 					$this->text_length += strlen($this->lexer->text);
@@ -2010,7 +2010,7 @@
 					// Push this text token onto the stack.
 					$this->stack[] = [
 						BBCODE_STACK_TOKEN => BBCODE_TEXT,
-						BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+						BBCODE_STACK_TEXT => $this->fixupOutput($this->lexer->text),
 						BBCODE_STACK_TAG => false,
 						BBCODE_STACK_CLASS => $this->current_class,
 					];
@@ -2025,7 +2025,7 @@
 					// If this token pushes us past the output limit, don't process anything further.
 					if ($this->output_limit > 0
 						&& $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-						$this->Internal_DoLimit();
+						$this->internal_DoLimit();
 						break 2;
 					}
 					$this->text_length += strlen($this->lexer->text);
@@ -2053,7 +2053,7 @@
 						// If this token pushes us past the output limit, don't process anything further.
 						if ($this->output_limit > 0
 							&& $this->text_length + 1 >= $this->output_limit) {
-							$this->Internal_DoLimit();
+							$this->internal_DoLimit();
 							break 2;
 						}
 						$this->text_length += 1;
@@ -2074,7 +2074,7 @@
 						// Any whitespace before a newline isn't worth outputting, so if there's
 						// whitespace sitting on top of the stack, remove it so that it doesn't
 						// get outputted.
-						$this->Internal_CleanupWSByPoppingStack("s", $this->stack);
+						$this->internal_CleanupWSByPoppingStack("s", $this->stack);
 
 						if ($this->debug)
 							print "<b>Internal_ParseNewlineToken:</b> push newline.<br />\n";
@@ -2082,7 +2082,7 @@
 						// If this token pushes us past the output limit, don't process anything further.
 						if ($this->output_limit > 0
 							&& $this->text_length + 1 >= $this->output_limit) {
-							$this->Internal_DoLimit();
+							$this->internal_DoLimit();
 							break 2;
 						}
 						$this->text_length += 1;
@@ -2097,18 +2097,18 @@
 
 						// Any whitespace after a newline is meaningless, so if there's whitespace
 						// lingering on the input after this, remove it now.
-						$this->Internal_CleanupWSByEatingInput("s");
+						$this->internal_CleanupWSByEatingInput("s");
 					}
 					break;
 
 				case BBCODE_TAG:
 					// Use a separate function to handle tags, because they're complicated.
-					$this->Internal_ParseStartTagToken();
+					$this->internal_ParseStartTagToken();
 					break;
 
 				case BBCODE_ENDTAG:
 					// Use a separate function to handle end tags, because they're complicated.
-					$this->Internal_ParseEndTagToken();
+					$this->internal_ParseEndTagToken();
 					break;
 
 				default:
@@ -2121,12 +2121,12 @@
 
 			// Remove any trailing whitespace in post-trim mode.
 			if (strlen($this->post_trim) > 0)
-				$this->Internal_CleanupWSByPoppingStack($this->post_trim, $this->stack);
+				$this->internal_CleanupWSByPoppingStack($this->post_trim, $this->stack);
 
 			// Everything left on the stack should be HTML (or broken tags), so pop it
 			// all off as plain text, concatenate it, and return it.
-			$result = $this->Internal_GenerateOutput(0);
-			$result = $this->Internal_CollectTextReverse($result, count($result) - 1);
+			$result = $this->internal_GenerateOutput(0);
+			$result = $this->internal_CollectTextReverse($result, count($result) - 1);
 
 			// If we changed the limit (in fuzzy-limit mode), set it back.
 			$this->output_limit = $old_output_limit;
@@ -2147,9 +2147,9 @@
 					. "</tt><br />\n";
 			}
 
-			$BBCode_Profiler->End('_Parse');
+			$BBCode_Profiler->end('_Parse');
 
-			//$BBCode_Profiler->DumpAllGroups();
+			//$BBCode_Profiler->dumpAllGroups();
 
 			return $result;
 		}

--- a/plugins/NBBC/nbbc/test_nbbc.php
+++ b/plugins/NBBC/nbbc/test_nbbc.php
@@ -1093,26 +1093,26 @@ h1 { text-align: center; }
 		],
 	];
 
-	function MicroNow() {
+	function microNow() {
 		list($usec, $sec) = explode(" ", microtime());
 		return ((float)$usec + (float)$sec);
 	}
 
-	function FormatTime($time) {
+	function formatTime($time) {
 		return sprintf("%0.2f ms", $time * 1000);
 	}
 
 	$bbcode = new BBCode;
 
-	$bbcode->AddRule('wstest', [
+	$bbcode->addRule('wstest', [
 		'mode' => BBCODE_MODE_ENHANCED,
 		'allow' => ['_default' => '/^[a-zA-Z0-9._ -]+$/'],
 		'template' => '<span style="wstest:{$_default}">{$_content}</span>',
 		'class' => 'inline',
 		'allow_in' => ['listitem', 'block', 'columns', 'inline', 'link'],
 	]);	
-	$bbcode->SetLocalImgDir("smileys");
-	$bbcode->SetLocalImgURL("smileys");
+	$bbcode->setLocalImgDir("smileys");
+	$bbcode->setLocalImgURL("smileys");
 
 	print "<table class='test_table' align='center'>\n"
 		. "<thead><tr><th>Description</th><th>Result</th><th>Avg. Time</th></thead>\n"
@@ -1131,30 +1131,30 @@ h1 { text-align: center; }
 			$output = "<tr class='test'><td class='descr'>" . htmlspecialchars($test['descr']) . "</td>";
 
 			if (@$test['debug'] == true)
-				$bbcode->SetDebug(true);
-			else $bbcode->SetDebug(false);
-			$bbcode->SetTagMarker('[');
-			$bbcode->SetAllowAmpersand(false);
-			if (@$test['newline_ignore'] == true) $bbcode->SetIgnoreNewlines(true);
-			else $bbcode->SetIgnoreNewlines(false);
-			if (@$test['detect_urls'] == true) $bbcode->SetDetectURLs(true);
-			else $bbcode->SetDetectURLs(false);
-			if (@$test['urltarget'] == true) $bbcode->SetURLTargetable(true);
-			else $bbcode->SetURLTargetable(false);
+				$bbcode->setDebug(true);
+			else $bbcode->setDebug(false);
+			$bbcode->setTagMarker('[');
+			$bbcode->setAllowAmpersand(false);
+			if (@$test['newline_ignore'] == true) $bbcode->setIgnoreNewlines(true);
+			else $bbcode->setIgnoreNewlines(false);
+			if (@$test['detect_urls'] == true) $bbcode->setDetectURLs(true);
+			else $bbcode->setDetectURLs(false);
+			if (@$test['urltarget'] == true) $bbcode->setURLTargetable(true);
+			else $bbcode->setURLTargetable(false);
 			if (is_string(@$test['urlforcetarget']))
-				$bbcode->SetURLTarget($test['urlforcetarget']);
-			else $bbcode->SetURLTarget(false);
+				$bbcode->setURLTarget($test['urlforcetarget']);
+			else $bbcode->setURLTarget(false);
 			if (isset($test['plainmode']))
-				$bbcode->SetPlainMode($test['plainmode']);
-			else $bbcode->SetPlainMode(false);
+				$bbcode->setPlainMode($test['plainmode']);
+			else $bbcode->setPlainMode(false);
 			if (@$test['tag_marker'] == '<') {
-				$bbcode->SetTagMarker('<');
-				$bbcode->SetAllowAmpersand(true);
+				$bbcode->setTagMarker('<');
+				$bbcode->setAllowAmpersand(true);
 			}
 			else if (isset($test['tag_marker']))
-				$bbcode->SetTagMarker($test['tag_marker']);
+				$bbcode->setTagMarker($test['tag_marker']);
 
-			$result = $bbcode->Parse($test['bbcode']);
+			$result = $bbcode->parse($test['bbcode']);
 
 			$numtested++;
 
@@ -1171,14 +1171,14 @@ h1 { text-align: center; }
 
 				// If we didn't fail, run the same test twenty times so we can see how long
 				// it takes, on average.
-				$bbcode->SetDebug(false);
-				$start = MicroNow();
+				$bbcode->setDebug(false);
+				$start = microNow();
 				for ($i = 0; $i < 20; $i++)
-					$result = $bbcode->Parse($test['bbcode']);
-				$time = (MicroNow() - $start) / 20;
+					$result = $bbcode->parse($test['bbcode']);
+				$time = (microNow() - $start) / 20;
 
 				$output .= "<td class='good'>Pass</td>"
-					. "<td class='good' style='text-align:right;'>" . FormatTime($time) . "</td></tr>\n";
+					. "<td class='good' style='text-align:right;'>" . formatTime($time) . "</td></tr>\n";
 				$numpassed++;
 			}
 			else {

--- a/plugins/NoBump/class.nobump.plugin.php
+++ b/plugins/NoBump/class.nobump.plugin.php
@@ -4,21 +4,21 @@ class NoBumpPlugin extends Gdn_Plugin {
    /**
     * Add 'No Bump' option to new discussion form.
     */
-   public function DiscussionController_AfterBodyField_Handler($sender) {
-      if (Gdn::Session()->CheckPermission('Garden.Moderation.Manage'))
-         echo $sender->Form->CheckBox('NoBump', T('No Bump'), ['value' => '1']);
+   public function discussionController_afterBodyField_handler($sender) {
+      if (Gdn::session()->checkPermission('Garden.Moderation.Manage'))
+         echo $sender->Form->checkBox('NoBump', t('No Bump'), ['value' => '1']);
    }
 
    /**
     * Set Comment's DateInserted to Discussion's DateLastComment so there's no change.
     */
-   public function CommentModel_BeforeUpdateCommentCount_Handler($sender) {
-      if (Gdn::Session()->CheckPermission('Garden.Moderation.Manage')) {
-         if (Gdn::Controller()->Form->GetFormValue('NoBump'))
+   public function commentModel_beforeUpdateCommentCount_handler($sender) {
+      if (Gdn::session()->checkPermission('Garden.Moderation.Manage')) {
+         if (Gdn::controller()->Form->getFormValue('NoBump'))
             $sender->EventArguments['Discussion']['Sink'] = 1;
       }
    }
 
    /** No setup. */
-   public function Setup() { }
+   public function setup() { }
 }

--- a/plugins/NoIndex/class.noindex.plugin.php
+++ b/plugins/NoIndex/class.noindex.plugin.php
@@ -11,14 +11,14 @@ class NoIndexPlugin extends Gdn_Plugin {
    /**
     * Allow mods to add/remove NoIndex via discussion options.
     */
-   public function Base_DiscussionOptions_Handler($sender, $args) {
-      if (CheckPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE)) {
+   public function base_discussionOptions_handler($sender, $args) {
+      if (checkPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE)) {
          $discussion = $args['Discussion'];
-         $label = (GetValue('NoIndex', $discussion)) ? T('Remove NoIndex') : T('Add NoIndex');
+         $label = (getValue('NoIndex', $discussion)) ? t('Remove NoIndex') : t('Add NoIndex');
          $url = "/discussion/noindex?discussionid={$discussion->DiscussionID}";
          // Deal with inconsistencies in how options are passed
          if (isset($sender->Options)) {
-            $sender->Options .= Wrap(Anchor($label, $url, 'NoIndex'), 'li');
+            $sender->Options .= wrap(anchor($label, $url, 'NoIndex'), 'li');
          }
          else {
             $args['DiscussionOptions']['Bump'] = [
@@ -33,69 +33,69 @@ class NoIndexPlugin extends Gdn_Plugin {
    /**
     * Handle discussion option menu NoIndex action (simple toggle).
     */
-   public function DiscussionController_NoIndex_Create($sender, $args) {
-      $sender->Permission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE);
+   public function discussionController_noIndex_create($sender, $args) {
+      $sender->permission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE);
 
       // Get discussion
-      $discussionID = $sender->Request->Get('discussionid');
-      $discussion = $sender->DiscussionModel->GetID($discussionID);
+      $discussionID = $sender->Request->get('discussionid');
+      $discussion = $sender->DiscussionModel->getID($discussionID);
       if (!$discussion) {
-         throw NotFoundException('Discussion');
+         throw notFoundException('Discussion');
       }
 
       // Toggle NoIndex
-      $noIndex = GetValue('NoIndex', $discussion) ? 0 : 1;
+      $noIndex = getValue('NoIndex', $discussion) ? 0 : 1;
 
       // Update DateLastComment & redirect
-      $sender->DiscussionModel->SetProperty($discussionID, 'NoIndex', $noIndex);
-      redirectTo(DiscussionUrl($discussion));
+      $sender->DiscussionModel->setProperty($discussionID, 'NoIndex', $noIndex);
+      redirectTo(discussionUrl($discussion));
    }
 
     /**
      * Add a mod message to NoIndex discussions.
      */
-    public function DiscussionController_BeforeDiscussionDisplay_Handler($sender, $args) {
-        if (!CheckPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE))
+    public function discussionController_beforeDiscussionDisplay_handler($sender, $args) {
+        if (!checkPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE))
             return;
 
-        if (GetValue('NoIndex', $sender->Data('Discussion'))) {
-            echo Wrap(T('Discussion marked as noindex'), 'div', ['class' => 'Warning']);
+        if (getValue('NoIndex', $sender->data('Discussion'))) {
+            echo wrap(t('Discussion marked as noindex'), 'div', ['class' => 'Warning']);
         }
     }
 
     /**
      * Add the noindex/noarchive meta tag.
      */
-    public function DiscussionController_Render_Before($sender, $args) {
-        if ($sender->Head && GetValue('NoIndex', $sender->Data('Discussion'))) {
-            $sender->Head->AddTag('meta', ['name' => 'robots', 'content' => 'noindex,noarchive']);
+    public function discussionController_render_before($sender, $args) {
+        if ($sender->Head && getValue('NoIndex', $sender->data('Discussion'))) {
+            $sender->Head->addTag('meta', ['name' => 'robots', 'content' => 'noindex,noarchive']);
         }
     }
 
     /**
      * Show NoIndex meta tag on discussions list.
      */
-    public function Base_BeforeDiscussionMeta_Handler($sender, $args) {
-        $noIndex = GetValue('NoIndex', GetValue('Discussion', $args));
-        if (CheckPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE) && $noIndex) {
-            echo ' <span class="Tag Tag-NoIndex">'.T('NoIndex').'</span> ';
+    public function base_beforeDiscussionMeta_handler($sender, $args) {
+        $noIndex = getValue('NoIndex', getValue('Discussion', $args));
+        if (checkPermission(['Garden.Moderation.Manage', 'Garden.Curation.Manage'], FALSE) && $noIndex) {
+            echo ' <span class="Tag Tag-NoIndex">'.t('NoIndex').'</span> ';
         }
     }
 
    /**
     * Invoke structure changes.
     */
-   public function Setup() {
-        $this->Structure();
+   public function setup() {
+        $this->structure();
    }
 
     /**
      * Add NoIndex property to discussions.
      */
-    public function Structure() {
-       Gdn::Structure()
-          ->Table('Discussion')
-          ->Column('NoIndex', 'int', '0')
-          ->Set();
+    public function structure() {
+       Gdn::structure()
+          ->table('Discussion')
+          ->column('NoIndex', 'int', '0')
+          ->set();
    }
 }

--- a/plugins/Pockets/class.pockets.plugin.php
+++ b/plugins/Pockets/class.pockets.plugin.php
@@ -70,7 +70,7 @@ class PocketsPlugin extends Gdn_Plugin {
      *
      * @param $sender
      */
-    public function base_GetAppSettingsMenuItems_Handler($sender) {
+    public function base_getAppSettingsMenuItems_handler($sender) {
         $menu = $sender->EventArguments['SideMenu'];
         $menu->addItem('Appearance', t('Appearance'));
         $menu->addLink('Appearance', t('Pockets'), 'settings/pockets', 'Plugins.Pockets.Manage');
@@ -81,7 +81,7 @@ class PocketsPlugin extends Gdn_Plugin {
      *
      * @param $sender
      */
-    public function base_BeforeRenderAsset_Handler($sender) {
+    public function base_beforeRenderAsset_handler($sender) {
         $assetName = valr('EventArguments.AssetName', $sender);
         $this->processPockets($sender, $assetName, Pocket::REPEAT_BEFORE);
     }
@@ -403,8 +403,8 @@ class PocketsPlugin extends Gdn_Plugin {
                 // Convert some of the pocket data into a format digestable by the form.
                 list($repeatType, $repeatFrequency) = Pocket::parseRepeat($pocket['Repeat']);
                 $pocket['RepeatType'] = $repeatType;
-                $pocket['EveryFrequency'] = GetValue(0, $repeatFrequency, 1);
-                $pocket['EveryBegin'] = GetValue(1, $repeatFrequency, 1);
+                $pocket['EveryFrequency'] = getValue(0, $repeatFrequency, 1);
+                $pocket['EveryBegin'] = getValue(1, $repeatFrequency, 1);
                 $pocket['Indexes'] = implode(',', $repeatFrequency);
                 $pocket['Ad'] = $pocket['Type'] == Pocket::TYPE_AD;
                 $pocket['TestMode'] = Pocket::inTestMode($pocket);
@@ -423,7 +423,7 @@ class PocketsPlugin extends Gdn_Plugin {
 
         $sender->setData('Locations', $this->Locations);
         $sender->setData('LocationsArray', $this->getLocationsArray());
-        $sender->setData('Pages', ['' => '('.T('All').')', 'activity' => 'activity', 'comments' => 'comments', 'dashboard' => 'dashboard', 'discussions' => 'discussions', 'inbox' => 'inbox', 'profile' => 'profile']);
+        $sender->setData('Pages', ['' => '('.t('All').')', 'activity' => 'activity', 'comments' => 'comments', 'dashboard' => 'dashboard', 'discussions' => 'discussions', 'inbox' => 'inbox', 'profile' => 'profile']);
 
         return $sender->render('AddEdit', '', 'plugins/Pockets');
     }
@@ -436,7 +436,7 @@ class PocketsPlugin extends Gdn_Plugin {
      * @return mixed
      */
     protected function _Edit($sender, $pocketID) {
-        $sender->setData('Title', sprintf(T('Edit %s'), T('Pocket')));
+        $sender->setData('Title', sprintf(t('Edit %s'), t('Pocket')));
         return $this->_AddEdit($sender, $pocketID);
     }
 
@@ -454,7 +454,7 @@ class PocketsPlugin extends Gdn_Plugin {
         $form = new Gdn_Form();
         if ($form->authenticatedPostBack()) {
             Gdn::sql()->delete('Pocket', ['PocketID' => $pocketID]);
-            $sender->StatusMessage = sprintf(T('The %s has been deleted.'), strtolower(t('Pocket')));
+            $sender->StatusMessage = sprintf(t('The %s has been deleted.'), strtolower(t('Pocket')));
             $sender->setRedirectTo('settings/pockets');
         }
 

--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -221,17 +221,17 @@ class Pocket {
      * @return array
      */
     public static function parseRepeat($repeat) {
-        if (StringBeginsWith($repeat, Pocket::REPEAT_EVERY)) {
+        if (stringBeginsWith($repeat, Pocket::REPEAT_EVERY)) {
             $repeatType = Pocket::REPEAT_EVERY;
             $frequency = substr($repeat, strlen(Pocket::REPEAT_EVERY));
-        } elseif (StringBeginsWith($repeat, Pocket::REPEAT_INDEX)) {
+        } elseif (stringBeginsWith($repeat, Pocket::REPEAT_INDEX)) {
             $repeatType = Pocket::REPEAT_INDEX;
             $frequency = substr($repeat, strlen(Pocket::REPEAT_INDEX));
-        } elseif (StringBeginsWith($repeat, Pocket::REPEAT_ONCE)) {
+        } elseif (stringBeginsWith($repeat, Pocket::REPEAT_ONCE)) {
             $repeatType = Pocket::REPEAT_ONCE;
-        } elseif (StringBeginsWith($repeat, Pocket::REPEAT_BEFORE)) {
+        } elseif (stringBeginsWith($repeat, Pocket::REPEAT_BEFORE)) {
             $repeatType = Pocket::REPEAT_BEFORE;
-        } elseif (StringBeginsWith($repeat, Pocket::REPEAT_AFTER)) {
+        } elseif (stringBeginsWith($repeat, Pocket::REPEAT_AFTER)) {
             $repeatType = Pocket::REPEAT_AFTER;
         }
 

--- a/plugins/Pockets/views/addedit.php
+++ b/plugins/Pockets/views/addedit.php
@@ -3,7 +3,7 @@
 echo '<h1>', $this->data('Title'), '</h1>';
 
 /** @var Gdn_Form $Form */
-$Form = $this->Form; //new Gdn_Form();
+$Form = $this->Form; //new gdn_Form();
 echo $Form->open();
 echo $Form->errors();
 ?>
@@ -51,7 +51,7 @@ echo $Form->errors();
             echo '<div class="info">', t('Select the location of the pocket.', 'Select the location of the pocket.'), '</div>'; ?>
         </div>
         <div class="input-wrap">
-        <?php echo $Form->dropdown('Location', array_merge(['' => '('.sprintf(T('Select a %s'), t('Location')).')'], $this->data('LocationsArray'))); ?>
+        <?php echo $Form->dropdown('Location', array_merge(['' => '('.sprintf(t('Select a %s'), t('Location')).')'], $this->data('LocationsArray'))); ?>
         </div>
     </li>
     <li class="js-repeat form-group">

--- a/plugins/Pockets/views/delete.php
+++ b/plugins/Pockets/views/delete.php
@@ -8,7 +8,7 @@ echo $this->Form->errors();
 ?>
 <ul>
     <li>
-        <div class="Warning"><?php echo sprintf(T('Are you sure you want to delete this %s?'), strtolower(t('Pocket'))); ?></div>
+        <div class="Warning"><?php echo sprintf(t('Are you sure you want to delete this %s?'), strtolower(t('Pocket'))); ?></div>
     </li>
 </ul>
 <?php echo $this->Form->close('Delete');

--- a/plugins/PostCount/class.postcount.plugin.php
+++ b/plugins/PostCount/class.postcount.plugin.php
@@ -10,36 +10,36 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 
 class PostCountPlugin extends Gdn_Plugin {
    
-   public function UserInfoModule_OnBasicInfo_Handler($sender) {
-      $user = Gdn::UserModel()->GetID($sender->User->UserID);
+   public function userInfoModule_onBasicInfo_handler($sender) {
+      $user = Gdn::userModel()->getID($sender->User->UserID);
       if ($user) {
-         $postCount = GetValue('CountComments', $user, 0) + GetValue('CountDiscussions', $user, 0);
-         echo "<dt class=\"Posts\">".T('Posts')."</dt>\n";
+         $postCount = getValue('CountComments', $user, 0) + getValue('CountDiscussions', $user, 0);
+         echo "<dt class=\"Posts\">".t('Posts')."</dt>\n";
          echo "<dd class=\"Posts\">".number_format($postCount)."</dd>";
       }
    }
    
-   public function DiscussionController_AuthorInfo_Handler($sender) {
+   public function discussionController_authorInfo_handler($sender) {
       $this->_AttachPostCount($sender);
    }
    
-   public function PostController_AuthorInfo_Handler($sender) {
+   public function postController_authorInfo_handler($sender) {
       $this->_AttachPostCount($sender);
    }
    
    protected function _AttachPostCount($sender) {
-      $user = Gdn::UserModel()->GetID($sender->EventArguments['Author']->UserID);
+      $user = Gdn::userModel()->getID($sender->EventArguments['Author']->UserID);
       if ($user) {
-         $posts = GetValue('CountComments', $user, 0) + GetValue('CountDiscussions', $user, 0);
-         echo '<span class="MItem PostCount">'.Plural(number_format($posts), '@'.T('Posts.Singular: %s', 'Posts: <b>%s</b>'), '@'.T('Posts.Plural: %s', 'Posts: <b>%s</b>')).'</span>';
+         $posts = getValue('CountComments', $user, 0) + getValue('CountDiscussions', $user, 0);
+         echo '<span class="MItem PostCount">'.plural(number_format($posts), '@'.t('Posts.Singular: %s', 'Posts: <b>%s</b>'), '@'.t('Posts.Plural: %s', 'Posts: <b>%s</b>')).'</span>';
       }
    }
 
-   public function Setup() {
+   public function setup() {
       // Nothing to do here!
    }
    
-   public function Structure() {
+   public function structure() {
       // Nothing to do here!
    }
          

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -69,7 +69,7 @@ class QnAPlugin extends Gdn_Plugin {
      *
      * @param $sender Sending controller instance
      */
-    public function settingsController_QnA_create($sender) {
+    public function settingsController_qnA_create($sender) {
         // Prevent non-admins from accessing this page
         $sender->permission('Garden.Settings.Manage');
 
@@ -168,7 +168,7 @@ class QnAPlugin extends Gdn_Plugin {
      * @param array $args Event arguments.
      */
     public function base_discussionTypes_handler($sender, $args) {
-        if (!C('Plugins.QnA.UseBigButtons')) {
+        if (!c('Plugins.QnA.UseBigButtons')) {
             $args['Types']['Question'] = [
                 'Singular' => 'Question',
                 'Plural' => 'Questions',
@@ -424,13 +424,13 @@ class QnAPlugin extends Gdn_Plugin {
      *
      * @throws notFoundException
      */
-    public function discussionController_QnA_create($sender, $args) {
-        $Comment = Gdn::SQL()->getWhere('Comment', ['CommentID' => $sender->Request->get('commentid')])->firstRow(DATASET_TYPE_ARRAY);
+    public function discussionController_qnA_create($sender, $args) {
+        $Comment = Gdn::sql()->getWhere('Comment', ['CommentID' => $sender->Request->get('commentid')])->firstRow(DATASET_TYPE_ARRAY);
         if (!$Comment) {
             throw notFoundException('Comment');
         }
 
-        $Discussion = Gdn::SQL()->getWhere('Discussion', ['DiscussionID' => $Comment['DiscussionID']])->firstRow(DATASET_TYPE_ARRAY);
+        $Discussion = Gdn::sql()->getWhere('Discussion', ['DiscussionID' => $Comment['DiscussionID']])->firstRow(DATASET_TYPE_ARRAY);
 
         // Check for permission.
         if (!(Gdn::session()->UserID == val('InsertUserID', $Discussion) || Gdn::session()->checkPermission('Garden.Moderation.Manage'))) {
@@ -464,11 +464,11 @@ class QnAPlugin extends Gdn_Plugin {
             }
 
             // Update the comment.
-            Gdn::SQL()->put('Comment', $CommentSet, ['CommentID' => $Comment['CommentID']]);
+            Gdn::sql()->put('Comment', $CommentSet, ['CommentID' => $Comment['CommentID']]);
 
             // Update the discussion.
             if ($Discussion['QnA'] != $QnA && (!$Discussion['QnA'] || in_array($Discussion['QnA'], ['Unanswered', 'Answered', 'Rejected']))) {
-                Gdn::SQL()->put(
+                Gdn::sql()->put(
                     'Discussion',
                     $DiscussionSet,
                     ['DiscussionID' => $Comment['DiscussionID']]);
@@ -558,7 +558,7 @@ class QnAPlugin extends Gdn_Plugin {
      * @param string|int $discussionID Identifier of the discussion
      * @param string|int $commentID Identifier of the comment.
      */
-    public function discussionController_QnAOptions_create($sender, $discussionID = '', $commentID = '') {
+    public function discussionController_qnAOptions_create($sender, $discussionID = '', $commentID = '') {
         if ($discussionID) {
             $this->_discussionOptions($sender, $discussionID);
         } elseif ($commentID) {
@@ -574,7 +574,7 @@ class QnAPlugin extends Gdn_Plugin {
         // Find comments in this discussion with a QnA value.
         $set = [];
 
-        $row = Gdn::SQL()->getWhere('Comment',
+        $row = Gdn::sql()->getWhere('Comment',
             ['DiscussionID' => val('DiscussionID', $discussion), 'QnA is not null' => ''], 'QnA, DateAccepted', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
 
         if (!$row) {
@@ -605,7 +605,7 @@ class QnAPlugin extends Gdn_Plugin {
      * @param string|int $userID User identifier
      */
     public function recalculateUserQnA($userID) {
-        $countAcceptedAnswers = Gdn::SQL()->getCount('Comment', ['InsertUserID' => $userID, 'QnA' => 'Accepted']);
+        $countAcceptedAnswers = Gdn::sql()->getCount('Comment', ['InsertUserID' => $userID, 'QnA' => 'Accepted']);
         Gdn::userModel()->setField($userID, 'CountAcceptedAnswers', $countAcceptedAnswers);
     }
 
@@ -1018,7 +1018,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         // Check to see if the user has answered questions.
-        $count = Gdn::SQL()->getCount('Discussion', ['Type' => 'Question', 'InsertUserID' => Gdn::session()->UserID, 'QnA' => 'Answered']);
+        $count = Gdn::sql()->getCount('Discussion', ['Type' => 'Question', 'InsertUserID' => Gdn::session()->UserID, 'QnA' => 'Answered']);
         if ($count > 0) {
             $sender->informMessage(formatString(t("You've asked questions that have now been answered", "<a href=\"{/discussions/mine?qna=Answered,url}\">You've asked questions that now have answers</a>. Make sure you accept/reject the answers.")), 'Dismissable');
         }
@@ -1069,14 +1069,14 @@ class QnAPlugin extends Gdn_Plugin {
      * @param PostController $sender Sending controller instance.
      */
     public function postController_question_create($sender, $categoryUrlCode = '') {
-        // Create & call PostController->Discussion()
+        // Create & call PostController->discussion()
         $sender->View = PATH_PLUGINS.'/QnA/views/post.php';
         $sender->setData('Type', 'Question');
         $sender->discussion($categoryUrlCode);
     }
 
     /**
-     * Override the PostController->Discussion() method before render to use our view instead.
+     * Override the PostController->discussion() method before render to use our view instead.
      *
      * @param PostController $sender Sending controller instance.
      */

--- a/plugins/QnA/structure.php
+++ b/plugins/QnA/structure.php
@@ -23,11 +23,11 @@ Gdn::structure()
     ->column('CountAcceptedAnswers', 'int', '0')
     ->set();
 
-Gdn::SQL()->replace(
+Gdn::sql()->replace(
     'ActivityType',
     ['AllowComments' => '0', 'RouteCode' => 'question', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''],
     ['Name' => 'QuestionAnswer'], true);
-Gdn::SQL()->replace(
+Gdn::sql()->replace(
     'ActivityType',
     ['AllowComments' => '0', 'RouteCode' => 'answer', 'Notify' => '1', 'Public' => '0', 'ProfileHeadline' => '', 'FullHeadline' => ''],
     ['Name' => 'AnswerAccepted'], true);
@@ -36,12 +36,12 @@ if ($QnAExists && !$DateAcceptedExists) {
     // Default the date accepted to the accepted answer's date.
     $Px = Gdn::database()->DatabasePrefix;
     $Sql = "update {$Px}Discussion d set DateAccepted = (select min(c.DateInserted) from {$Px}Comment c where c.DiscussionID = d.DiscussionID and c.QnA = 'Accepted')";
-    Gdn::SQL()->query($Sql, 'update');
-    Gdn::SQL()->update('Discussion')
+    Gdn::sql()->query($Sql, 'update');
+    Gdn::sql()->update('Discussion')
         ->set('DateOfAnswer', 'DateAccepted', false, false)
         ->put();
 
-    Gdn::SQL()->update('Comment c')
+    Gdn::sql()->update('Comment c')
         ->join('Discussion d', 'c.CommentID = d.DiscussionID')
         ->set('c.DateAccepted', 'c.DateInserted', false, false)
         ->set('c.AcceptedUserID', 'd.InsertUserID', false, false)

--- a/plugins/QnA/views/discussionoptions.php
+++ b/plugins/QnA/views/discussionoptions.php
@@ -8,7 +8,7 @@ echo $this->Form->errors();
 
 <div class="P">
     <?php
-//   echo $this->Form->Label();
+//   echo $this->Form->label();
     echo $this->Form->radioList('Type', $this->data('_Types'), ['list' => true]);
     ?>
 </div>

--- a/plugins/ReactionsStub/class.reactionsstub.plugin.php
+++ b/plugins/ReactionsStub/class.reactionsstub.plugin.php
@@ -4,27 +4,27 @@ class ReactionsStubPlugin extends Gdn_Plugin {
 
    public function __construct() {}
 
-   public function RootController_React_Create($sender, $recordType, $reaction, $iD) {
-      $sender->Render('blank', 'utility', 'dashboard');
+   public function rootController_react_create($sender, $recordType, $reaction, $iD) {
+      $sender->render('blank', 'utility', 'dashboard');
    }
 
-   private function AddJs($sender) {
-      $sender->AddJsFile('jquery-ui.js');
-      $sender->AddJsFile('reactions.js', 'plugins/ReactionsStub');
+   private function addJs($sender) {
+      $sender->addJsFile('jquery-ui.js');
+      $sender->addJsFile('reactions.js', 'plugins/ReactionsStub');
    }
 
-   public function DiscussionController_Render_Before($sender) {
-      $sender->AddCssFile('reactions.css', 'plugins/ReactionsStub');
-      $this->AddJs($sender);
+   public function discussionController_render_before($sender) {
+      $sender->addCssFile('reactions.css', 'plugins/ReactionsStub');
+      $this->addJs($sender);
    }
 
-   public function Setup() {}
+   public function setup() {}
 
 }
 
 if (!function_exists('WriteReactions')) {
 
-   function WriteReactions($row) {
+   function writeReactions($row) {
       $reactions = <<<REACTIONS
 <div class="Reactions"><span class="Flag ToggleFlyout"><a class="Hijack ReactButton ReactButton-Flag" href="" title="Flag" rel="nofollow"><span class="ReactSprite ReactFlag"></span> <span class="ReactLabel">Flag</span></a>
    <ul class="Flyout MenuItems Flags" style="display: none;"><li><a class="Hijack ReactButton ReactButton-Spam" href="/react/comment/spam?id=25011203" title="Spam" rel="nofollow"><span class="ReactSprite ReactSpam"></span> <span class="ReactLabel">Spam</span></a>

--- a/plugins/Reporting/views/awesome-regarding.php
+++ b/plugins/Reporting/views/awesome-regarding.php
@@ -1,17 +1,17 @@
 <div class="RegardingEvent">
    <span class="InformSprite Heart"/>&nbsp;</span> <?php 
-      echo FormatString(T("{ReportingUser} likes this {EntityType} written by {ReportedUser}"), [
-         'ReportingUser'      => UserAnchor(GetValue('ReportingUser', $this->Data('ReportInfo')), 'ReportingUser'),
-         'EntityType'         => GetValue('EntityType', $this->Data('ReportInfo')),
-         'ReportedUser'       => UserAnchor(GetValue('ReportedUser', $this->Data('ReportInfo')), 'ReportedUser')
+      echo formatString(t("{ReportingUser} likes this {EntityType} written by {ReportedUser}"), [
+         'ReportingUser'      => userAnchor(getValue('ReportingUser', $this->data('ReportInfo')), 'ReportingUser'),
+         'EntityType'         => getValue('EntityType', $this->data('ReportInfo')),
+         'ReportedUser'       => userAnchor(getValue('ReportedUser', $this->data('ReportInfo')), 'ReportedUser')
       ]);
    ?>
    <div class="RegardingTime"><?php 
-      $ReportedDate = GetValue('ReportedTime', $this->Data('ReportInfo'));
-      echo Gdn_Format::FuzzyTime($ReportedDate);
+      $ReportedDate = getValue('ReportedTime', $this->data('ReportInfo'));
+      echo Gdn_Format::fuzzyTime($ReportedDate);
    ?></div>
    <?php
-      $ReportedReason = GetValue('ReportedReason', $this->Data('ReportInfo'), NULL);
+      $ReportedReason = getValue('ReportedReason', $this->data('ReportInfo'), NULL);
       if (!is_null($ReportedReason)) {?>
          <div class="ReportedReason">"<?php echo $ReportedReason; ?>"</div>
          <?php
@@ -20,10 +20,10 @@
 </div>
 <div class="RegardingActions">
    <?php 
-      $ForeignURL = GetValue('ForeignURL', $this->Data('RegardingData'), NULL);
+      $ForeignURL = getValue('ForeignURL', $this->data('RegardingData'), NULL);
       if (!is_null($ForeignURL)) {
-         ?><div class="ActionButton"><a href="<?php echo $ForeignURL; ?>" title="<?php echo T("Visit awesome content location"); ?>"><?php echo T("Visit"); ?></a></div><?php
+         ?><div class="ActionButton"><a href="<?php echo $ForeignURL; ?>" title="<?php echo t("Visit awesome content location"); ?>"><?php echo t("Visit"); ?></a></div><?php
       }
    ?>
-   <?php $this->Data('RegardingSender')->FireEvent("RegardingActions"); ?>
+   <?php $this->data('RegardingSender')->fireEvent("RegardingActions"); ?>
 </div>

--- a/plugins/Reporting/views/awesome.php
+++ b/plugins/Reporting/views/awesome.php
@@ -1,42 +1,42 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 <?php
-   $ReportingData = GetValue('Plugin.Reporting.Data', $this->Data);
+   $ReportingData = getValue('Plugin.Reporting.Data', $this->Data);
    
-   $Context = GetValue('Context', $ReportingData);
+   $Context = getValue('Context', $ReportingData);
    $UpperContext = ucfirst($Context);
-   $ElementID = GetValue('ElementID', $ReportingData);
-   $ElementAuthorID = GetValue('ElementAuthorID', $ReportingData);
-   $ElementAuthor = GetValue('ElementAuthor', $ReportingData);
-   $ElementTitle = GetValue('ElementTitle', $ReportingData);
-   $ElementExcerpt = GetValue('ElementExcerpt', $ReportingData);
-   $URL = GetValue('URL', $ReportingData);
-   $Title = sprintf(T("Report this %s"), $Context);
+   $ElementID = getValue('ElementID', $ReportingData);
+   $ElementAuthorID = getValue('ElementAuthorID', $ReportingData);
+   $ElementAuthor = getValue('ElementAuthor', $ReportingData);
+   $ElementTitle = getValue('ElementTitle', $ReportingData);
+   $ElementExcerpt = getValue('ElementExcerpt', $ReportingData);
+   $URL = getValue('URL', $ReportingData);
+   $Title = sprintf(t("Report this %s"), $Context);
 ?>
-<h2><?php echo T($Title); ?></h2>
+<h2><?php echo t($Title); ?></h2>
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 <div class="AwesomePost">
    <ul>
       <li>
          <div class="Excerpt">
-            <div><?php echo sprintf(T("%s said:"), UserAnchor($ElementAuthor)); ?></div>
+            <div><?php echo sprintf(t("%s said:"), userAnchor($ElementAuthor)); ?></div>
             <div>"<?php echo $ElementExcerpt; ?>"</div>
          </div>
          <div class="Warning">
-            <?php echo sprintf(T("You consider this <b>%s</b> to be awesome, and you want us to take a look. If you're sure you want to do this, please enter a brief reason/explanation below."), $Context); ?>
+            <?php echo sprintf(t("You consider this <b>%s</b> to be awesome, and you want us to take a look. If you're sure you want to do this, please enter a brief reason/explanation below."), $Context); ?>
          </div>
       </li>
       <li>
          <?php
-            echo $this->Form->Label('Reason', 'Plugin.Reporting.Reason');
-            echo Wrap($this->Form->TextBox('Plugin.Reporting.Reason', ['MultiLine' => TRUE]), 'div', ['class' => 'TextBoxWrapper']);
+            echo $this->Form->label('Reason', 'Plugin.Reporting.Reason');
+            echo wrap($this->Form->textBox('Plugin.Reporting.Reason', ['MultiLine' => TRUE]), 'div', ['class' => 'TextBoxWrapper']);
          ?>
       </li>
       <?php
-         $this->FireEvent('ReportContentAfter');
+         $this->fireEvent('ReportContentAfter');
       ?>
    </ul>
-   <?php echo $this->Form->Close('This is awesome!'); ?>
+   <?php echo $this->Form->close('This is awesome!'); ?>
 </div>

--- a/plugins/Reporting/views/report-regarding.php
+++ b/plugins/Reporting/views/report-regarding.php
@@ -1,17 +1,17 @@
 <div class="RegardingEvent">
    <span class="InformSprite Skull"/>&nbsp;</span> <?php 
-      echo FormatString(T("{ReportingUser} reported this {EntityType} written by {ReportedUser}"), [
-         'ReportingUser'      => UserAnchor(GetValue('ReportingUser', $this->Data('ReportInfo')), 'ReportingUser'),
-         'EntityType'         => GetValue('EntityType', $this->Data('ReportInfo')),
-         'ReportedUser'       => UserAnchor(GetValue('ReportedUser', $this->Data('ReportInfo')), 'ReportedUser')
+      echo formatString(t("{ReportingUser} reported this {EntityType} written by {ReportedUser}"), [
+         'ReportingUser'      => userAnchor(getValue('ReportingUser', $this->data('ReportInfo')), 'ReportingUser'),
+         'EntityType'         => getValue('EntityType', $this->data('ReportInfo')),
+         'ReportedUser'       => userAnchor(getValue('ReportedUser', $this->data('ReportInfo')), 'ReportedUser')
       ]);
    ?>
    <div class="RegardingTime"><?php 
-      $ReportedDate = GetValue('ReportedTime', $this->Data('ReportInfo'));
-      echo Gdn_Format::FuzzyTime($ReportedDate);
+      $ReportedDate = getValue('ReportedTime', $this->data('ReportInfo'));
+      echo Gdn_Format::fuzzyTime($ReportedDate);
    ?></div>
    <?php
-      $ReportedReason = GetValue('ReportedReason', $this->Data('ReportInfo'), NULL);
+      $ReportedReason = getValue('ReportedReason', $this->data('ReportInfo'), NULL);
       if (!is_null($ReportedReason)) {?>
          <div class="ReportedReason">"<?php echo $ReportedReason; ?>"</div>
          <?php
@@ -20,10 +20,10 @@
 </div>
 <div class="RegardingActions">
    <?php 
-      $ForeignURL = GetValue('ForeignURL', $this->Data('RegardingData'), NULL);
+      $ForeignURL = getValue('ForeignURL', $this->data('RegardingData'), NULL);
       if (!is_null($ForeignURL)) {
-         ?><div class="ActionButton"><a href="<?php echo $ForeignURL; ?>" title="<?php echo T("Visit reported content location"); ?>"><?php echo T("Visit"); ?></a></div><?php
+         ?><div class="ActionButton"><a href="<?php echo $ForeignURL; ?>" title="<?php echo t("Visit reported content location"); ?>"><?php echo t("Visit"); ?></a></div><?php
       }
    ?>
-   <?php $this->Data('RegardingSender')->FireEvent("RegardingActions"); ?>
+   <?php $this->data('RegardingSender')->fireEvent("RegardingActions"); ?>
 </div>

--- a/plugins/Reporting/views/report.php
+++ b/plugins/Reporting/views/report.php
@@ -1,42 +1,42 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 <?php
-   $ReportingData = GetValue('Plugin.Reporting.Data', $this->Data);
+   $ReportingData = getValue('Plugin.Reporting.Data', $this->Data);
    
-   $Context = GetValue('Context', $ReportingData);
+   $Context = getValue('Context', $ReportingData);
    $UpperContext = ucfirst($Context);
-   $ElementID = GetValue('ElementID', $ReportingData);
-   $ElementAuthorID = GetValue('ElementAuthorID', $ReportingData);
-   $ElementAuthor = GetValue('ElementAuthor', $ReportingData);
-   $ElementTitle = GetValue('ElementTitle', $ReportingData);
-   $ElementExcerpt = GetValue('ElementExcerpt', $ReportingData);
-   $URL = GetValue('URL', $ReportingData);
-   $Title = sprintf(T("Report this %s"), $Context);
+   $ElementID = getValue('ElementID', $ReportingData);
+   $ElementAuthorID = getValue('ElementAuthorID', $ReportingData);
+   $ElementAuthor = getValue('ElementAuthor', $ReportingData);
+   $ElementTitle = getValue('ElementTitle', $ReportingData);
+   $ElementExcerpt = getValue('ElementExcerpt', $ReportingData);
+   $URL = getValue('URL', $ReportingData);
+   $Title = sprintf(t("Report this %s"), $Context);
 ?>
-<h2><?php echo T($Title); ?></h2>
+<h2><?php echo t($Title); ?></h2>
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
 <div class="ReportPost">
    <ul>
       <li>
          <div class="Excerpt">
-            <div><?php echo sprintf(T("%s said:"), UserAnchor($ElementAuthor)); ?></div>
+            <div><?php echo sprintf(t("%s said:"), userAnchor($ElementAuthor)); ?></div>
             <div>"<?php echo $ElementExcerpt; ?>"</div>
          </div>
          <div class="Warning">
-            <?php echo sprintf(T("You are about to report this <b>%s</b> for moderator review. If you're sure you want to do this, please enter a brief reason/explanation below."), $Context); ?>
+            <?php echo sprintf(t("You are about to report this <b>%s</b> for moderator review. If you're sure you want to do this, please enter a brief reason/explanation below."), $Context); ?>
          </div>
       </li>
       <li>
          <?php
-            echo $this->Form->Label('Reason', 'Plugin.Reporting.Reason');
-            echo Wrap($this->Form->TextBox('Plugin.Reporting.Reason', ['MultiLine' => TRUE]), 'div', ['class' => 'TextBoxWrapper']);
+            echo $this->Form->label('Reason', 'Plugin.Reporting.Reason');
+            echo wrap($this->Form->textBox('Plugin.Reporting.Reason', ['MultiLine' => TRUE]), 'div', ['class' => 'TextBoxWrapper']);
          ?>
       </li>
       <?php
-         $this->FireEvent('ReportContentAfter');
+         $this->fireEvent('ReportContentAfter');
       ?>
    </ul>
-   <?php echo $this->Form->Close('Report this!'); ?>
+   <?php echo $this->Form->close('Report this!'); ?>
 </div>

--- a/plugins/Reporting/views/settings.php
+++ b/plugins/Reporting/views/settings.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
-$CategoryData = GetValue('CategoryData', $this->Data);
+$CategoryData = getValue('CategoryData', $this->Data);
 ?>
-<h1><?php echo T($this->Data('Title')); ?></h1>
+<h1><?php echo t($this->data('Title')); ?></h1>
 <div class="alert alert-info padded">
    <?php echo t('Let your users report bad content and tag awesome content in your community.'); ?>
 </div>
@@ -17,7 +17,7 @@ $CategoryData = GetValue('CategoryData', $this->Data);
 <?php
 
 $Alt = FALSE;
-$ActionURL = 'plugin/reporting/feature/%s/%s?TransientKey='.Gdn::Session()->TransientKey();
+$ActionURL = 'plugin/reporting/feature/%s/%s?TransientKey='.Gdn::session()->transientKey();
 foreach ($Features as $Feature => $FeatureDesc) {
    $Alt = $Alt ? FALSE : TRUE;
    list($FeatureName, $FeatureVerb, $FeatureDescription) = $FeatureDesc;
@@ -25,7 +25,7 @@ foreach ($Features as $Feature => $FeatureDesc) {
    $FeatureEnabled = c('Plugins.Reporting.'.$FeatureKey);
 
    $FeatureActionKey = ucfirst($Feature).'Action';
-   $FeatureAction = GetValue($FeatureActionKey, $ReportingData);
+   $FeatureAction = getValue($FeatureActionKey, $ReportingData);
 
    ?>
    <div class="form-group">
@@ -34,7 +34,7 @@ foreach ($Features as $Feature => $FeatureDesc) {
             <?php echo $FeatureName; ?>
          </div>
          <div class="info">
-            <?php echo Gdn_Format::Text($FeatureDescription); ?>
+            <?php echo Gdn_Format::text($FeatureDescription); ?>
          </div>
       </div>
       <div class="input-wrap-right">
@@ -42,7 +42,7 @@ foreach ($Features as $Feature => $FeatureDesc) {
          <?php
             $ButtonAction = $FeatureEnabled ? 'disable': 'enable';
             $ButtonURL = sprintf($ActionURL, $Feature, $ButtonAction);
-            echo Anchor(T(ucfirst($ButtonAction)), $ButtonURL, 'ToggleFeature SmallButton');
+            echo anchor(t(ucfirst($ButtonAction)), $ButtonURL, 'ToggleFeature SmallButton');
          ?>
       </div>
    </div>

--- a/plugins/Resolved/class.resolved.plugin.php
+++ b/plugins/Resolved/class.resolved.plugin.php
@@ -64,7 +64,7 @@ class ResolvedPlugin extends Gdn_Plugin {
     public function base_afterBodyField_handler($sender, $args) {
         if (checkPermission('Plugins.Resolved.Manage')) {
             echo '<span class="ResolvedCheckbox">' .
-            $sender->Form->checkBox('Resolved', T('Resolved'), ['value' => '1']) . '</span>';
+            $sender->Form->checkBox('Resolved', t('Resolved'), ['value' => '1']) . '</span>';
         }
     }
 
@@ -78,7 +78,7 @@ class ResolvedPlugin extends Gdn_Plugin {
         $resolved = val('Resolved', $discussion);
         $newResolved = (int) !$resolved;
         if (checkPermission('Plugins.Resolved.Manage')) {
-            $label = T($resolved ? 'Unresolve' : 'Resolve');
+            $label = t($resolved ? 'Unresolve' : 'Resolve');
             $url = "/discussion/resolve?discussionid={$discussion->DiscussionID}&resolve={$newResolved}";
             // Deal with inconsistencies in how options are passed
             if (isset($sender->Options)) {
@@ -101,7 +101,7 @@ class ResolvedPlugin extends Gdn_Plugin {
     public function base_beforeDiscussionMeta_handler($sender, $args) {
         $resolved = val('Resolved', val('Discussion', $args));
         if (checkPermission('Plugins.Resolved.Manage') && !$resolved) {
-            echo ' <span class="Tag Tag-Unresolved">' . T('Unresolved') . '</span> ';
+            echo ' <span class="Tag Tag-Unresolved">' . t('Unresolved') . '</span> ';
         }
     }
 
@@ -132,13 +132,13 @@ class ResolvedPlugin extends Gdn_Plugin {
 
         // Make sure we are posting back.
         if (!$sender->Request->isPostBack()) {
-            throw PermissionException('Javascript');
+            throw permissionException('Javascript');
         }
 
         $discussion = $sender->DiscussionModel->getID($discussionID);
 
         if (!$discussion) {
-            throw NotFoundException('Discussion');
+            throw notFoundException('Discussion');
         }
 
         // Resolve the discussion.
@@ -148,7 +148,7 @@ class ResolvedPlugin extends Gdn_Plugin {
 
         if (!$resolve) {
             require_once $sender->fetchViewLocation('helper_functions', 'Discussions');
-            $sender->jsonTarget(".Section-DiscussionList #Discussion_{$discussionID} .Meta-Discussion", '<span class="Tag Tag-Unresolved" title="Unresolved">' . T('Unresolved') . '</span>', 'Prepend');
+            $sender->jsonTarget(".Section-DiscussionList #Discussion_{$discussionID} .Meta-Discussion", '<span class="Tag Tag-Unresolved" title="Unresolved">' . t('Unresolved') . '</span>', 'Prepend');
             $sender->jsonTarget(".Section-DiscussionList #Discussion_{$discussionID}", 'Unresolved', 'AddClass');
         } else {
             $sender->jsonTarget(".Section-DiscussionList #Discussion_{$discussionID} .Tag-Unresolved", null, 'Remove');
@@ -208,7 +208,7 @@ class ResolvedPlugin extends Gdn_Plugin {
      */
     public function base_afterDiscussionFilters_handler($sender) {
         if (checkPermission('Plugins.Resolved.Manage')) {
-            $unresolved .= T('Unresolved').filterCountString(self::countUnresolved());
+            $unresolved .= t('Unresolved').filterCountString(self::countUnresolved());
             echo '<li class="Unresolved">'.anchor(sprite('SpUnresolved').' '.$unresolved, '/discussions/unresolved') . '</li>';
         }
     }
@@ -244,7 +244,7 @@ class ResolvedPlugin extends Gdn_Plugin {
         $page = val(0, $args, 0);
 
         // Determine offset from $Page
-        list($page, $limit) = offsetLimit($page, C('Vanilla.Discussions.PerPage', 30));
+        list($page, $limit) = offsetLimit($page, c('Vanilla.Discussions.PerPage', 30));
 
         // Validate $Page
         if (!is_numeric($page) || $page < 0) {
@@ -260,9 +260,9 @@ class ResolvedPlugin extends Gdn_Plugin {
             ->orWhere('d.Type is null')
             ->endWhereGroup();
 
-        $sender->DiscussionData = $discussionModel->Get($page, $limit, $wheres);
+        $sender->DiscussionData = $discussionModel->get($page, $limit, $wheres);
         $sender->setData('Discussions', $sender->DiscussionData);
-        $countDiscussions = $discussionModel->GetCount($wheres);
+        $countDiscussions = $discussionModel->getCount($wheres);
         $sender->setData('CountDiscussions', $countDiscussions);
         $sender->Category = false;
 
@@ -298,8 +298,8 @@ class ResolvedPlugin extends Gdn_Plugin {
         $sender->addModule('CategoriesModule');
 
         // Render default view
-        $sender->setData('Title', T('Unresolved'));
-        $sender->setData('Breadcrumbs', [['Name' => T('Unresolved'), 'Url' => '/discussions/unresolved']]);
+        $sender->setData('Title', t('Unresolved'));
+        $sender->setData('Breadcrumbs', [['Name' => t('Unresolved'), 'Url' => '/discussions/unresolved']]);
         $sender->render('index');
     }
 

--- a/plugins/RightToLeft/class.righttoleft.plugin.php
+++ b/plugins/RightToLeft/class.righttoleft.plugin.php
@@ -25,14 +25,14 @@ class RightToLeftPlugin extends Gdn_Plugin {
     *
     * @param Gdn_Controller $sender
     */
-    public function Base_Render_Before($sender) {
-        $currentLocale = substr(Gdn::Locale()->Current(), 0, 2);
+    public function base_render_before($sender) {
+        $currentLocale = substr(Gdn::locale()->current(), 0, 2);
 
         if (in_array($currentLocale, $this->rtlLocales)) {
-            if (InSection('Dashboard')) {
-               $sender->AddCssFile('admin_rtl.css', 'plugins/RightToLeft');
+            if (inSection('Dashboard')) {
+               $sender->addCssFile('admin_rtl.css', 'plugins/RightToLeft');
             } else {
-               $sender->AddCssFile('style_rtl.css', 'plugins/RightToLeft');
+               $sender->addCssFile('style_rtl.css', 'plugins/RightToLeft');
             }
 
             $sender->CssClass .= ' rtl';

--- a/plugins/SMFCompatibility/class.smfcompatibility.plugin.php
+++ b/plugins/SMFCompatibility/class.smfcompatibility.plugin.php
@@ -10,7 +10,7 @@
 * See the "license.txt" file for details of the Simple Machines license.          *
 **********************************************************************************/
 
-Gdn::FactoryInstall('BBCodeFormatter', 'SMFCompatibilityPlugin', __FILE__, Gdn::FactorySingleton);
+Gdn::factoryInstall('BBCodeFormatter', 'SMFCompatibilityPlugin', __FILE__, Gdn::FactorySingleton);
 
 class SMFCompatibilityPlugin extends Gdn_Plugin {
 	/// CONSTRUCTOR ///
@@ -23,51 +23,51 @@ class SMFCompatibilityPlugin extends Gdn_Plugin {
 
 	/// METHODS ///
 
-   public function Base_BeforeDispatch_Handler($sender) {
-      $request = Gdn::Request();
-      $folder = ltrim($request->RequestFolder(), '/');
+   public function base_beforeDispatch_handler($sender) {
+      $request = Gdn::request();
+      $folder = ltrim($request->requestFolder(), '/');
       $uri = ltrim($_SERVER['REQUEST_URI'], '/');
 
       // Fix the url in the request for routing.
       if (preg_match("`^{$folder}index.php/`", $uri)) {
-         $request->PathAndQuery(substr($uri, strlen($folder)));
+         $request->pathAndQuery(substr($uri, strlen($folder)));
       }
    }
 
-	public function Format($string) {
+	public function format($string) {
       try {
          $result = parse_bbc($string);
       } catch (Exception $ex) {
          $result = '<!-- Error: '.htmlspecialchars($ex->getMessage()).'-->'
-            .Gdn_Format::Display($string);
+            .Gdn_Format::display($string);
       }
       return $result;
 	}
 
-	public function Setup() {
-      $oldFormat = C('Garden.InputFormatter');
+	public function setup() {
+      $oldFormat = c('Garden.InputFormatter');
 
       if ($oldFormat != 'BBCode') {
-         SaveToConfig([
+         saveToConfig([
             'Garden.InputFormatter' => 'BBCode',
             'Garden.InputFormatterBak' => $oldFormat]);
       }
 
       // Setup the default routes.
-      $router = Gdn::Router();
-      $router->SetRoute('\?board=(\d+).*$', 'categories/$1', 'Permanent');
-      $router->SetRoute('index\.php/topic,(\d+).(\d+)\.html.*$', 'discussion/$1/x/$2lim', 'Permanent');
-      $router->SetRoute('index\.php/board,(\d+)\.(\d+)\.html.*$', 'categories/$1/$2lim', 'Permanent');
-      $router->SetRoute('\?action=profile%3Bu%3D(\d+).*$', 'profile/$1/x', 'Permanent');
-      $router->SetRoute('index\.php/topic,(\d+)\.msg(\d+)\.html.*$', 'discussion/comment/$2/#Comment_$2', 'Permanent');
-      $router->SetRoute('\?topic=(\d+).*$', 'discussion/$1/x/p1', 'Permanent');
+      $router = Gdn::router();
+      $router->setRoute('\?board=(\d+).*$', 'categories/$1', 'Permanent');
+      $router->setRoute('index\.php/topic,(\d+).(\d+)\.html.*$', 'discussion/$1/x/$2lim', 'Permanent');
+      $router->setRoute('index\.php/board,(\d+)\.(\d+)\.html.*$', 'categories/$1/$2lim', 'Permanent');
+      $router->setRoute('\?action=profile%3Bu%3D(\d+).*$', 'profile/$1/x', 'Permanent');
+      $router->setRoute('index\.php/topic,(\d+)\.msg(\d+)\.html.*$', 'discussion/comment/$2/#Comment_$2', 'Permanent');
+      $router->setRoute('\?topic=(\d+).*$', 'discussion/$1/x/p1', 'Permanent');
 	}
 
-   public function OnDisable() {
-      $oldFormat = C('Garden.InputFormatterBak');
+   public function onDisable() {
+      $oldFormat = c('Garden.InputFormatterBak');
 
       if ($oldFormat !== FALSE) {
-         SaveToConfig('Garden.InputFormatter', $oldFormat);
+         saveToConfig('Garden.InputFormatter', $oldFormat);
       }
    }
 }

--- a/plugins/SMFCompatibility/functions.smf.php
+++ b/plugins/SMFCompatibility/functions.smf.php
@@ -46,28 +46,28 @@ function smf_setglobals() {
 
    $txt = [];
    $txt['lang_character_set'] = 'utf8';
-   $txt['smf238'] = T('Code');
-   $txt['smf239'] = T('Quote from');
-   $txt['smf240'] = T('Quote');
-   $txt[176] = T('on');
+   $txt['smf238'] = t('Code');
+   $txt['smf239'] = t('Quote from');
+   $txt['smf240'] = t('Quote');
+   $txt[176] = t('on');
    $txt['lang_locale'] = 'en';
-   $txt[287] = T('Smiley');
-   $txt[288] = T('Angry');
-   $txt[289] = T('Cheesy');
-   $txt[290] = T('Laugh');
-   $txt[291] = T('Sad');
-   $txt[292] = T('Wink');
-   $txt[293] = T('Grin');
-   $txt[294] = T('Shocked');
-   $txt[295] = T('Cool');
-   $txt[296] = T('Huh');
-   $txt[450] = T('Roll Eyes');
-   $txt[451] = T('Tongue');
-   $txt[526] = T('Embarrassed');
-   $txt[527] = T('Lips sealed');
-   $txt[528] = T('Undecided');
-   $txt[529] = T('Kiss');
-   $txt[530] = T('Cry');
+   $txt[287] = t('Smiley');
+   $txt[288] = t('Angry');
+   $txt[289] = t('Cheesy');
+   $txt[290] = t('Laugh');
+   $txt[291] = t('Sad');
+   $txt[292] = t('Wink');
+   $txt[293] = t('Grin');
+   $txt[294] = t('Shocked');
+   $txt[295] = t('Cool');
+   $txt[296] = t('Huh');
+   $txt[450] = t('Roll Eyes');
+   $txt[451] = t('Tongue');
+   $txt[526] = t('Embarrassed');
+   $txt[527] = t('Lips sealed');
+   $txt[528] = t('Undecided');
+   $txt[529] = t('Kiss');
+   $txt[530] = t('Cry');
 }
 smf_setglobals();
 
@@ -1656,7 +1656,7 @@ function permute($array)
 // Format a time to make it look purdy.
 function timeformat($logTime, $show_today = true)
 {
-   return Gdn_Format::Date($logTime);
+   return Gdn_Format::date($logTime);
 
 	global $user_info, $txt, $db_prefix, $modSettings, $func;
 

--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -12,14 +12,14 @@ class ShareThisPlugin extends Gdn_Plugin {
    /**
     * Show buttons after OP message body.
     */
-	public function DiscussionController_AfterDiscussionBody_Handler($sender) {
-      $publisherNumber = C('Plugin.ShareThis.PublisherNumber', 'Publisher Number');
-      $viaHandle = C('Plugin.ShareThis.ViaHandle', '');
-      $copyNShare = C('Plugin.ShareThis.CopyNShare', false);
+	public function discussionController_afterDiscussionBody_handler($sender) {
+      $publisherNumber = c('Plugin.ShareThis.PublisherNumber', 'Publisher Number');
+      $viaHandle = c('Plugin.ShareThis.ViaHandle', '');
+      $copyNShare = c('Plugin.ShareThis.CopyNShare', false);
 
       $doNotHash = $copyNShare ? 'false' : 'true';
       $doNotCopy = $copyNShare ? 'false' : 'true';
-      $domain = Gdn::Request()->Scheme() == 'https' ? 'https://ws.sharethis.com' : 'http://w.sharethis.com';
+      $domain = Gdn::request()->scheme() == 'https' ? 'https://ws.sharethis.com' : 'http://w.sharethis.com';
 
       echo <<<SHARETHIS
       <script type="text/javascript">var switchTo5x=true;</script>
@@ -44,46 +44,46 @@ SHARETHIS;
 
    }
 
-   public function Setup() {
+   public function setup() {
       // Nothing to do here!
    }
    
    /**
     * Settings page.
     */
-   public function PluginController_ShareThis_Create($sender) {
-   	$sender->Permission('Garden.Settings.Manage');
-   	$sender->Title('ShareThis');
-      $sender->AddSideMenu('plugin/sharethis');
+   public function pluginController_shareThis_create($sender) {
+   	$sender->permission('Garden.Settings.Manage');
+   	$sender->title('ShareThis');
+      $sender->addSideMenu('plugin/sharethis');
       $sender->Form = new Gdn_Form();
 
-      $publisherNumber = C('Plugin.ShareThis.PublisherNumber', 'Publisher Number');
-      $viaHandle = C('Plugin.ShareThis.ViaHandle', '');
-      $copyNShare = C('Plugin.ShareThis.CopyNShare', false);
+      $publisherNumber = c('Plugin.ShareThis.PublisherNumber', 'Publisher Number');
+      $viaHandle = c('Plugin.ShareThis.ViaHandle', '');
+      $copyNShare = c('Plugin.ShareThis.CopyNShare', false);
 
       $validation = new Gdn_Validation();
       $configurationModel = new Gdn_ConfigurationModel($validation);
       $configArray = ['Plugin.ShareThis.PublisherNumber','Plugin.ShareThis.ViaHandle', 'Plugin.ShareThis.CopyNShare'];
-      if ($sender->Form->AuthenticatedPostBack() === FALSE) {
+      if ($sender->Form->authenticatedPostBack() === FALSE) {
          $configArray['Plugin.ShareThis.PublisherNumber'] = $publisherNumber;
          $configArray['Plugin.ShareThis.ViaHandle'] = $viaHandle;
          $configArray['Plugin.ShareThis.CopyNShare'] = $copyNShare;
       }
 
-      $configurationModel->SetField($configArray);
-      $sender->Form->SetModel($configurationModel);
+      $configurationModel->setField($configArray);
+      $sender->Form->setModel($configurationModel);
       // If seeing the form for the first time...
-      if ($sender->Form->AuthenticatedPostBack() === FALSE) {
+      if ($sender->Form->authenticatedPostBack() === FALSE) {
          // Apply the config settings to the form.
-         $sender->Form->SetData($configurationModel->Data);
+         $sender->Form->setData($configurationModel->Data);
       } else {
          // Define some validation rules for the fields being saved
-         $configurationModel->Validation->ApplyRule('Plugin.ShareThis.PublisherNumber', 'Required');
-         if ($sender->Form->Save() !== FALSE)
-            $sender->InformMessage(T("Your changes have been saved."));
+         $configurationModel->Validation->applyRule('Plugin.ShareThis.PublisherNumber', 'Required');
+         if ($sender->Form->save() !== FALSE)
+            $sender->informMessage(t("Your changes have been saved."));
       }
 
-      $sender->Render('sharethis', '', 'plugins/ShareThis');
+      $sender->render('sharethis', '', 'plugins/ShareThis');
    }
 
     public function discussionController_render_before($sender) {

--- a/plugins/ShareThis/views/sharethis.php
+++ b/plugins/ShareThis/views/sharethis.php
@@ -1,8 +1,8 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-    <h1><?php echo $this->Data('Title'); ?></h1>
+    <h1><?php echo $this->data('Title'); ?></h1>
 <?php
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 ?>
     <div class="alert alert-info padded">
         <?php echo t('This plugin adds ShareThis buttons to the bottom of each post.'); ?>
@@ -11,7 +11,7 @@ echo $this->Form->Errors();
     <ul>
         <li class="form-group">
             <div class="label-wrap">
-                <?php echo $this->Form->Label("ShareThis Publisher Number", 'Plugin.ShareThis.PublisherNumber'); ?>
+                <?php echo $this->Form->label("ShareThis Publisher Number", 'Plugin.ShareThis.PublisherNumber'); ?>
                 <div class="info">
                     <?php echo t('<a href="http://sharethis.com/register" target="_blank">Register with ShareThis for a publishers account</a>, which gives you support, publishing tools, and analytics. If you do not have, or want a publisher account please leave this field blank.'); ?>
                 </div>
@@ -26,10 +26,10 @@ echo $this->Form->Errors();
         </li>
         <li class="form-group">
             <div class="input-wrap no-label">
-                <?php echo $this->Form->CheckBox('Plugin.ShareThis.CopyNShare', "Enable 'CopyNShare' functionality"); ?>
+                <?php echo $this->Form->checkBox('Plugin.ShareThis.CopyNShare', "Enable 'CopyNShare' functionality"); ?>
             </div>
         </li>
     </ul>
-<?php echo $this->Form->Close('Save');
+<?php echo $this->Form->close('Save');
 
 

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -59,7 +59,7 @@ class SignaturesPlugin extends Gdn_Plugin {
      * @param $sender
      */
     public function profileController_afterAddSideMenu_handler($sender) {
-        if (!CheckPermission('Garden.SignIn.Allow')) {
+        if (!checkPermission('Garden.SignIn.Allow')) {
             return;
         }
 
@@ -170,7 +170,7 @@ class SignaturesPlugin extends Gdn_Plugin {
 
             if (sizeof($frmValues)) {
 
-                if (!GetValue($this->makeMetaKey('Sig'), $frmValues)) {
+                if (!getValue($this->makeMetaKey('Sig'), $frmValues)) {
                     // Delete the signature.
                     $frmValues[$this->makeMetaKey('Sig')] = null;
                     $frmValues[$this->makeMetaKey('Format')] = null;
@@ -192,7 +192,7 @@ class SignaturesPlugin extends Gdn_Plugin {
 
                         $this->setUserMeta($sigUserID, $key, $userMetaValue);
                     }
-                    $sender->informMessage(T("Your changes have been saved."));
+                    $sender->informMessage(t("Your changes have been saved."));
                 }
             }
         } else {
@@ -221,7 +221,7 @@ class SignaturesPlugin extends Gdn_Plugin {
         // Validate the signature.
         if (function_exists('ValidateSignature')) {
             $sig = trim(val('Plugin.Signatures.Sig', $values));
-            if (validateRequired($sig) && !ValidateSignature($sig, val('Plugin.Signatures.Format', $values))) {
+            if (validateRequired($sig) && !validateSignature($sig, val('Plugin.Signatures.Format', $values))) {
                 $sender->Form->addError('Signature invalid.');
             }
         }
@@ -381,7 +381,7 @@ class SignaturesPlugin extends Gdn_Plugin {
             if (function_exists('ValidateSignature')) {
                 $sig = $sender->Form->getFormValue('Body');
                 $format = $sender->Form->getFormValue('Format');
-                if (validateRequired($sig) && !ValidateSignature($sig, $format)) {
+                if (validateRequired($sig) && !validateSignature($sig, $format)) {
                     $sender->Form->addError('Signature invalid.');
                 }
             }
@@ -448,13 +448,13 @@ class SignaturesPlugin extends Gdn_Plugin {
             $userIDList = [];
 
             if ($discussion) {
-                $userIDList[GetValue('InsertUserID', $discussion)] = 1;
+                $userIDList[getValue('InsertUserID', $discussion)] = 1;
             }
 
             if ($comments && $comments->numRows()) {
                 $comments->dataSeek(-1);
                 while ($comment = $comments->nextRow()) {
-                    $userIDList[GetValue('InsertUserID', $comment)] = 1;
+                    $userIDList[getValue('InsertUserID', $comment)] = 1;
                 }
             }
 

--- a/plugins/Solr/class.searchmodel.php
+++ b/plugins/Solr/class.searchmodel.php
@@ -9,8 +9,8 @@ class SearchModel extends Gdn_Model {
 
    /// METHODS ///
 
-   public function Search($search, $offset = 0, $limit = 20) {
-      $baseUrl = C('Plugins.Solr.SearchUrl', 'http://localhost:8983/solr/select/?');
+   public function search($search, $offset = 0, $limit = 20) {
+      $baseUrl = c('Plugins.Solr.SearchUrl', 'http://localhost:8983/solr/select/?');
       if (!$baseUrl)
          throw new Gdn_UserException("The search url has not been configured.");
 
@@ -21,7 +21,7 @@ class SearchModel extends Gdn_Model {
       $search = preg_replace('`([][+&|!(){}^"~*?:\\\\-])`', "\\\\$1", $search);
 
       // Add the category watch.
-      $categories = CategoryModel::CategoryWatch();
+      $categories = CategoryModel::categoryWatch();
       if ($categories === FALSE) {
          return [];
       } elseif ($categories !== TRUE) {
@@ -55,7 +55,7 @@ class SearchModel extends Gdn_Model {
          // Add the url.
          switch ($row['DocType']) {
             case 'Discussion':
-               $row['Url'] = '/discussion/'.$row['PrimaryID'].'/'.Gdn_Format::Url($row['Title']);
+               $row['Url'] = '/discussion/'.$row['PrimaryID'].'/'.Gdn_Format::url($row['Title']);
                break;
             case 'Comment':
                $row['Url'] = "/discussion/comment/{$row['PrimaryID']}/#Comment_{$row['PrimaryID']}";
@@ -67,7 +67,7 @@ class SearchModel extends Gdn_Model {
       }
 
       // Join the users into the result.
-      Gdn_DataSet::Join($result, ['table' => 'User', 'parent' => 'UserID', 'prefix' => '', 'Name', 'Photo']);
+      Gdn_DataSet::join($result, ['table' => 'User', 'parent' => 'UserID', 'prefix' => '', 'Name', 'Photo']);
 
       return $result;
 	}

--- a/plugins/Solr/class.solr.plugin.php
+++ b/plugins/Solr/class.solr.plugin.php
@@ -5,18 +5,18 @@
  */
 
 class SolrPlugin extends Gdn_Plugin {
-   public function SettingsController_Solr_Create($sender, $args = []) {
-      $sender->Permission('Garden.Settings.Manage');
+   public function settingsController_solr_create($sender, $args = []) {
+      $sender->permission('Garden.Settings.Manage');
 
       $conf = new ConfigurationModule($sender);
-      $conf->Initialize([
+      $conf->initialize([
           'Plugins.Solr.SearchUrl' => ['Default' => 'http://localhost:8983/solr/select/?']
       ]);
 
-      $sender->AddSideMenu();
-      $sender->SetData('Title', T('Solr Search Settings'));
+      $sender->addSideMenu();
+      $sender->setData('Title', t('Solr Search Settings'));
       $sender->ConfigurationModule = $conf;
-//      $Conf->RenderAll();
-      $sender->Render('Settings', '', 'plugins/Solr');
+//      $Conf->renderAll();
+      $sender->render('Settings', '', 'plugins/Solr');
    }
 }

--- a/plugins/Solr/views/settings.php
+++ b/plugins/Solr/views/settings.php
@@ -1,11 +1,11 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-<h1><?php echo $this->Data('Title'); ?></h1>
+<h1><?php echo $this->data('Title'); ?></h1>
 <div class="Warning">
    <?php
-   echo T('Warning: This is for advanced users.');
+   echo t('Warning: This is for advanced users.');
    ?>
 </div>
 <?php
 $Cf = $this->ConfigurationModule;
 
-$Cf->Render();
+$Cf->render();

--- a/plugins/Spoof/class.spoof.plugin.php
+++ b/plugins/Spoof/class.spoof.plugin.php
@@ -8,18 +8,18 @@ class SpoofPlugin implements Gdn_IPlugin {
 	/**
 	 * Add the spoof admin screen to the dashboard menu.
 	 */
-   public function Base_GetAppSettingsMenuItems_Handler($sender) {
+   public function base_getAppSettingsMenuItems_handler($sender) {
       // Clean out entire menu & re-add everything
       $menu = &$sender->EventArguments['SideMenu'];
-      $menu->AddLink('Users', T('Spoof'), 'user/spoof', 'Garden.Settings.Manage');
+      $menu->addLink('Users', t('Spoof'), 'user/spoof', 'Garden.Settings.Manage');
 	}
 
 	/**
 	 * Admin screen for spoofing a user.
 	 */
-   public function UserController_Spoof_Create($sender) {
-		$sender->Permission('Garden.Settings.Manage');
-      $sender->AddSideMenu('user/spoof');
+   public function userController_spoof_create($sender) {
+		$sender->permission('Garden.Settings.Manage');
+      $sender->addSideMenu('user/spoof');
 		$this->_SpoofMethod($sender);
 	}
 
@@ -29,18 +29,18 @@ class SpoofPlugin implements Gdn_IPlugin {
      *
      * @param UserController $sender
 	 */
-	public function UserController_AutoSpoof_Create($sender) {
-		$spoofUserID = GetValue('0', $sender->RequestArgs);
-		$transientKey = GetValue('1', $sender->RequestArgs);
+	public function userController_autoSpoof_create($sender) {
+		$spoofUserID = getValue('0', $sender->RequestArgs);
+		$transientKey = getValue('1', $sender->RequestArgs);
 		// Validate the transient key && permissions
-		if (Gdn::Session()->ValidateTransientKey($transientKey) && Gdn::Session()->CheckPermission('Garden.Settings.Manage')) {
+		if (Gdn::session()->validateTransientKey($transientKey) && Gdn::session()->checkPermission('Garden.Settings.Manage')) {
 			$identity = new Gdn_CookieIdentity();
-			$identity->Init([
-				'Salt' => Gdn::Config('Garden.Cookie.Salt'),
-				'Name' => Gdn::Config('Garden.Cookie.Name'),
-				'Domain' => Gdn::Config('Garden.Cookie.Domain')
+			$identity->init([
+				'Salt' => Gdn::config('Garden.Cookie.Salt'),
+				'Name' => Gdn::config('Garden.Cookie.Name'),
+				'Domain' => Gdn::config('Garden.Cookie.Domain')
 			]);
-			$identity->SetIdentity($spoofUserID, TRUE);
+			$identity->setIdentity($spoofUserID, TRUE);
 		}
 		if ($this->_DeliveryType !== DELIVERY_TYPE_ALL) {
 			$sender->setRedirectTo('profile');
@@ -53,11 +53,11 @@ class SpoofPlugin implements Gdn_IPlugin {
 	/**
 	 * Adds a "Spoof" link to the user management list.
 	 */
-	public function UserController_UserListOptions_Handler($sender) {
-		if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage'))
+	public function userController_userListOptions_handler($sender) {
+		if (!Gdn::session()->checkPermission('Garden.Settings.Manage'))
 			return;
 
-		$user = GetValue('User', $sender->EventArguments);
+		$user = getValue('User', $sender->EventArguments);
 		if ($user) {
 			$attr = [
 				'aria-label' => t('Spoof'),
@@ -65,38 +65,38 @@ class SpoofPlugin implements Gdn_IPlugin {
 				'data-follow-link' => 'true'
 			];
 			$class = 'js-modal-confirm btn btn-icon';
-			echo anchor(dashboardSymbol('spoof'), '/user/autospoof/'.$user->UserID.'/'.Gdn::Session()->TransientKey(), $class, $attr);
+			echo anchor(dashboardSymbol('spoof'), '/user/autospoof/'.$user->UserID.'/'.Gdn::session()->transientKey(), $class, $attr);
 		}
 	}
 
 	/**
 	 * Adds a "Spoof" link to the site management list.
 	 */
-	public function ManageController_SiteListOptions_Handler($sender) {
-		if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage'))
+	public function manageController_siteListOptions_handler($sender) {
+		if (!Gdn::session()->checkPermission('Garden.Settings.Manage'))
 			return;
 
-		$site = GetValue('Site', $sender->EventArguments);
+		$site = getValue('Site', $sender->EventArguments);
 		if ($site)
-			echo Anchor(T('Spoof'), '/user/autospoof/'.$site->InsertUserID.'/'.Gdn::Session()->TransientKey(), 'PopConfirm SmallButton');
+			echo anchor(t('Spoof'), '/user/autospoof/'.$site->InsertUserID.'/'.Gdn::session()->transientKey(), 'PopConfirm SmallButton');
 	}
 
-   public function ProfileController_AfterAddSideMenu_Handler($sender) {
-		if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage'))
+   public function profileController_afterAddSideMenu_handler($sender) {
+		if (!Gdn::session()->checkPermission('Garden.Settings.Manage'))
 			return;
 
       $sideMenu = $sender->EventArguments['SideMenu'];
-      $viewingUserID = Gdn::Session()->UserID;
+      $viewingUserID = Gdn::session()->UserID;
 
       if ($sender->User->UserID != $viewingUserID)
-         $sideMenu->AddLink('Options', T('Spoof User'), '/user/autospoof/'.$sender->User->UserID.'/'.Gdn::Session()->TransientKey(), '', ['class' => 'PopConfirm']);
+         $sideMenu->addLink('Options', t('Spoof User'), '/user/autospoof/'.$sender->User->UserID.'/'.Gdn::session()->transientKey(), '', ['class' => 'PopConfirm']);
    }
 
 
 	/**
 	 * Creates a spoof login page.
 	 */
-	public function EntryController_Spoof_Create($sender) {
+	public function entryController_spoof_create($sender) {
 		$this->_SpoofMethod($sender);
 	}
 
@@ -104,43 +104,43 @@ class SpoofPlugin implements Gdn_IPlugin {
 	 * Standard method for authenticating an admin and allowing them to spoof a user.
 	 */
 	private function _SpoofMethod($sender) {
-      $sender->Title('Spoof');
+      $sender->title('Spoof');
       $sender->Form = new Gdn_Form();
-      $userReference = $sender->Form->GetValue('UserReference', '');
-      $email = $sender->Form->GetValue('Email', '');
-      $password = $sender->Form->GetValue('Password', '');
+      $userReference = $sender->Form->getValue('UserReference', '');
+      $email = $sender->Form->getValue('Email', '');
+      $password = $sender->Form->getValue('Password', '');
 
       if ($userReference != '' && $email != '' && $password != '') {
-         $userModel = Gdn::UserModel();
-         $userData = $userModel->ValidateCredentials($email, 0, $password);
+         $userModel = Gdn::userModel();
+         $userData = $userModel->validateCredentials($email, 0, $password);
 
          if (is_object($userData) && $userModel->checkPermission($userData->UserID, 'Garden.Settings.Manage')) {
 				if (is_numeric($userReference)) {
-					$spoofUser = $userModel->GetID($userReference);
+					$spoofUser = $userModel->getID($userReference);
 				} else {
-				   $spoofUser = $userModel->GetByUsername($userReference);
+				   $spoofUser = $userModel->getByUsername($userReference);
 				}
 
 				if ($spoofUser) {
 					$identity = new Gdn_CookieIdentity();
-					$identity->Init([
-						'Salt' => Gdn::Config('Garden.Cookie.Salt'),
-						'Name' => Gdn::Config('Garden.Cookie.Name'),
-						'Domain' => Gdn::Config('Garden.Cookie.Domain')
+					$identity->init([
+						'Salt' => Gdn::config('Garden.Cookie.Salt'),
+						'Name' => Gdn::config('Garden.Cookie.Name'),
+						'Domain' => Gdn::config('Garden.Cookie.Domain')
 					]);
-					$identity->SetIdentity($spoofUser->UserID, TRUE);
+					$identity->setIdentity($spoofUser->UserID, TRUE);
 	                redirectTo('profile');
 				} else {
-					$sender->Form->AddError('Failed to find requested user.');
+					$sender->Form->addError('Failed to find requested user.');
 				}
          } else {
-            $sender->Form->AddError('Bad Credentials');
+            $sender->Form->addError('Bad Credentials');
          }
       }
 
-      $sender->Render(PATH_PLUGINS . DS . 'Spoof' . DS . 'views' . DS . 'spoof.php');
+      $sender->render(PATH_PLUGINS . DS . 'Spoof' . DS . 'views' . DS . 'spoof.php');
    }
 
-   public function Setup() {}
+   public function setup() {}
 
 }

--- a/plugins/Spoof/views/spoof.php
+++ b/plugins/Spoof/views/spoof.php
@@ -1,6 +1,6 @@
 <?php if (!defined('APPLICATION')) exit();
-echo $this->Form->Open();
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->errors();
 echo heading(t('Spoof'));
 ?>
 <ul>
@@ -19,8 +19,8 @@ echo heading(t('Spoof'));
    <li class="form-group">
       <?php echo $this->Form->labelWrap('Your Password', 'Password'); ?>
       <div class="input-wrap">
-         <?php echo $this->Form->Input('Password', 'password'); ?>
+         <?php echo $this->Form->input('Password', 'password'); ?>
       </div>
    </li>
 </ul>
-<?php echo $this->Form->Close('Go'); ?>
+<?php echo $this->Form->close('Go'); ?>

--- a/plugins/Sprites/class.sprites.plugin.php
+++ b/plugins/Sprites/class.sprites.plugin.php
@@ -10,13 +10,13 @@
 
 class SpritesPlugin extends Gdn_Plugin {
 
-   public function Base_Render_Before($sender) {
+   public function base_render_before($sender) {
       if ($sender->MasterView == '' || $sender->MasterView == 'default')
-         $sender->AddCssFile('sprites.css', 'plugins/Sprites');
+         $sender->addCssFile('sprites.css', 'plugins/Sprites');
    }
 
-   public function Setup() {}
+   public function setup() {}
 
-   public function Structure() {}
+   public function structure() {}
 
 }

--- a/plugins/StopAutoDraft/class.stopautodraft.plugin.php
+++ b/plugins/StopAutoDraft/class.stopautodraft.plugin.php
@@ -10,15 +10,15 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 
 class StopAutoDraftPlugin extends Gdn_Plugin {
 
-   public function DiscussionController_Render_Before($sender) {
+   public function discussionController_render_before($sender) {
 		$this->_NoDrafting($sender);
 	}
-   public function PostController_Render_Before($sender) {
+   public function postController_render_before($sender) {
 		$this->_NoDrafting($sender);
 	}
 	private function _NoDrafting($sender) {
-	   $sender->RemoveJsFile('autosave.js');
-		$sender->Head->AddString('
+	   $sender->removeJsFile('autosave.js');
+		$sender->Head->addString('
 <script type="text/javascript">
 jQuery(document).ready(function($) {
    $.fn.autosave = function(opts) {
@@ -29,7 +29,7 @@ jQuery(document).ready(function($) {
 ');
    }
 	
-   public function OnDisable() { }
-   public function Setup() { }
+   public function onDisable() { }
+   public function setup() { }
 	
 }

--- a/plugins/SubmarineDiscussions/class.submarinediscussions.plugin.php
+++ b/plugins/SubmarineDiscussions/class.submarinediscussions.plugin.php
@@ -4,16 +4,16 @@ class SubmarineDiscussionsPlugin extends Gdn_Plugin {
    /**
 	 * Add 'sink' option to new discussion form.
 	 */
-   public function PostController_DiscussionFormOptions_Handler($sender) {
-      $session = Gdn::Session();
-      if ($session->CheckPermission('Vanilla.Discussions.Sink'))
-         $sender->EventArguments['Options'] .= '<li>'.$sender->Form->CheckBox('Sink', T('Sink'), ['value' => '1']).'</li>';
+   public function postController_discussionFormOptions_handler($sender) {
+      $session = Gdn::session();
+      if ($session->checkPermission('Vanilla.Discussions.Sink'))
+         $sender->EventArguments['Options'] .= '<li>'.$sender->Form->checkBox('Sink', t('Sink'), ['value' => '1']).'</li>';
    }
    
    /**
 	 * Set DateLastComment to null if this is an insert and 'sink' was selected.
 	 */
-   public function DiscussionModel_BeforeSaveDiscussion_Handler($sender) {
+   public function discussionModel_beforeSaveDiscussion_handler($sender) {
       if ($sender->EventArguments['Insert'] && $sender->EventArguments['FormPostValues']['Sink'] == 1)
          $sender->EventArguments['FormPostValues']['DateLastComment'] = NULL;
    }

--- a/plugins/TouchIcon/class.touchicon.plugin.php
+++ b/plugins/TouchIcon/class.touchicon.plugin.php
@@ -10,8 +10,8 @@ class TouchIconPlugin extends Gdn_Plugin {
    /**
 	 * Create route.
 	 */
-   public function Setup() {
-      Gdn::Router()->SetRoute(
+   public function setup() {
+      Gdn::router()->setRoute(
          'apple-touch-icon.png',
          'utility/showtouchicon',
          'Internal'
@@ -21,18 +21,18 @@ class TouchIconPlugin extends Gdn_Plugin {
    /**
     * Remove route.
     */
-   public function OnDisable() {
-      Gdn::Router()->DeleteRoute('apple-touch-icon.png');
+   public function onDisable() {
+      Gdn::router()->deleteRoute('apple-touch-icon.png');
    }
 
    /**
     * Updates.
     */
-   public function Structure() {
+   public function structure() {
       // Backwards compatibility with v1.
-      if (C('Plugins.TouchIcon.Uploaded')) {
-         SaveToConfig('Garden.TouchIcon', 'TouchIcon/apple-touch-icon.png');
-         RemoveFromConfig('Plugins.TouchIcon.Uploaded');
+      if (c('Plugins.TouchIcon.Uploaded')) {
+         saveToConfig('Garden.TouchIcon', 'TouchIcon/apple-touch-icon.png');
+         removeFromConfig('Plugins.TouchIcon.Uploaded');
       }
    }
 
@@ -42,20 +42,20 @@ class TouchIconPlugin extends Gdn_Plugin {
     * @since 1.0
     * @access public
     */
-   public function SettingsController_TouchIcon_Create($sender) {
-      $sender->Permission('Garden.Settings.Manage');
-      $sender->AddSideMenu('settings/touchicon');
-      $sender->Title(T('Touch Icon'));
+   public function settingsController_touchIcon_create($sender) {
+      $sender->permission('Garden.Settings.Manage');
+      $sender->addSideMenu('settings/touchicon');
+      $sender->title(t('Touch Icon'));
 
-      if ($sender->Form->AuthenticatedPostBack()) {
+      if ($sender->Form->authenticatedPostBack()) {
          $upload = new Gdn_UploadImage();
          try {
             // Validate the upload
-            $tmpImage = $upload->ValidateUpload('TouchIcon', FALSE);
+            $tmpImage = $upload->validateUpload('TouchIcon', FALSE);
             if ($tmpImage) {
                // Save the uploaded image.
                $touchIconPath ='banner/touchicon_'.substr(md5(microtime()), 16).'.png';
-               $imageInfo = $upload->SaveImageAs(
+               $imageInfo = $upload->saveImageAs(
                   $tmpImage,
                   $touchIconPath,
                   114,
@@ -63,17 +63,17 @@ class TouchIconPlugin extends Gdn_Plugin {
                   ['OutputType' => 'png', 'ImageQuality' => '8']
                );
 
-               SaveToConfig('Garden.TouchIcon', $imageInfo['SaveName']);
+               saveToConfig('Garden.TouchIcon', $imageInfo['SaveName']);
             }
          } catch (Exception $ex) {
-            $sender->Form->AddError($ex->getMessage());
+            $sender->Form->addError($ex->getMessage());
          }
 
-         $sender->InformMessage(T("Your icon has been saved."));
+         $sender->informMessage(t("Your icon has been saved."));
       }
 
-      $sender->SetData('Path', $this->getIconUrl());
-      $sender->Render($this->GetView('touchicon.php'));
+      $sender->setData('Path', $this->getIconUrl());
+      $sender->render($this->getView('touchicon.php'));
    }
 
    /**
@@ -82,7 +82,7 @@ class TouchIconPlugin extends Gdn_Plugin {
     * @return string Path to icon
     */
    public function getIconUrl() {
-      $icon = C('Garden.TouchIcon') ? Gdn_Upload::Url(C('Garden.TouchIcon')) : Asset(self::DEFAULT_PATH);
+      $icon = c('Garden.TouchIcon') ? Gdn_Upload::url(c('Garden.TouchIcon')) : asset(self::DEFAULT_PATH);
       return $icon;
    }
 
@@ -92,7 +92,7 @@ class TouchIconPlugin extends Gdn_Plugin {
     * @since 1.0
     * @access public
     */
-   public function UtilityController_ShowTouchIcon_Create($sender) {
+   public function utilityController_showTouchIcon_create($sender) {
       $redirect = $this->getIconUrl();
       redirectTo($redirect, 302, false);
       exit();

--- a/plugins/TouchIcon/views/touchicon.php
+++ b/plugins/TouchIcon/views/touchicon.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 $Session = Gdn::session();
 ?>
-<h1><?php echo T('Touch Icon'); ?></h1>
+<h1><?php echo t('Touch Icon'); ?></h1>
 <?php
 echo $this->Form->open(['enctype' => 'multipart/form-data']);
 echo $this->Form->errors();

--- a/plugins/TrackingCodes/class.trackingcodes.plugin.php
+++ b/plugins/TrackingCodes/class.trackingcodes.plugin.php
@@ -7,20 +7,20 @@ class TrackingCodesPlugin extends Gdn_Plugin {
    /**
     * Adds dashboard menu option.
     */
-   public function Base_GetAppSettingsMenuItems_Handler($sender) {
+   public function base_getAppSettingsMenuItems_handler($sender) {
       $menu = &$sender->EventArguments['SideMenu'];
-      $menu->AddLink('Add-ons', T('Tracking Codes'), 'settings/trackingcodes', 'Garden.Settings.Manage');
+      $menu->addLink('Add-ons', t('Tracking Codes'), 'settings/trackingcodes', 'Garden.Settings.Manage');
 	}
 
 	/**
 	 * Tracking codes management page.
 	 */
-	public function SettingsController_TrackingCodes_Create($sender) {
-		$sender->Permission('Garden.Settings.Manage');
-      $sender->AddSideMenu('settings/trackingcodes');
+	public function settingsController_trackingCodes_create($sender) {
+		$sender->permission('Garden.Settings.Manage');
+      $sender->addSideMenu('settings/trackingcodes');
 
-      $sender->Title('Tracking Codes');
-		$action = strtolower(GetValue(0, $sender->RequestArgs, ''));
+      $sender->title('Tracking Codes');
+		$action = strtolower(getValue(0, $sender->RequestArgs, ''));
 		if ($action == 'add')
 			$this->_Add($sender);
 		else if ($action == 'edit')
@@ -32,27 +32,27 @@ class TrackingCodesPlugin extends Gdn_Plugin {
 		else if ($action == 'sort')
 			$this->_Sort($sender);
 		else
-			$sender->Render('index', '', 'plugins/TrackingCodes');
+			$sender->render('index', '', 'plugins/TrackingCodes');
 	}
 
    /**
     * Delete a code.
     */
    private function _Delete($sender) {
-      $sender->Permission('Garden.Settings.Manage');
-		$key = GetValue(1, $sender->RequestArgs);
-		$transientKey = GetValue(2, $sender->RequestArgs);
-      $session = Gdn::Session();
-      if ($transientKey !== FALSE && $session->ValidateTransientKey($transientKey)) {
-			$trackingCodes = C('Plugins.TrackingCodes.All');
+      $sender->permission('Garden.Settings.Manage');
+		$key = getValue(1, $sender->RequestArgs);
+		$transientKey = getValue(2, $sender->RequestArgs);
+      $session = Gdn::session();
+      if ($transientKey !== FALSE && $session->validateTransientKey($transientKey)) {
+			$trackingCodes = c('Plugins.TrackingCodes.All');
 			if (!is_array($trackingCodes))
 				$trackingCodes = [];
 
 			if ($key !== FALSE)
 				foreach ($trackingCodes as $index => $code) {
-					if ($key == GetValue('Key', $code, FALSE)) {
+					if ($key == getValue('Key', $code, FALSE)) {
 						unset($trackingCodes[$index]);
-						SaveToConfig('Plugins.TrackingCodes.All', $trackingCodes);
+						saveToConfig('Plugins.TrackingCodes.All', $trackingCodes);
 						break;
 					}
 				}
@@ -65,21 +65,21 @@ class TrackingCodesPlugin extends Gdn_Plugin {
     * Toggle a tracking code's state.
     */
    private function _Toggle($sender) {
-      $sender->Permission('Garden.Settings.Manage');
-		$key = GetValue(1, $sender->RequestArgs);
-		$transientKey = GetValue(2, $sender->RequestArgs);
-      $session = Gdn::Session();
-      if ($transientKey !== FALSE && $session->ValidateTransientKey($transientKey)) {
-			$trackingCodes = C('Plugins.TrackingCodes.All');
+      $sender->permission('Garden.Settings.Manage');
+		$key = getValue(1, $sender->RequestArgs);
+		$transientKey = getValue(2, $sender->RequestArgs);
+      $session = Gdn::session();
+      if ($transientKey !== FALSE && $session->validateTransientKey($transientKey)) {
+			$trackingCodes = c('Plugins.TrackingCodes.All');
 			if (!is_array($trackingCodes))
 				$trackingCodes = [];
 
 			if ($key !== FALSE)
 				foreach ($trackingCodes as $index => $code) {
-					if ($key == GetValue('Key', $code, FALSE)) {
-						$code['Enabled'] = GetValue('Enabled', $code) == '1' ? '0' : '1';
+					if ($key == getValue('Key', $code, FALSE)) {
+						$code['Enabled'] = getValue('Enabled', $code) == '1' ? '0' : '1';
 						$trackingCodes[$index] = $code;
-						SaveToConfig('Plugins.TrackingCodes.All', $trackingCodes);
+						saveToConfig('Plugins.TrackingCodes.All', $trackingCodes);
 						break;
 					}
 				}
@@ -94,39 +94,39 @@ class TrackingCodesPlugin extends Gdn_Plugin {
     * @param SettingsController $sender
     */
    private function _Edit($sender) {
-		$sender->Permission('Garden.Settings.Manage');
-      $sender->AddSideMenu('settings/trackingcodes');
-      $sender->AddJsFile('jquery.autogrow.js');
+		$sender->permission('Garden.Settings.Manage');
+      $sender->addSideMenu('settings/trackingcodes');
+      $sender->addJsFile('jquery.autogrow.js');
 		$editIndex = FALSE;
-		$editKey = GetValue(1, $sender->RequestArgs);
+		$editKey = getValue(1, $sender->RequestArgs);
 		$sender->Code = FALSE;
-		$trackingCodes = C('Plugins.TrackingCodes.All');
+		$trackingCodes = c('Plugins.TrackingCodes.All');
 		if (!is_array($trackingCodes))
 			$trackingCodes = [];
 
 		if ($editKey !== FALSE)
 			foreach ($trackingCodes as $index => $code) {
-				if ($editKey == GetValue('Key', $code, FALSE)) {
+				if ($editKey == getValue('Key', $code, FALSE)) {
 					$editIndex = $index;
 					$sender->Code = $code;
 					break;
 				}
 			}
 
-      if (!$sender->Form->AuthenticatedPostBack()) {
+      if (!$sender->Form->authenticatedPostBack()) {
 			// Set defaults
 			if ($sender->Code)
-				$sender->Form->SetData($sender->Code);
+				$sender->Form->setData($sender->Code);
       } else {
 			// Let the form take care of itself, but save to the db.
-			$formValues = $sender->Form->FormValues();
-			$valuesToSave['Key'] = GetValue('Key', $formValues, '');
+			$formValues = $sender->Form->formValues();
+			$valuesToSave['Key'] = getValue('Key', $formValues, '');
 			if ($valuesToSave['Key'] == '')
-				$valuesToSave['Key'] = time().Gdn::Session()->UserID; // create a new unique id for the item
+				$valuesToSave['Key'] = time().Gdn::session()->UserID; // create a new unique id for the item
 
-			$valuesToSave['Name'] = GetValue('Name', $formValues, '');
-			$valuesToSave['Code'] = GetValue('Code', $formValues, '');
-			$valuesToSave['Enabled'] = GetValue('Enabled', $formValues, '');
+			$valuesToSave['Name'] = getValue('Name', $formValues, '');
+			$valuesToSave['Code'] = getValue('Code', $formValues, '');
+			$valuesToSave['Enabled'] = getValue('Enabled', $formValues, '');
 			if ($editIndex !== FALSE) {
 				$sender->Code = $valuesToSave; // Show the correct page title (add or edit).
 				$trackingCodes[$editIndex] = $valuesToSave;
@@ -134,28 +134,28 @@ class TrackingCodesPlugin extends Gdn_Plugin {
 				$trackingCodes[] = $valuesToSave;
 			}
 
-			SaveToConfig('Plugins.TrackingCodes.All', $trackingCodes);
-         $sender->InformMessage(T('Your changes have been saved.'));
+			saveToConfig('Plugins.TrackingCodes.All', $trackingCodes);
+         $sender->informMessage(t('Your changes have been saved.'));
 			$sender->setRedirectTo('settings/trackingcodes');
       }
 
-      $sender->Render('edit', '', 'plugins/TrackingCodes');
+      $sender->render('edit', '', 'plugins/TrackingCodes');
    }
 
 
 	/**
 	 * Dump all of the tracking codes to the page if *not* in admin master view.
 	 */
-	public function Base_AfterBody_Handler($sender) {
+	public function base_afterBody_handler($sender) {
 		if ($sender->MasterView == 'admin')
 			return;
 
-		$trackingCodes = C('Plugins.TrackingCodes.All');
+		$trackingCodes = c('Plugins.TrackingCodes.All');
 		if (!is_array($trackingCodes))
 			$trackingCodes = [];
 		foreach ($trackingCodes as $index => $code) {
-			if (GetValue('Enabled', $code) == '1')
-				echo GetValue('Code', $code);
+			if (getValue('Enabled', $code) == '1')
+				echo getValue('Code', $code);
 		}
 	}
 }

--- a/plugins/TrackingCodes/views/edit.php
+++ b/plugins/TrackingCodes/views/edit.php
@@ -1,32 +1,32 @@
 <?php if (!defined('APPLICATION')) exit();?>
 <h1><?php
    if (($this->Code))
-      echo T('Edit Tracking Code');
+      echo t('Edit Tracking Code');
    else
-      echo T('Add Tracking Code');
+      echo t('Add Tracking Code');
 ?></h1>
 <?php
-echo $this->Form->Open();
-echo $this->Form->Hidden('Key');
-echo $this->Form->Errors();
+echo $this->Form->open();
+echo $this->Form->hidden('Key');
+echo $this->Form->errors();
 ?>
 <ul>
    <li>
       <?php
-         echo $this->Form->Label('Name', 'Name');
-         echo $this->Form->TextBox('Name');
+         echo $this->Form->label('Name', 'Name');
+         echo $this->Form->textBox('Name');
       ?>
    </li>
    <li>
       <?php
-         echo $this->Form->Label('Code', 'Code');
-         echo $this->Form->TextBox('Code', ['MultiLine' => TRUE]);
+         echo $this->Form->label('Code', 'Code');
+         echo $this->Form->textBox('Code', ['MultiLine' => TRUE]);
       ?>
    </li>
    <li>
       <?php
-         echo $this->Form->CheckBox('Enabled', 'Enable this tracking code', ['value' => '1']);
+         echo $this->Form->checkBox('Enabled', 'Enable this tracking code', ['value' => '1']);
       ?>
    </li>
 </ul>
-<?php echo $this->Form->Close('Save');
+<?php echo $this->Form->close('Save');

--- a/plugins/TrackingCodes/views/index.php
+++ b/plugins/TrackingCodes/views/index.php
@@ -1,40 +1,40 @@
 <?php if (!defined('APPLICATION')) exit();
-$Session = Gdn::Session();
-$TrackingCodes = C('Plugins.TrackingCodes.All');
+$Session = Gdn::session();
+$TrackingCodes = c('Plugins.TrackingCodes.All');
 if (!is_array($TrackingCodes))
    $TrackingCodes = [];
 
 ?>
-<h1><?php echo T('Tracking Codes'); ?></h1>
-<div class="Info"><?php echo T('Tracking codes are added to every page just above the closing &lt;/body&gt; tag. Useful for common tracking code generators like Google Analytics, Hubspot, etc. Add, edit and enable/disable them below.'); ?></div>
-<div class="FilterMenu"><?php echo Anchor(T('Add Tracking Code'), 'settings/trackingcodes/edit', 'AddTrackingCode SmallButton'); ?></div>
+<h1><?php echo t('Tracking Codes'); ?></h1>
+<div class="Info"><?php echo t('Tracking codes are added to every page just above the closing &lt;/body&gt; tag. Useful for common tracking code generators like Google Analytics, Hubspot, etc. Add, edit and enable/disable them below.'); ?></div>
+<div class="FilterMenu"><?php echo anchor(t('Add Tracking Code'), 'settings/trackingcodes/edit', 'AddTrackingCode SmallButton'); ?></div>
 <?php if (count($TrackingCodes) > 0) { ?>
 <table id="MessageTable" border="0" cellpadding="0" cellspacing="0" class="AltColumns Sortable">
    <thead>
       <tr id="0">
-         <th><?php echo T('Tracking Code'); ?></th>
-         <th class="Alt"><?php echo T('State'); ?></th>
-         <th><?php echo T('Options'); ?></th>
+         <th><?php echo t('Tracking Code'); ?></th>
+         <th class="Alt"><?php echo t('State'); ?></th>
+         <th><?php echo t('Options'); ?></th>
       </tr>
    </thead>
    <tbody>
 <?php
 $Alt = FALSE;
 foreach ($TrackingCodes as $Index => $Code) {
-   $Key = GetValue('Key', $Code, '');
+   $Key = getValue('Key', $Code, '');
    $Alt = $Alt ? FALSE : TRUE;
    ?>
    <tr id="<?php
       echo $Index;
       echo $Alt ? '" class="Alt' : '';
    ?>">
-      <td class="Info nowrap"><strong><?php echo GetValue('Name', $Code, 'Undefined'); ?></strong></td>
-      <td class="Alt"><?php echo GetValue('Enabled', $Code) == '1' ? 'Enabled' : 'Disabled'; ?></td>
+      <td class="Info nowrap"><strong><?php echo getValue('Name', $Code, 'Undefined'); ?></strong></td>
+      <td class="Alt"><?php echo getValue('Enabled', $Code) == '1' ? 'Enabled' : 'Disabled'; ?></td>
       <td>
          <?php
-         echo Anchor(T(GetValue('Enabled', $Code) == '1' ? 'Disable' : 'Enable'), '/settings/trackingcodes/toggle/'.$Key.'/'.$Session->TransientKey(), 'ToggleCode SmallButton');
-         echo Anchor(T('Edit'), '/settings/trackingcodes/edit/'.$Key, 'EditCode SmallButton');
-         echo Anchor(T('Delete'), '/settings/trackingcodes/delete/'.$Key.'/'.$Session->TransientKey(), 'PopConfirm SmallButton');
+         echo anchor(t(getValue('Enabled', $Code) == '1' ? 'Disable' : 'Enable'), '/settings/trackingcodes/toggle/'.$Key.'/'.$Session->transientKey(), 'ToggleCode SmallButton');
+         echo anchor(t('Edit'), '/settings/trackingcodes/edit/'.$Key, 'EditCode SmallButton');
+         echo anchor(t('Delete'), '/settings/trackingcodes/delete/'.$Key.'/'.$Session->transientKey(), 'PopConfirm SmallButton');
          ?>
          </div>
       </td>

--- a/plugins/TrollManagement/class.sharedfingerprintmodule.php
+++ b/plugins/TrollManagement/class.sharedfingerprintmodule.php
@@ -6,37 +6,37 @@ class SharedFingerprintModule extends Gdn_Module {
 
 	protected $_Data = FALSE;
 	
-	public function GetData($fingerprintUserID, $fingerprint) {
-		if (!Gdn::Session()->CheckPermission('Garden.Users.Edit'))
+	public function getData($fingerprintUserID, $fingerprint) {
+		if (!Gdn::session()->checkPermission('Garden.Users.Edit'))
 			return;
 		
-		$this->_Data = Gdn::SQL()
-			->Select()
-			->From('User')
-			->Where('Fingerprint', $fingerprint)
-			->Where('UserID <>', $fingerprintUserID)
-			->Get();
+		$this->_Data = Gdn::sql()
+			->select()
+			->from('User')
+			->where('Fingerprint', $fingerprint)
+			->where('UserID <>', $fingerprintUserID)
+			->get();
 	}
 
-	public function AssetTarget() {
+	public function assetTarget() {
 		return 'Panel';
 	}
 
-	public function ToString() {
+	public function toString() {
       if (!$this->_Data)
 			return;
       
-		if ($this->_Data->NumRows() == 0)
+		if ($this->_Data->numRows() == 0)
 			return;
 		
 		ob_start();
 		?>
       <div id="SharedFingerprint" class="Box">
-         <h4><?php echo T("Shared Accounts"); ?> <span class="Count"><?php echo $this->_Data->NumRows(); ?></span></h4>
+         <h4><?php echo t("Shared Accounts"); ?> <span class="Count"><?php echo $this->_Data->numRows(); ?></span></h4>
 			<ul class="PanelInfo">
          <?php
-			foreach ($this->_Data->Result() as $sharedAccount) {
-				echo '<li><strong>'.UserAnchor($sharedAccount).'</strong><br /></li>';
+			foreach ($this->_Data->result() as $sharedAccount) {
+				echo '<li><strong>'.userAnchor($sharedAccount).'</strong><br /></li>';
 			}
          ?>
 			</ul>

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -83,7 +83,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
         // Validate the transient key && permissions
         // Make sure we are posting back.
         if (!$sender->Request->isAuthenticatedPostBack()) {
-            throw PermissionException('Javascript');
+            throw permissionException('Javascript');
         }
 
         $trolls = self::getTrolls();

--- a/plugins/Vanoogle/class.vanoogle.plugin.php
+++ b/plugins/Vanoogle/class.vanoogle.plugin.php
@@ -27,31 +27,31 @@ class VanooglePlugin extends Gdn_Plugin {
      * Build the setting page.
      * @param $sender
      */
-    public function SettingsController_Vanoogle_Create($sender) {
-        $sender->Permission('Garden.Settings.Manage');
+    public function settingsController_vanoogle_create($sender) {
+        $sender->permission('Garden.Settings.Manage');
 
         $validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
-        $configurationModel->SetField(["Plugins.Vanoogle.CSE"]);
-        $sender->Form->SetModel($configurationModel);
+        $configurationModel->setField(["Plugins.Vanoogle.CSE"]);
+        $sender->Form->setModel($configurationModel);
 
-        if ($sender->Form->AuthenticatedPostBack() === FALSE) {
-            $sender->Form->SetData($configurationModel->Data);
+        if ($sender->Form->authenticatedPostBack() === FALSE) {
+            $sender->Form->setData($configurationModel->Data);
         } else {
-            $data = $sender->Form->FormValues();
-            $configurationModel->Validation->ApplyRule("Plugins.Vanoogle.CSE", "Required");
-            if ($sender->Form->Save() !== FALSE)
-                $sender->StatusMessage = T("Your settings have been saved.");
+            $data = $sender->Form->formValues();
+            $configurationModel->Validation->applyRule("Plugins.Vanoogle.CSE", "Required");
+            if ($sender->Form->save() !== FALSE)
+                $sender->StatusMessage = t("Your settings have been saved.");
         }
 
-        $sender->AddSideMenu();
-        $sender->SetData("Title", T("Vanoogle Settings"));
+        $sender->addSideMenu();
+        $sender->setData("Title", t("Vanoogle Settings"));
 
         $categoryModel = new CategoryModel();
-        $sender->SetData("CategoryData", $categoryModel->GetAll(), TRUE);
-        array_shift($sender->CategoryData->Result());
+        $sender->setData("CategoryData", $categoryModel->getAll(), TRUE);
+        array_shift($sender->CategoryData->result());
 
-        $sender->Render($this->GetView("settings.php"));
+        $sender->render($this->getView("settings.php"));
     }
 
     /**
@@ -59,18 +59,18 @@ class VanooglePlugin extends Gdn_Plugin {
      *
      * @param $sender
      */
-    public function Base_Render_Before($sender) {
-        if (!C("Plugins.Vanoogle.CSE"))
+    public function base_render_before($sender) {
+        if (!c("Plugins.Vanoogle.CSE"))
             return;
 
         // Normally one would use ->AddJsFile or ->Head->AddScript, but these insert a version arg in the url that makes the google api barf.
-        $sender->Head->AddTag('script', [
-            'src' => Asset('https://www.google.com/jsapi', FALSE, FALSE),
+        $sender->Head->addTag('script', [
+            'src' => asset('https://www.google.com/jsapi', FALSE, FALSE),
             'type' => 'text/javascript',
-            'id' => C("Plugins.Vanoogle.CSE")
+            'id' => c("Plugins.Vanoogle.CSE")
         ]);
-        $sender->AddCssFile('vanoogle.css', 'plugins/Vanoogle');
-        $sender->AddJsFile('vanoogle.js', 'plugins/Vanoogle');
+        $sender->addCssFile('vanoogle.css', 'plugins/Vanoogle');
+        $sender->addJsFile('vanoogle.js', 'plugins/Vanoogle');
     }
 
     /**
@@ -78,12 +78,12 @@ class VanooglePlugin extends Gdn_Plugin {
      *
      * @param $sender
      */
-    public function Base_Render_After($sender) {
-        if (!C("Plugins.Vanoogle.ApiKey"))
+    public function base_render_after($sender) {
+        if (!c("Plugins.Vanoogle.ApiKey"))
             return;
         ?>
             <div id="hidden" style="display:none;">
-                <div id="VanoogleSearch"><?php echo T('Loading Search...');?></div>
+                <div id="VanoogleSearch"><?php echo t('Loading Search...');?></div>
                 <div id="vanoogle_webResult">
                     <li class="Item gs-webResult gs-result"
                       data-vars="{longUrl:function(){var i = unescapedUrl.indexOf(visibleUrl); return i &lt; 1 ? visibleUrl : unescapedUrl.substring(i);},trimmedTitle:function(){return html(title.replace(/[-][^-]+$/, ''));}}">
@@ -116,5 +116,5 @@ class VanooglePlugin extends Gdn_Plugin {
         <?php
     }
 
-    public function Setup() {}
+    public function setup() {}
 }

--- a/plugins/Vanoogle/views/settings.php
+++ b/plugins/Vanoogle/views/settings.php
@@ -16,22 +16,22 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
  */?>
-<h1> <?php echo $this->Data("Title");?> </h1>
+<h1> <?php echo $this->data("Title");?> </h1>
 <?php
-	echo $this->Form->Open();
-	echo $this->Form->Errors();
+	echo $this->Form->open();
+	echo $this->Form->errors();
 ?>
 <ul>
 	<li>
-		<h3><?php echo T("Required Settings"); ?></h3>
+		<h3><?php echo t("Required Settings"); ?></h3>
 		<ul class='CheckBoxList'>
 			<li>
 				<?php
-					echo $this->Form->Label("Enter your Custom Search Engine ID.  If you don't have one, create one here: <a target='_blank' href='http://www.google.com/cse/'>http://www.google.com/cse/", "Plugins.Vanoogle.CSE", [
+					echo $this->Form->label("Enter your Custom Search Engine ID.  If you don't have one, create one here: <a target='_blank' href='http://www.google.com/cse/'>http://www.google.com/cse/", "Plugins.Vanoogle.CSE", [
 						"class" => "CheckBoxLabel",
 					]);
 					echo "<br>"; 
-					echo $this->Form->Input("Plugins.Vanoogle.CSE", "input", [
+					echo $this->Form->input("Plugins.Vanoogle.CSE", "input", [
 						"size" => "40",
 						"style" => "font-family: Courier, 'Courier New', monospace;", 
 					]); 
@@ -43,5 +43,5 @@
 <br>
 
 <?php 
-   echo $this->Form->Close("Save");
+   echo $this->Form->close("Save");
 

--- a/plugins/Voting/class.voting.plugin.php
+++ b/plugins/Voting/class.voting.plugin.php
@@ -12,28 +12,28 @@ class VotingPlugin extends Gdn_Plugin {
 	/**
 	 * Admin Toggle to turn Voting on/off
 	 */
-   public function Base_GetAppSettingsMenuItems_Handler($sender) {
+   public function base_getAppSettingsMenuItems_handler($sender) {
       $menu = &$sender->EventArguments['SideMenu'];
-      $menu->AddItem('Forum', T('Forum'));
-      $menu->AddLink('Forum', T('Voting'), 'settings/voting', 'Garden.Settings.Manage');
+      $menu->addItem('Forum', t('Forum'));
+      $menu->addLink('Forum', t('Voting'), 'settings/voting', 'Garden.Settings.Manage');
    }
-   public function SettingsController_Voting_Create($sender) {
-      $sender->Permission('Garden.Settings.Manage');
+   public function settingsController_voting_create($sender) {
+      $sender->permission('Garden.Settings.Manage');
       $conf = new ConfigurationModule($sender);
-		$conf->Initialize([
+		$conf->initialize([
 			'Plugins.Voting.ModThreshold1' => ['Type' => 'int', 'Control' => 'TextBox', 'Default' => -10, 'Description' => 'The vote that will flag a post for moderation.'],
 			'Plugins.Voting.ModThreshold2' => ['Type' => 'int', 'Control' => 'TextBox', 'Default' => -20, 'Description' => 'The vote that will remove a post to the moderation queue.']
 		]);
 
-     $sender->AddSideMenu('settings/voting');
-     $sender->SetData('Title', T('Vote Settings'));
+     $sender->addSideMenu('settings/voting');
+     $sender->setData('Title', t('Vote Settings'));
      $sender->ConfigurationModule = $conf;
-     $conf->RenderAll();
+     $conf->renderAll();
    }
-   public function SettingsController_ToggleVoting_Create($sender) {
-      $sender->Permission('Garden.Settings.Manage');
-      if (Gdn::Session()->ValidateTransientKey(GetValue(0, $sender->RequestArgs)))
-         SaveToConfig('Plugins.Voting.Enabled', C('Plugins.Voting.Enabled') ? FALSE : TRUE);
+   public function settingsController_toggleVoting_create($sender) {
+      $sender->permission('Garden.Settings.Manage');
+      if (Gdn::session()->validateTransientKey(getValue(0, $sender->RequestArgs)))
+         saveToConfig('Plugins.Voting.Enabled', c('Plugins.Voting.Enabled') ? FALSE : TRUE);
 
       redirectTo('settings/voting');
    }
@@ -41,29 +41,29 @@ class VotingPlugin extends Gdn_Plugin {
 	/**
 	 * Add JS & CSS to the page.
 	 */
-   public function AddJsCss($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function addJsCss($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $sender->AddCSSFile('voting.css', 'plugins/Voting');
-		$sender->AddJSFile('voting.js', 'plugins/Voting');
+      $sender->addCSSFile('voting.css', 'plugins/Voting');
+		$sender->addJSFile('voting.js', 'plugins/Voting');
    }
-	public function DiscussionsController_Render_Before($sender) {
-		$this->AddJsCss($sender);
+	public function discussionsController_render_before($sender) {
+		$this->addJsCss($sender);
 	}
-   public function CategoriesController_Render_Before($sender) {
-      $this->AddJsCss($sender);
+   public function categoriesController_render_before($sender) {
+      $this->addJsCss($sender);
    }
 
 	/**
 	 * Add the "Stats" buttons to the discussion list.
 	 */
-	public function Base_BeforeDiscussionContent_Handler($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+	public function base_beforeDiscussionContent_handler($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-		$session = Gdn::Session();
-		$discussion = GetValue('Discussion', $sender->EventArguments);
+		$session = Gdn::session();
+		$discussion = getValue('Discussion', $sender->EventArguments);
 		// Answers
 		$css = 'StatBox AnswersBox';
 		if ($discussion->CountComments > 1)
@@ -76,44 +76,44 @@ class VotingPlugin extends Gdn_Plugin {
 		if (!is_numeric($discussion->CountBookmarks))
 			$discussion->CountBookmarks = 0;
 
-		echo Wrap(
-			// Anchor(
-			Wrap(T('Comments')) . Gdn_Format::BigNumber($discussion->CountComments)
-			// ,'/discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::Url($Discussion->Name).($Discussion->CountCommentWatch > 0 ? '/#Item_'.$Discussion->CountCommentWatch : '')
+		echo wrap(
+			// anchor(
+			wrap(t('Comments')) . Gdn_Format::bigNumber($discussion->CountComments)
+			// ,'/discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::url($Discussion->Name).($Discussion->CountCommentWatch > 0 ? '/#Item_'.$Discussion->CountCommentWatch : '')
 			// )
 			, 'div', ['class' => $css]);
 
 		// Views
-		echo Wrap(
-			// Anchor(
-			Wrap(T('Views')) . Gdn_Format::BigNumber($discussion->CountViews)
-			// , '/discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::Url($Discussion->Name).($Discussion->CountCommentWatch > 0 ? '/#Item_'.$Discussion->CountCommentWatch : '')
+		echo wrap(
+			// anchor(
+			wrap(t('Views')) . Gdn_Format::bigNumber($discussion->CountViews)
+			// , '/discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::url($Discussion->Name).($Discussion->CountCommentWatch > 0 ? '/#Item_'.$Discussion->CountCommentWatch : '')
 			// )
 			, 'div', ['class' => 'StatBox ViewsBox']);
 
 		// Follows
-		$title = T($discussion->Bookmarked == '1' ? 'Unbookmark' : 'Bookmark');
-		if ($session->IsValid()) {
-			echo Wrap(Anchor(
-				Wrap(T('Follows')) . Gdn_Format::BigNumber($discussion->CountBookmarks),
-				'/discussion/bookmark/'.$discussion->DiscussionID.'/'.$session->TransientKey().'?Target='.urlencode($sender->SelfUrl),
+		$title = t($discussion->Bookmarked == '1' ? 'Unbookmark' : 'Bookmark');
+		if ($session->isValid()) {
+			echo wrap(anchor(
+				wrap(t('Follows')) . Gdn_Format::bigNumber($discussion->CountBookmarks),
+				'/discussion/bookmark/'.$discussion->DiscussionID.'/'.$session->transientKey().'?Target='.urlencode($sender->SelfUrl),
 				'',
 				['title' => $title]
 			), 'div', ['class' => 'StatBox FollowsBox']);
 		} else {
-			echo Wrap(Wrap(T('Follows')) . $discussion->CountBookmarks, 'div', ['class' => 'StatBox FollowsBox']);
+			echo wrap(wrap(t('Follows')) . $discussion->CountBookmarks, 'div', ['class' => 'StatBox FollowsBox']);
 		}
 
 		// Votes
-		if ($session->IsValid()) {
-			echo Wrap(Anchor(
-				Wrap(T('Votes')) . Gdn_Format::BigNumber($countVotes),
-				'/discussion/votediscussion/'.$discussion->DiscussionID.'/'.$session->TransientKey().'?Target='.urlencode($sender->SelfUrl),
+		if ($session->isValid()) {
+			echo wrap(anchor(
+				wrap(t('Votes')) . Gdn_Format::bigNumber($countVotes),
+				'/discussion/votediscussion/'.$discussion->DiscussionID.'/'.$session->transientKey().'?Target='.urlencode($sender->SelfUrl),
 				'',
-				['title' => T('Vote')]
+				['title' => t('Vote')]
 			), 'div', ['class' => 'StatBox VotesBox']);
 		} else {
-			echo Wrap(Wrap(T('Votes')) . $countVotes, 'div', ['class' => 'StatBox VotesBox']);
+			echo wrap(wrap(t('Votes')) . $countVotes, 'div', ['class' => 'StatBox VotesBox']);
 		}
 	}
 
@@ -121,39 +121,39 @@ class VotingPlugin extends Gdn_Plugin {
 	 * Sort the comments by popularity if necessary
     * @param CommentModel $commentModel
 	 */
-   public function CommentModel_AfterConstruct_Handler($commentModel) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function commentModel_afterConstruct_handler($commentModel) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $sort = self::CommentSort();
+      $sort = self::commentSort();
 
       switch (strtolower($sort)) {
          case 'date':
-            $commentModel->OrderBy('c.DateInserted');
+            $commentModel->orderBy('c.DateInserted');
             break;
          case 'popular':
          default:
-            $commentModel->OrderBy(['coalesce(c.Score, 0) desc', 'c.CommentID']);
+            $commentModel->orderBy(['coalesce(c.Score, 0) desc', 'c.CommentID']);
             break;
       }
    }
 
    protected static $_CommentSort;
-   public static function CommentSort() {
-//		if (!C('Plugins.Voting.Enabled'))
+   public static function commentSort() {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
       if (self::$_CommentSort)
          return self::$_CommentSort;
 
-      $sort = GetIncomingValue('Sort', '');
-      if (Gdn::Session()->IsValid()) {
+      $sort = getIncomingValue('Sort', '');
+      if (Gdn::session()->isValid()) {
          if ($sort == '') {
             // No sort was specified so grab it from the user's preferences.
-            $sort = Gdn::Session()->GetPreference('Plugins.Voting.CommentSort', 'popular');
+            $sort = Gdn::session()->getPreference('Plugins.Voting.CommentSort', 'popular');
          } else {
             // Save the sort to the user's preferences.
-            Gdn::Session()->SetPreference('Plugins.Voting.CommentSort', $sort == 'popular' ? '' : $sort);
+            Gdn::session()->setPreference('Plugins.Voting.CommentSort', $sort == 'popular' ? '' : $sort);
          }
       }
 
@@ -166,23 +166,23 @@ class VotingPlugin extends Gdn_Plugin {
 	/**
 	 * Insert sorting tabs after first comment.
 	 */
-	public function DiscussionController_BeforeCommentDisplay_Handler($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+	public function discussionController_beforeCommentDisplay_handler($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
 		$answerCount = $sender->Discussion->CountComments - 1;
-		$type = GetValue('Type', $sender->EventArguments, 'Comment');
-		if ($type == 'Comment' && !GetValue('VoteHeaderWritten', $sender)) { //$Type != 'Comment' && $AnswerCount > 0) {
+		$type = getValue('Type', $sender->EventArguments, 'Comment');
+		if ($type == 'Comment' && !getValue('VoteHeaderWritten', $sender)) { //$Type != 'Comment' && $AnswerCount > 0) {
 		?>
 		<li class="Item">
 			<div class="VotingSort">
 			<?php
 			echo
-				Wrap($answerCount.' '.Plural($answerCount, 'Comment', 'Comments'), 'strong');
+				wrap($answerCount.' '.plural($answerCount, 'Comment', 'Comments'), 'strong');
 				echo ' sorted by '
-               .Anchor('Votes', Url(DiscussionUrl($sender->Discussion).'?Sort=popular', TRUE), '', ['rel' => 'nofollow', 'class' => self::CommentSort() == 'popular' ? 'Active' : ''])
+               .anchor('Votes', url(discussionUrl($sender->Discussion).'?Sort=popular', TRUE), '', ['rel' => 'nofollow', 'class' => self::commentSort() == 'popular' ? 'Active' : ''])
                .' '
-               .Anchor('Date Added', Url(DiscussionUrl($sender->Discussion).'?Sort=date', TRUE), '', ['rel' => 'nofollow', 'class' => self::CommentSort() == 'date' ? 'Active' : '']);
+               .anchor('Date Added', url(discussionUrl($sender->Discussion).'?Sort=date', TRUE), '', ['rel' => 'nofollow', 'class' => self::commentSort() == 'date' ? 'Active' : '']);
 			?>
 			</div>
 		</li>
@@ -191,47 +191,47 @@ class VotingPlugin extends Gdn_Plugin {
 		}
 	}
 
-	public function DiscussionController_AfterCommentMeta_Handler($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+	public function discussionController_afterCommentMeta_handler($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 /*
 		echo '<span class="Votes">';
-			$Session = Gdn::Session();
-			$Object = GetValue('Object', $Sender->EventArguments);
+			$Session = Gdn::session();
+			$Object = getValue('Object', $Sender->EventArguments);
 			$VoteType = $Sender->EventArguments['Type'] == 'Discussion' ? 'votediscussion' : 'votecomment';
 			$ID = $Sender->EventArguments['Type'] == 'Discussion' ? $Object->DiscussionID : $Object->CommentID;
 			$CssClass = '';
-			$VoteUpUrl = '/discussion/'.$VoteType.'/'.$ID.'/voteup/'.$Session->TransientKey().'/';
-			$VoteDownUrl = '/discussion/'.$VoteType.'/'.$ID.'/votedown/'.$Session->TransientKey().'/';
-			if (!$Session->IsValid()) {
-				$VoteUpUrl = Gdn::Authenticator()->SignInUrl($Sender->SelfUrl);
+			$VoteUpUrl = '/discussion/'.$VoteType.'/'.$ID.'/voteup/'.$Session->transientKey().'/';
+			$VoteDownUrl = '/discussion/'.$VoteType.'/'.$ID.'/votedown/'.$Session->transientKey().'/';
+			if (!$Session->isValid()) {
+				$VoteUpUrl = Gdn::authenticator()->signInUrl($Sender->SelfUrl);
 				$VoteDownUrl = $VoteUpUrl;
 				$CssClass = ' SignInPopup';
 			}
-			echo Anchor(Wrap(Wrap('Vote Up', 'i'), 'i', array('class' => 'ArrowSprite SpriteUp', 'rel' => 'nofollow')), $VoteUpUrl, 'VoteUp'.$CssClass);
-			echo Wrap(StringIsNullOrEmpty($Object->Score) ? '0' : Gdn_Format::BigNumber($Object->Score));
-			echo Anchor(Wrap(Wrap('Vote Down', 'i'), 'i', array('class' => 'ArrowSprite SpriteDown', 'rel' => 'nofollow')), $VoteDownUrl, 'VoteDown'.$CssClass);
+			echo anchor(Wrap(wrap('Vote Up', 'i'), 'i', array('class' => 'ArrowSprite SpriteUp', 'rel' => 'nofollow')), $VoteUpUrl, 'VoteUp'.$CssClass);
+			echo wrap(StringIsNullOrEmpty($Object->Score) ? '0' : Gdn_Format::bigNumber($Object->Score));
+			echo anchor(Wrap(wrap('Vote Down', 'i'), 'i', array('class' => 'ArrowSprite SpriteDown', 'rel' => 'nofollow')), $VoteDownUrl, 'VoteDown'.$CssClass);
 		echo '</span>';
 
  */
 
-      $session = Gdn::Session();
-      $object = GetValue('Object', $sender->EventArguments);
+      $session = Gdn::session();
+      $object = getValue('Object', $sender->EventArguments);
       $voteType = $sender->EventArguments['Type'] == 'Discussion' ? 'votediscussion' : 'votecomment';
       $iD = $sender->EventArguments['Type'] == 'Discussion' ? $object->DiscussionID : $object->CommentID;
       $cssClass = '';
-      $voteUpUrl = '/discussion/'.$voteType.'/'.$iD.'/voteup/'.$session->TransientKey().'/';
-      $voteDownUrl = '/discussion/'.$voteType.'/'.$iD.'/votedown/'.$session->TransientKey().'/';
-      if (!$session->IsValid()) {
-         $voteUpUrl = Gdn::Authenticator()->SignInUrl($sender->SelfUrl);
+      $voteUpUrl = '/discussion/'.$voteType.'/'.$iD.'/voteup/'.$session->transientKey().'/';
+      $voteDownUrl = '/discussion/'.$voteType.'/'.$iD.'/votedown/'.$session->transientKey().'/';
+      if (!$session->isValid()) {
+         $voteUpUrl = Gdn::authenticator()->signInUrl($sender->SelfUrl);
          $voteDownUrl = $voteUpUrl;
          $cssClass = ' SignInPopup';
       }
 
       echo '<span class="Voter">';
-			echo Anchor(Wrap(Wrap('Vote Up', 'i'), 'i', ['class' => 'ArrowSprite SpriteUp', 'rel' => 'nofollow']), $voteUpUrl, 'VoteUp'.$cssClass);
-			echo Wrap(StringIsNullOrEmpty($object->Score) ? '0' : Gdn_Format::BigNumber($object->Score));
-			echo Anchor(Wrap(Wrap('Vote Down', 'i'), 'i', ['class' => 'ArrowSprite SpriteDown', 'rel' => 'nofollow']), $voteDownUrl, 'VoteDown'.$cssClass);
+			echo anchor(wrap(wrap('Vote Up', 'i'), 'i', ['class' => 'ArrowSprite SpriteUp', 'rel' => 'nofollow']), $voteUpUrl, 'VoteUp'.$cssClass);
+			echo wrap(stringIsNullOrEmpty($object->Score) ? '0' : Gdn_Format::bigNumber($object->Score));
+			echo anchor(wrap(wrap('Vote Down', 'i'), 'i', ['class' => 'ArrowSprite SpriteDown', 'rel' => 'nofollow']), $voteDownUrl, 'VoteDown'.$cssClass);
 		echo '</span>';
  }
 
@@ -239,102 +239,102 @@ class VotingPlugin extends Gdn_Plugin {
    /**
 	 * Add the vote.js file to discussions page, and handle sorting of answers.
 	 */
-   public function DiscussionController_Render_Before($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function discussionController_render_before($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $this->AddJsCss($sender);
+      $this->addJsCss($sender);
    }
 
 
    /**
     * Increment/decrement comment scores
     */
-   public function DiscussionController_VoteComment_Create($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function discussionController_voteComment_create($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $commentID = GetValue(0, $sender->RequestArgs, 0);
-      $voteType = GetValue(1, $sender->RequestArgs);
-      $transientKey = GetValue(2, $sender->RequestArgs);
-      $session = Gdn::Session();
+      $commentID = getValue(0, $sender->RequestArgs, 0);
+      $voteType = getValue(1, $sender->RequestArgs);
+      $transientKey = getValue(2, $sender->RequestArgs);
+      $session = Gdn::session();
       $finalVote = 0;
       $total = 0;
-      if ($session->IsValid() && $session->ValidateTransientKey($transientKey) && $commentID > 0) {
+      if ($session->isValid() && $session->validateTransientKey($transientKey) && $commentID > 0) {
          $commentModel = new CommentModel();
-         $oldUserVote = $commentModel->GetUserScore($commentID, $session->UserID);
+         $oldUserVote = $commentModel->getUserScore($commentID, $session->UserID);
          $newUserVote = $voteType == 'voteup' ? 1 : -1;
          $finalVote = intval($oldUserVote) + intval($newUserVote);
          // Allow admins to vote unlimited.
-         $allowVote = $session->CheckPermission('Garden.Moderation.Manage');
+         $allowVote = $session->checkPermission('Garden.Moderation.Manage');
          // Only allow users to vote up or down by 1.
          if (!$allowVote)
             $allowVote = $finalVote > -2 && $finalVote < 2;
 
          if ($allowVote)
-            $total = $commentModel->SetUserScore($commentID, $session->UserID, $finalVote);
+            $total = $commentModel->setUserScore($commentID, $session->UserID, $finalVote);
 
          // Move the comment into or out of moderation.
          if (class_exists('LogModel')) {
             $moderate = FALSE;
 
-            if ($total <= C('Plugins.Voting.ModThreshold1', -10)) {
+            if ($total <= c('Plugins.Voting.ModThreshold1', -10)) {
                $logOptions = ['GroupBy' => ['RecordID']];
                // Get the comment row.
-               $data = $commentModel->GetID($commentID, DATASET_TYPE_ARRAY);
+               $data = $commentModel->getID($commentID, DATASET_TYPE_ARRAY);
                if ($data) {
                   // Get the users that voted the comment down.
                   $otherUserIDs = $commentModel->SQL
-                     ->Select('UserID')
-                     ->From('UserComment')
-                     ->Where('CommentID', $commentID)
-                     ->Where('Score <', 0)
-                     ->Get()->ResultArray();
+                     ->select('UserID')
+                     ->from('UserComment')
+                     ->where('CommentID', $commentID)
+                     ->where('Score <', 0)
+                     ->get()->resultArray();
                   $otherUserIDs = array_column($otherUserIDs, 'UserID');
                   $logOptions['OtherUserIDs'] = $otherUserIDs;
 
                   // Add the comment to moderation.
-                  if ($total > C('Plugins.Voting.ModThreshold2', -20))
-                     LogModel::Insert('Moderate', 'Comment', $data, $logOptions);
+                  if ($total > c('Plugins.Voting.ModThreshold2', -20))
+                     LogModel::insert('Moderate', 'Comment', $data, $logOptions);
                }
                $moderate = TRUE;
             }
-            if ($total <= C('Plugins.Voting.ModThreshold2', -20)) {
+            if ($total <= c('Plugins.Voting.ModThreshold2', -20)) {
                // Remove the comment.
-               $commentModel->Delete($commentID, ['Log' => 'Moderate']);
+               $commentModel->delete($commentID, ['Log' => 'Moderate']);
 
-               $sender->InformMessage(sprintf(T('The %s has been removed for moderation.'), T('comment')));
+               $sender->informMessage(sprintf(t('The %s has been removed for moderation.'), t('comment')));
             } elseif ($moderate) {
-               $sender->InformMessage(sprintf(T('The %s has been flagged for moderation.'), T('comment')));
+               $sender->informMessage(sprintf(t('The %s has been flagged for moderation.'), t('comment')));
             }
          }
       }
-      $sender->DeliveryType(DELIVERY_TYPE_BOOL);
-      $sender->SetJson('TotalScore', $total);
-      $sender->SetJson('FinalVote', $finalVote);
-      $sender->Render();
+      $sender->deliveryType(DELIVERY_TYPE_BOOL);
+      $sender->setJson('TotalScore', $total);
+      $sender->setJson('FinalVote', $finalVote);
+      $sender->render();
    }
 
    /**
     * Increment/decrement discussion scores
     */
-   public function DiscussionController_VoteDiscussion_Create($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function discussionController_voteDiscussion_create($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $discussionID = GetValue(0, $sender->RequestArgs, 0);
-      $transientKey = GetValue(1, $sender->RequestArgs);
+      $discussionID = getValue(0, $sender->RequestArgs, 0);
+      $transientKey = getValue(1, $sender->RequestArgs);
       $voteType = FALSE;
       if ($transientKey == 'voteup' || $transientKey == 'votedown') {
          $voteType = $transientKey;
-         $transientKey = GetValue(2, $sender->RequestArgs);
+         $transientKey = getValue(2, $sender->RequestArgs);
       }
-      $session = Gdn::Session();
+      $session = Gdn::session();
       $newUserVote = 0;
       $total = 0;
-      if ($session->IsValid() && $session->ValidateTransientKey($transientKey) && $discussionID > 0) {
+      if ($session->isValid() && $session->validateTransientKey($transientKey) && $discussionID > 0) {
          $discussionModel = new DiscussionModel();
-         $oldUserVote = $discussionModel->GetUserScore($discussionID, $session->UserID);
+         $oldUserVote = $discussionModel->getUserScore($discussionID, $session->UserID);
 
          if ($voteType == 'voteup')
             $newUserVote = 1;
@@ -345,16 +345,16 @@ class VotingPlugin extends Gdn_Plugin {
 
          $finalVote = intval($oldUserVote) + intval($newUserVote);
          // Allow admins to vote unlimited.
-         $allowVote = $session->CheckPermission('Garden.Moderation.Manage');
+         $allowVote = $session->checkPermission('Garden.Moderation.Manage');
          // Only allow users to vote up or down by 1.
          if (!$allowVote)
             $allowVote = $finalVote > -2 && $finalVote < 2;
 
          if ($allowVote) {
-            $total = $discussionModel->SetUserScore($discussionID, $session->UserID, $finalVote);
+            $total = $discussionModel->setUserScore($discussionID, $session->UserID, $finalVote);
          } else {
-				$discussion = $discussionModel->GetID($discussionID);
-				$total = GetValue('Score', $discussion, 0);
+				$discussion = $discussionModel->getID($discussionID);
+				$total = getValue('Score', $discussion, 0);
 				$finalVote = $oldUserVote;
 			}
 
@@ -362,122 +362,122 @@ class VotingPlugin extends Gdn_Plugin {
          if (class_exists('LogModel')) {
             $moderate = FALSE;
 
-            if ($total <= C('Plugins.Voting.ModThreshold1', -10)) {
+            if ($total <= c('Plugins.Voting.ModThreshold1', -10)) {
                $logOptions = ['GroupBy' => ['RecordID']];
                // Get the comment row.
                if (isset($discussion))
                   $data = (array)$discussion;
                else
-                  $data = (array)$discussionModel->GetID($discussionID);
+                  $data = (array)$discussionModel->getID($discussionID);
                if ($data) {
                   // Get the users that voted the comment down.
                   $otherUserIDs = $discussionModel->SQL
-                     ->Select('UserID')
-                     ->From('UserComment')
-                     ->Where('CommentID', $discussionID)
-                     ->Where('Score <', 0)
-                     ->Get()->ResultArray();
+                     ->select('UserID')
+                     ->from('UserComment')
+                     ->where('CommentID', $discussionID)
+                     ->where('Score <', 0)
+                     ->get()->resultArray();
                   $otherUserIDs = array_column($otherUserIDs, 'UserID');
                   $logOptions['OtherUserIDs'] = $otherUserIDs;
 
                   // Add the comment to moderation.
-                  if ($total > C('Plugins.Voting.ModThreshold2', -20))
-                     LogModel::Insert('Moderate', 'Discussion', $data, $logOptions);
+                  if ($total > c('Plugins.Voting.ModThreshold2', -20))
+                     LogModel::insert('Moderate', 'Discussion', $data, $logOptions);
                }
                $moderate = TRUE;
             }
-            if ($total <= C('Plugins.Voting.ModThreshold2', -20)) {
+            if ($total <= c('Plugins.Voting.ModThreshold2', -20)) {
                // Remove the comment.
-               $discussionModel->Delete($discussionID, ['Log' => 'Moderate']);
+               $discussionModel->delete($discussionID, ['Log' => 'Moderate']);
 
-               $sender->InformMessage(sprintf(T('The %s has been removed for moderation.'), T('discussion')));
+               $sender->informMessage(sprintf(t('The %s has been removed for moderation.'), t('discussion')));
             } elseif ($moderate) {
-               $sender->InformMessage(sprintf(T('The %s has been flagged for moderation.'), T('discussion')));
+               $sender->informMessage(sprintf(t('The %s has been flagged for moderation.'), t('discussion')));
             }
          }
       }
-      $sender->DeliveryType(DELIVERY_TYPE_BOOL);
-      $sender->SetJson('TotalScore', $total);
-      $sender->SetJson('FinalVote', $finalVote);
-      $sender->Render();
+      $sender->deliveryType(DELIVERY_TYPE_BOOL);
+      $sender->setJson('TotalScore', $total);
+      $sender->setJson('FinalVote', $finalVote);
+      $sender->render();
    }
 
    /**
     * Grab the score field whenever the discussions are queried.
     */
-   public function DiscussionModel_AfterDiscussionSummaryQuery_Handler($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function discussionModel_afterDiscussionSummaryQuery_handler($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $sender->SQL->Select('d.Score');
+      $sender->SQL->select('d.Score');
    }
 
-   public function DiscussionsController_AfterDiscussionFilters_Handler($sender) {
+   public function discussionsController_afterDiscussionFilters_handler($sender) {
 		echo '<li class="PopularDiscussions '.($sender->RequestMethod == 'popular' ? ' Active' : '').'">'
-			.Anchor(Sprite('SpPopularDiscussions').' '.T('Popular'), '/discussions/popular', 'PopularDiscussions')
+			.anchor(sprite('SpPopularDiscussions').' '.t('Popular'), '/discussions/popular', 'PopularDiscussions')
 		.'</li>';
    }
 
 	/**
 	 * Add the "Popular Questions" tab.
     */
-	public function Base_BeforeDiscussionTabs_Handler($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+	public function base_beforeDiscussionTabs_handler($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
 		echo '<li'.($sender->RequestMethod == 'popular' ? ' class="Active"' : '').'>'
-			.Anchor(T('Popular'), '/discussions/popular', 'PopularDiscussions TabLink')
+			.anchor(t('Popular'), '/discussions/popular', 'PopularDiscussions TabLink')
 		.'</li>';
 	}
 
-//   public function CategoriesController_BeforeDiscussionContent_Handler($Sender) {
-//      $this->DiscussionsController_BeforeDiscussionContent_Handler($Sender);
+//   public function categoriesController_BeforeDiscussionContent_Handler($Sender) {
+//      $this->discussionsController_BeforeDiscussionContent_Handler($Sender);
 //   }
 
    /**
     * Load popular discussions.
     */
-   public function DiscussionsController_Popular_Create($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function discussionsController_popular_create($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $sender->AddModule('DiscussionFilterModule');
-      $sender->Title(T('Popular'));
-      $sender->Head->Title($sender->Head->Title());
+      $sender->addModule('DiscussionFilterModule');
+      $sender->title(t('Popular'));
+      $sender->Head->title($sender->Head->title());
 
-      $offset = GetValue('0', $sender->RequestArgs, '0');
+      $offset = getValue('0', $sender->RequestArgs, '0');
 
       // Get rid of announcements from this view
       if ($sender->Head) {
-         $sender->AddJsFile('discussions.js');
-         $sender->Head->AddRss($sender->SelfUrl.'/feed.rss', $sender->Head->Title());
+         $sender->addJsFile('discussions.js');
+         $sender->Head->addRss($sender->SelfUrl.'/feed.rss', $sender->Head->title());
       }
       if (!is_numeric($offset) || $offset < 0)
          $offset = 0;
 
       // Add Modules
-      $sender->AddModule('NewDiscussionModule');
+      $sender->addModule('NewDiscussionModule');
       $bookmarkedModule = new BookmarkedModule($sender);
-      $bookmarkedModule->GetData();
-      $sender->AddModule($bookmarkedModule);
+      $bookmarkedModule->getData();
+      $sender->addModule($bookmarkedModule);
 
-      $sender->SetData('Category', FALSE, TRUE);
-      $limit = C('Vanilla.Discussions.PerPage', 30);
+      $sender->setData('Category', FALSE, TRUE);
+      $limit = c('Vanilla.Discussions.PerPage', 30);
       $discussionModel = new DiscussionModel();
-      $countDiscussions = $discussionModel->GetCount();
-      $sender->SetData('CountDiscussions', $countDiscussions);
+      $countDiscussions = $discussionModel->getCount();
+      $sender->setData('CountDiscussions', $countDiscussions);
       $sender->AnnounceData = FALSE;
-		$sender->SetData('Announcements', [], TRUE);
-      $discussionModel->SQL->OrderBy('d.CountViews', 'desc');
-      $sender->DiscussionData = $discussionModel->Get($offset, $limit);
-      $sender->SetData('Discussions', $sender->DiscussionData, TRUE);
-      $sender->SetJson('Loading', $offset . ' to ' . $limit);
+		$sender->setData('Announcements', [], TRUE);
+      $discussionModel->SQL->orderBy('d.CountViews', 'desc');
+      $sender->DiscussionData = $discussionModel->get($offset, $limit);
+      $sender->setData('Discussions', $sender->DiscussionData, TRUE);
+      $sender->setJson('Loading', $offset . ' to ' . $limit);
 
       // Build a pager.
       $pagerFactory = new Gdn_PagerFactory();
-      $sender->Pager = $pagerFactory->GetPager('Pager', $sender);
+      $sender->Pager = $pagerFactory->getPager('Pager', $sender);
       $sender->Pager->ClientID = 'Pager';
-      $sender->Pager->Configure(
+      $sender->Pager->configure(
          $offset,
          $limit,
          $countDiscussions,
@@ -485,28 +485,28 @@ class VotingPlugin extends Gdn_Plugin {
       );
 
       // Deliver json data if necessary
-      if ($sender->DeliveryType() != DELIVERY_TYPE_ALL) {
-         $sender->SetJson('LessRow', $sender->Pager->ToString('less'));
-         $sender->SetJson('MoreRow', $sender->Pager->ToString('more'));
+      if ($sender->deliveryType() != DELIVERY_TYPE_ALL) {
+         $sender->setJson('LessRow', $sender->Pager->toString('less'));
+         $sender->setJson('MoreRow', $sender->Pager->toString('more'));
          $sender->View = 'discussions';
       }
 
       // Render the controller
       $sender->View = 'index';
-      $sender->Render();
+      $sender->render();
    }
 
 	/**
 	 * If turning off scoring, make the forum go back to the traditional "jump
 	 * to what I last read" functionality.
 	 */
-   public function OnDisable() {
-		SaveToConfig('Vanilla.Comments.AutoOffset', TRUE);
+   public function onDisable() {
+		saveToConfig('Vanilla.Comments.AutoOffset', TRUE);
    }
 
    /**
    * Don't let the users access the category management screens.
-   public function SettingsController_Render_Before($Sender) {
+   public function settingsController_Render_Before($Sender) {
       if (strpos(strtolower($Sender->RequestMethod), 'categor') > 0)
          redirectTo($Sender->Routes['DefaultPermission']);
    }
@@ -516,43 +516,43 @@ class VotingPlugin extends Gdn_Plugin {
 	/**
 	 * Insert the voting html on comments in a discussion.
 	 */
-	public function PostController_AfterCommentMeta_Handler($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+	public function postController_afterCommentMeta_handler($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-		$this->DiscussionController_AfterCommentMeta_Handler($sender);
+		$this->discussionController_afterCommentMeta_handler($sender);
 	}
 
 	/**
 	 * Add voting css to post controller.
 	 */
-	public function PostController_Render_Before($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+	public function postController_render_before($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $this->AddJsCss($sender);
+      $this->addJsCss($sender);
 	}
 
-   public function ProfileController_Render_Before($sender) {
-//		if (!C('Plugins.Voting.Enabled'))
+   public function profileController_render_before($sender) {
+//		if (!c('Plugins.Voting.Enabled'))
 //			return;
 
-      $this->AddJsCss($sender);
+      $this->addJsCss($sender);
    }
 
 	/**
 	 * Add a field to the db for storing the "State" of a question.
 	 */
-   public function Setup() {
+   public function setup() {
       // Add some fields to the database
-      $structure = Gdn::Structure();
+      $structure = Gdn::structure();
 
       // "Unanswered" or "Answered"
-      $structure->Table('Discussion')
-         ->Column('State', 'varchar(30)', TRUE)
-         ->Set(FALSE, FALSE);
+      $structure->table('Discussion')
+         ->column('State', 'varchar(30)', TRUE)
+         ->set(FALSE, FALSE);
 
-//    SaveToConfig('Vanilla.Categories.Use', FALSE);
-//      SaveToConfig('Vanilla.Comments.AutoOffset', FALSE);
+//    saveToConfig('Vanilla.Categories.Use', FALSE);
+//      saveToConfig('Vanilla.Comments.AutoOffset', FALSE);
    }
 }

--- a/plugins/Voting/views/settings.php
+++ b/plugins/Voting/views/settings.php
@@ -1,13 +1,13 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-<h1><?php echo T($this->Data['Title']); ?></h1>
+<h1><?php echo t($this->Data['Title']); ?></h1>
 <div class="Info">
-   <?php echo T("Voting allows users to vote on discussions & comments, giving a community score. Popular comments then rise to the top of the discussion."); ?>
+   <?php echo t("Voting allows users to vote on discussions & comments, giving a community score. Popular comments then rise to the top of the discussion."); ?>
 </div>
 <div class="FilterMenu">
       <?php
-      echo Anchor(
-         T(C('Plugins.Voting.Enabled') ? 'Disable Voting' : 'Enable Voting'),
-         'settings/togglevoting/'.Gdn::Session()->TransientKey(),
+      echo anchor(
+         t(c('Plugins.Voting.Enabled') ? 'Disable Voting' : 'Enable Voting'),
+         'settings/togglevoting/'.Gdn::session()->transientKey(),
          'SmallButton'
       );
    ?>

--- a/plugins/Voting/views/taggeddiscussions.php
+++ b/plugins/Voting/views/taggeddiscussions.php
@@ -1,15 +1,15 @@
 <?php if (!defined('APPLICATION')) exit();
-include($this->FetchViewLocation('helper_functions', 'discussions', 'vanilla'));
+include($this->fetchViewLocation('helper_functions', 'discussions', 'vanilla'));
 ?>
 <div class="TaggedHeading"><?php printf("Questions tagged with '%s'", $this->Tag); ?></div>
-<?php if ($this->DiscussionData->NumRows() > 0) { ?>
+<?php if ($this->DiscussionData->numRows() > 0) { ?>
 <ul class="DataList Discussions">
-   <?php include($this->FetchViewLocation('discussions')); ?>
+   <?php include($this->fetchViewLocation('discussions')); ?>
 </ul>
 <?php
-   echo $this->Pager->ToString('more');
+   echo $this->Pager->toString('more');
 } else {
    ?>
-   <div class="Empty"><?php printf(T('No items tagged with %s.'), $this->Tag); ?></div>
+   <div class="Empty"><?php printf(t('No items tagged with %s.'), $this->Tag); ?></div>
    <?php
 }

--- a/plugins/example/class.example.plugin.php
+++ b/plugins/example/class.example.plugin.php
@@ -53,7 +53,7 @@ class ExamplePlugin extends Gdn_Plugin {
      *
      * One of the most powerful tools at a plugin developer's fingertips is the ability to freely create
      * methods on other controllers, effectively extending their capabilities. This method creates the
-     * Example() method on the PluginController, effectively allowing the plugin to be invoked via the
+     * example() method on the PluginController, effectively allowing the plugin to be invoked via the
      * URL: http://www.yourforum.com/plugin/example/
      *
      * From here, we can do whatever we like, including turning this plugin into a mini controller and
@@ -64,7 +64,7 @@ class ExamplePlugin extends Gdn_Plugin {
     public function pluginController_example_create($sender) {
         /*
          * If you build your views properly, this will be used as the <title> for your page, and for the header
-         * in the dashboard. Something like this works well: <h1><?php echo T($this->Data['Title']); ?></h1>
+         * in the dashboard. Something like this works well: <h1><?php echo t($this->Data['Title']); ?></h1>
          */
         $sender->title('Example Plugin');
         $sender->addSideMenu('plugin/example');
@@ -73,20 +73,20 @@ class ExamplePlugin extends Gdn_Plugin {
         $sender->Form = new Gdn_Form();
 
         /*
-         * This method does a lot of work. It allows a single method (PluginController::Example() in this case)
+         * This method does a lot of work. It allows a single method (PluginController::example() in this case)
          * to "forward" calls to internal methods on this plugin based on the URL's first parameter following the
          * real method name, in effect mimicing the functionality of as a real top level controller.
          *
-         * For example, if we accessed the URL: http://www.yourforum.com/plugin/Example/test, Dispatch() here would
-         * look for a method called ExamplePlugin::Controller_Test(), and invoke it. Similarly, we we accessed the
-         * URL: http://www.yourforum.com/plugin/Example/foobar, Dispatch() would find and call
-         * ExamplePlugin::Controller_Foobar().
+         * For example, if we accessed the URL: http://www.yourforum.com/plugin/Example/test, dispatch() here would
+         * look for a method called ExamplePlugin::controller_Test(), and invoke it. Similarly, we we accessed the
+         * URL: http://www.yourforum.com/plugin/Example/foobar, dispatch() would find and call
+         * ExamplePlugin::controller_Foobar().
          *
          * The main benefit of this style of extending functionality is that all of a plugin's external API is
          * consolidated under one namespace, reducing the chance for random method name conflicts with other
          * plugins.
          *
-         * Note: When the URL is accessed without parameters, Controller_Index() is called. This is a good place
+         * Note: When the URL is accessed without parameters, controller_Index() is called. This is a good place
          * for a dashboard settings screen.
          */
         $this->dispatch($sender, $sender->RequestArgs);
@@ -126,7 +126,7 @@ class ExamplePlugin extends Gdn_Plugin {
             }
         }
 
-        // GetView() looks for files inside plugins/PluginFolderName/views/ and returns their full path. Useful!
+        // getView() looks for files inside plugins/PluginFolderName/views/ and returns their full path. Useful!
         $sender->render($this->getView('example.php'));
     }
 
@@ -147,12 +147,12 @@ class ExamplePlugin extends Gdn_Plugin {
      * Hook into the rendering of each discussion link
      *
      * How did we find this event? We know we're trying to display a line of text when each discussion is rendered
-     * on the /discussions/ page. That page corresponds to the DiscussionsController::Index() method. This method,
+     * on the /discussions/ page. That page corresponds to the DiscussionsController::index() method. This method,
      * by default, renders the views/discussions/index.php view. That view contains this line:
-     *     <?php include($this->FetchViewLocation('discussions')); ?>
+     *     <?php include($this->fetchViewLocation('discussions')); ?>
      *
-     * So we look inside views/discussions/discussions.php. We find a loop that calls WriteDiscussion() for each
-     * discussion in the list. WriteDiscussion() fires several events each time it is called. One of those events
+     * So we look inside views/discussions/discussions.php. We find a loop that calls writeDiscussion() for each
+     * discussion in the list. writeDiscussion() fires several events each time it is called. One of those events
      * is called "AfterDiscussionTitle". Since we know that the parent controller context is "DiscussionsController",
      * and that the event's name is "AfterDiscussionTitle", it is easy to see that our handler method should be called
      *
@@ -221,22 +221,22 @@ class ExamplePlugin extends Gdn_Plugin {
 
     /**
      * This is a special method name that will automatically trigger when a forum owner runs /utility/update.
-     * It must be manually triggered if you want it to run on Setup().
+     * It must be manually triggered if you want it to run on setup().
      */
     public function structure() {
         /*
         // Create table GDN_Example, if it doesn't already exist
-        Gdn::Structure()
-            ->Table('Example')
-            ->PrimaryKey('ExampleID')
-            ->Column('Name', 'varchar(255)')
-            ->Column('Type', 'varchar(128)')
-            ->Column('Size', 'int(11)')
-            ->Column('InsertUserID', 'int(11)')
-            ->Column('DateInserted', 'datetime')
-            ->Column('ForeignID', 'int(11)', TRUE)
-            ->Column('ForeignTable', 'varchar(24)', TRUE)
-            ->Set(FALSE, FALSE);
+        Gdn::structure()
+            ->table('Example')
+            ->primaryKey('ExampleID')
+            ->column('Name', 'varchar(255)')
+            ->column('Type', 'varchar(128)')
+            ->column('Size', 'int(11)')
+            ->column('InsertUserID', 'int(11)')
+            ->column('DateInserted', 'datetime')
+            ->column('ForeignID', 'int(11)', TRUE)
+            ->column('ForeignTable', 'varchar(24)', TRUE)
+            ->set(FALSE, FALSE);
         */
     }
 

--- a/plugins/example/views/example.php
+++ b/plugins/example/views/example.php
@@ -1,6 +1,6 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 
-<h1><?php echo T($this->Data['Title']); ?></h1>
+<h1><?php echo t($this->Data['Title']); ?></h1>
 <div class="Info">
     <?php echo t($this->Data['PluginDescription']); ?>
 </div>

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -87,7 +87,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             $connectLabel = '<span class="Username"></span><div class="ConnectLabel TextColor">'.sprintf(t('Sign In with %s'), $provider['Name']).'</div>';
         }
 
-        if (!C('Plugins.JsConnect.NoGuestCheck')) {
+        if (!c('Plugins.JsConnect.NoGuestCheck')) {
             $result = '<div style="display: none" class="JsConnect-Container ConnectButton Small UserInfo" rel="'.$url.'">';
 
             if (!val('IsDefault', $provider)) {
@@ -523,7 +523,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             $provider = self::getProvider($client_id);
 
             if (empty($provider)) {
-                throw NotFoundException('Provider');
+                throw notFoundException('Provider');
             }
 
             $get = arrayTranslate($sender->Request->get(), ['client_id', 'display']);
@@ -536,7 +536,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             $sender->Form->addHidden('Target', $target);
 
             $sender->MasterView = 'empty';
-            $sender->Render('JsConnect', '', 'plugins/jsconnect');
+            $sender->render('JsConnect', '', 'plugins/jsconnect');
         }
     }
 
@@ -575,7 +575,7 @@ class JsConnectPlugin extends Gdn_Plugin {
         $Secret = val('AssociationSecret', $Provider);
 
         if (Gdn::session()->isValid()) {
-            $User = ArrayTranslate((array)Gdn::session()->User, ['UserID' => 'UniqueID', 'Name', 'Email', 'PhotoUrl', 'DateOfBirth', 'Gender']);
+            $User = arrayTranslate((array)Gdn::session()->User, ['UserID' => 'UniqueID', 'Name', 'Email', 'PhotoUrl', 'DateOfBirth', 'Gender']);
 
             // Grab the user's roles.
             $Roles = Gdn::userModel()->getRoles(Gdn::session()->UserID);

--- a/plugins/jsconnect/functions.jsconnect.php
+++ b/plugins/jsconnect/functions.jsconnect.php
@@ -50,7 +50,7 @@ function writeJsConnect($user, $request, $clientID, $secret, $secure = true) {
         } elseif (!isset($request['sig'])) {
             $error = ['error' => 'invalid_request', 'message' => 'Missing sig parameter.'];
         } // Make sure the timestamp hasn't timedout
-        elseif (abs($request['timestamp'] - JsTimestamp()) > JS_TIMEOUT) {
+        elseif (abs($request['timestamp'] - jsTimestamp()) > JS_TIMEOUT) {
             $error = ['error' => 'invalid_request', 'message' => 'The timestamp is invalid.'];
         } elseif (!isset($request['nonce'])) {
             $error = ['error' => 'invalid_request', 'message' => 'Missing nonce parameter.'];

--- a/plugins/jsconnect/views/settings.php
+++ b/plugins/jsconnect/views/settings.php
@@ -11,7 +11,7 @@ helpAsset(t('Need More Help?'), $links);
 echo heading(sprintf(t('%s Settings'), 'jsConnect'), t('Add Connection'), '/settings/jsconnect/addedit', 'btn btn-primary js-modal');
 
 $inTestMode = [];
-foreach ($this->Data('Providers') as $Provider) {
+foreach ($this->data('Providers') as $Provider) {
     if ($Provider['TestMode']) {
         $inTestMode[] = $Provider;
     }
@@ -65,7 +65,7 @@ foreach ($this->Data('Providers') as $Provider) {
         </tr>
         </thead>
         <tbody>
-        <?php foreach ($this->Data('Providers') as $Provider): ?>
+        <?php foreach ($this->data('Providers') as $Provider): ?>
             <tr>
                 <td><?php echo htmlspecialchars($Provider['AuthenticationKey']); ?></td>
                 <td><?php echo htmlspecialchars($Provider['Name']); ?></td>

--- a/plugins/vBulletinCompatibility/class.vbulletincompatibility.plugin.php
+++ b/plugins/vBulletinCompatibility/class.vbulletincompatibility.plugin.php
@@ -13,7 +13,7 @@ class VbulletinCompatibilityPlugin extends Gdn_Plugin {
    public function __construct() {
    }
    
-   public function Gdn_Router_BeforeLoadRoutes_Handler($sender) {
+   public function gdn_Router_BeforeLoadRoutes_Handler($sender) {
       $vbRoutes = [
           'forumdisplay\.php\?f=(\d+)'    => ['categories/$1', 'Permanent'],
           'showthread\.php\?t=(\d+)'      => ['discussion/$1', 'Permanent'],


### PR DESCRIPTION
I used this script: https://gist.github.com/DaazKu/fc20843e3f7bd2e0311194c0e70dada5
- It's using the tokenizer.
- It skips class instantiation by checking that there is no `new` before the token. (It also skips namespace searching for the new keyword)
- It's also handling:
   - `SQL()` to `sql()`
   - `Controller_Event_Handler()` to `controller_event_handler()`
   - `AnythingElse()` to `anythingElse()`
- It renames function in comments. (That part is regex based but that should do)