### PR TITLE
Fix QnA addon not tracking points per-category

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -511,7 +511,7 @@ class QnAPlugin extends Gdn_Plugin {
                 } else {
                     $nbsPoint = $change * (int)c('QnA.Points.AcceptedAnswer', 1);
                     if ($nbsPoint && c('QnA.Points.Enabled', false)) {
-                        UserModel::givePoints($comment['InsertUserID'], $nbsPoint, 'QnA');
+                        CategoryModel::givePoints($comment['InsertUserID'], $nbsPoint, 'QnA', $discussion['CategoryID']);
                     }
                 }
             }
@@ -689,7 +689,7 @@ class QnAPlugin extends Gdn_Plugin {
                     } else {
                         $nbsPoint = $change * (int)c('QnA.Points.AcceptedAnswer', 1);
                         if ($nbsPoint && c('QnA.Points.Enabled', false)) {
-                            UserModel::givePoints($comment['InsertUserID'], $nbsPoint, 'QnA');
+                            CategoryModel::givePoints($comment['InsertUserID'], $nbsPoint, 'QnA', $discussion['CategoryID']);
                         }
                     }
                 }
@@ -1119,6 +1119,6 @@ class QnAPlugin extends Gdn_Plugin {
             return;
         }
 
-        UserModel::givePoints(GDN::session()->UserID, c('QnA.Points.Answer', 1), 'QnA');
+        CategoryModel::givePoints(GDN::session()->UserID, c('QnA.Points.Answer', 1), 'QnA', $discussion['CategoryID']);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/addons/issues/551

There is a feature that you can enable that track points per category.
To track the points properly you have to call 
```
$source = ['QnA', 'CategoryID' => $categoryID];
UserModel::givePoints($userID, $points, $source, $timestamp);
```
where `$categoryID` is the "PointsCategoryID" of the category of the post.

Fortunately there is a convenience method on the CategoryModel that does all the work for you!
