### PR TITLE
Backport: Improve load time of Participated Discussions

### DIFF
--- a/plugins/Participated/addon.json
+++ b/plugins/Participated/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Participated Discussions",
-    "description": "Users may view a list of all discussions they have commented on. This is a more user-friendly version of an auto-subscribe option.",
-    "version": "1.1.1",
+    "description": "Users may view a list of all discussions they have participated in. This is a more user-friendly version of an auto-subscribe option.",
+    "version": "2.0",
     "mobileFriendly": true,
     "requiredTheme": false,
     "hasLocale": true,

--- a/plugins/Participated/class.participated.plugin.php
+++ b/plugins/Participated/class.participated.plugin.php
@@ -53,10 +53,8 @@ class ParticipatedPlugin extends Gdn_Plugin {
             ->select('ud.CountComments', '', 'CountCommentWatch')
             ->from('UserDiscussion ud')
             ->join('Discussion d', 'ud.DiscussionID = d.DiscussionID')
-            ->join('Comment c', 'ud.DiscussionID = c.DiscussionID and c.InsertUserID = ud.UserID')
             ->where('ud.UserID', $userID)
             ->where('ud.Participated', 1)
-            ->groupBy('d.DiscussionID')
             ->orderBy('d.DateLastComment', 'desc')
             ->limit($limit, $offset);
 


### PR DESCRIPTION
This update backports #535 to [releases/2017-Q2-6](https://github.com/vanilla/addons/tree/release/2017-Q2-6).