### PR TITLE
Fix ActivityModel before-save hook in Civil Tongue Ex

### DIFF
--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -358,15 +358,14 @@ class CivilTonguePlugin extends Gdn_Plugin {
     /**
      * Cleanup Activity messages.
      *
-     * @param $Sender
-     * @param $Args
+     * @param ActivityModel $sender
+     * @param array $args
      */
-    public function activityModel_beforeSave_handler($sender, &$args) {
+    public function activityModel_beforeSave_handler($sender, $args) {
         $activity = val('Activity', $args);
         setValue('Story', $activity, $this->replace(val('Story', $activity)));
         $sender->EventArguments['Activity'] = $activity;
     }
-
 
     /**
      * Cleanup private messages displayed on the messages page.


### PR DESCRIPTION
Vanilla's [`EventManager` uses `call_user_func_array`](https://github.com/vanilla/vanilla/blob/27e57016f48c964782df35a5e1b13f1e528b5ebe/library/Garden/EventManager.php#L278) to invoke event hooks. The Civil Tongue addon's `activityModel_beforeSave` function signature attempts to pass its `$args` parameter by reference, which is not compatible with the aforementioned call to [`call_user_func_array`](http://php.net/manual/en/function.call-user-func-array.php). The hook fails and is not executed.

This update drops the attempt to pass by reference, which causes the hook to be properly fired.