### PR TITLE
Add a get satisfaction discussion url slug case to the redirector plugin

### DIFF
--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -107,6 +107,9 @@ class RedirectorPlugin extends Gdn_Plugin {
             'p' => 'CommentID',
             'start' => 'Offset',
         ],
+        'topics' => [ // get satisfaction discussion
+            '_arg0' => 'DiscussionID', // this should be a url slug
+        ],
     ];
 
     /**


### PR DESCRIPTION
Get satisfaction uses slug created from the discussion name to create their URL.

Migrating the URL slug (removing the domain) into the UrlCode column and this code will redirect the discussions properly. 

Example:

https://community.{generic}.com/{generic}/topics/-discussion-fake-software-thread-99-71-0-d5t1siggrtrn