### PR TITLE
Use a category on the categories page as a link to another category or discussion.

### DIFF
--- a/plugins/categoryaslink/addon.json
+++ b/plugins/categoryaslink/addon.json
@@ -1,6 +1,6 @@
 {
     "name": "Category As Link",
-    "description": "Designate a category to be displayed as a link instead of a category.",
+    "description": "Configure a category to show up on the Category List but link to a custom URL.",
     "version": "1.0",
     "key": "categoryaslink",
     "type": "addon",

--- a/plugins/categoryaslink/addon.json
+++ b/plugins/categoryaslink/addon.json
@@ -1,0 +1,17 @@
+{
+    "name": "Category As Link",
+    "description": "Designate a category to be displayed as a link instead of a category.",
+    "version": "1.0",
+    "key": "categoryaslink",
+    "type": "addon",
+    "authors": [
+        {
+            "name": "Patrick Kelly",
+            "email": "patrick.k@vanillaforums.com",
+            "homepage": "https://vanillaforums.com"
+        }
+    ],
+    "require": {
+        "vanilla": ">=2.3.0"
+    }
+}

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -25,7 +25,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      */
     public function structure() {
         Gdn::structure()->table('Category')
-            ->column('RedirectURL', 'varchar(255)', true)
+            ->column('RedirectUrl', 'varchar(255)', true)
             ->set();
     }
 
@@ -37,14 +37,14 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      * @param SettingsController $args
      */
     public function settingsController_addEditCategory_handler($sender, $args) {
-        $sender->Data['_ExtendedFields']['RedirectURL'] = [
+        $sender->Data['_ExtendedFields']['RedirectUrl'] = [
             'Control' => 'TextBox',
             'Description' => 'Instead of acting as a category this will link to a discussion, another category or any URL when you add a full valid URL.',
             'Options' => ['IncludeNull' => 'None']
         ];
 
-        $sender->Form->validateRule('RedirectURL', 'validateWebAddress', t('Redirect Link URL must be a valid Web Address'));
-        if ($sender->Form->getFormValue('RedirectURL')) {
+        $sender->Form->validateRule('RedirectUrl', 'validateWebAddress', t('Redirect Link URL must be a valid Web Address'));
+        if ($sender->Form->getFormValue('RedirectUrl')) {
             // Has to be displayed as Discussions for the BeforeCategoriesRender
             // to redirect any requests to the category.
             $sender->Form->setFormValue('DisplayAs', 'Discussions');
@@ -68,11 +68,11 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
         $categories =& $sender->Data['CategoryTree'];
 
         foreach ($categories as &$category) {
-            if (!val('RedirectURL', $category)) {
+            if (!val('RedirectUrl', $category)) {
                 continue;
             }
 
-            if (val('RedirectURL', $category)) {
+            if (val('RedirectUrl', $category)) {
                 // Linked discussion.
                 // Add CSS classes in case someone wants to display Aliased Categories differently.
                 $category['_CssClass'] = 'Aliased AliasedCategory';
@@ -92,7 +92,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      * @param CategoriesController $args
      */
     public function categoriesController_beforeCategoriesRender_handler($sender, $args) {
-        if ($sender->data('Category.RedirectURL')) {
+        if ($sender->data('Category.RedirectUrl')) {
             redirectTo(categoryUrl($sender->Data('Category')), 301);
         }
     }
@@ -102,7 +102,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
 if (!function_exists("categoryUrl")) {
 
    /**
-    * Override links to categories with either the URL of the LinkedCategory or RedirectURL.
+    * Override links to categories with either the URL of the LinkedCategory or RedirectUrl.
     *
     * @param string | array $category
     * @param string | int $page The page number.
@@ -117,9 +117,9 @@ if (!function_exists("categoryUrl")) {
         $category = (array)$category;
 
         // If there is a URL that links to a discussion it overrides the category or even a link to an alias category.
-        if (val('RedirectURL', $category)) {
+        if (val('RedirectUrl', $category)) {
             // SafeURL because you may be linking to another web property, another forum or knowledgebase.
-            return safeURL(val('RedirectURL', $category));
+            return safeURL(val('RedirectUrl', $category));
         }
 
         // Build URL.

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license proprietary
+ */
+
+
+/**
+ * Class CategoryAsLinkPlugin
+ *
+ * A plugin to allow admins to create a "category" that will not have any posts but will serve as a link.
+ */
+class CategoryAsLinkPlugin extends Gdn_Plugin {
+
+    /**
+     * Executes every time the plugin is turned on, makes changes to config.
+     */
+    public function setup() {
+        $this->structure();
+    }
+
+
+    /**
+     * Add columns to the Category table to stor Linked CategoryIDs or LinkedDiscussion URLs.
+     */
+    public function structure() {
+        Gdn::structure()->table('Category')
+            ->column('LinkedCategoryID', 'int', true)
+            ->column('LinkedDiscussion', 'varchar(255)', true)
+            ->set();
+    }
+
+
+    /**
+     * On the category add/edit page the dashboard, add a dropdown of categories, to link a category
+     * to another category. Add a textbox to link a category to some other URI (e.g. a discussion).
+     *
+     * @param SettingsController $sender
+     * @param SettingsController $args
+     */
+    public function settingsController_addEditCategory_handler($sender, $args) {
+        $sender->Data['_ExtendedFields']['LinkedCategoryID'] = [
+            'Control' => 'categorydropdown',
+            'Description' => 'Act as a copy of another category on this forum.',
+            'Options' => ['IncludeNull' => 'None']
+        ];
+        $sender->Data['_ExtendedFields']['LinkedDiscussion'] = [
+            'Control' => 'TextBox',
+            'Description' => 'Act as a link to a discussion. Paste the full URL of the address. If you have linked this category to another category this will override it.',
+            'Options' => ['IncludeNull' => 'None']
+        ];
+
+        $sender->Form->validateRule('LinkedDiscussion', 'validateWebAddress', t('Linked Discussion must be a valid Web Address'));
+    }
+
+
+    /**
+     * Loop through all the categories and prepare data to display LinkedCategory data or LinkedDiscussions.
+     *
+     * @param CategoriesController $sender
+     * @param CategoriesController $args
+     */
+    public function categoriesController_render_before($sender, $args) {
+        if (!isset($sender->Data['CategoryTree'])
+            || !is_array($sender->Data['CategoryTree'])
+            || !is_array(reset($sender->Data['CategoryTree']))) {
+            return;
+        }
+
+        $categories =& $sender->Data['CategoryTree'];
+
+        foreach ($categories as &$category) {
+            if (!val('LinkedCategoryID', $category) && !val('LinkedDiscussion', $category)) {
+                continue;
+            }
+
+            $linkedCategoryID = val('LinkedCategoryID', $category);
+            if (isset($linkedCategoryID)) {
+                // Get linked category data.
+                $linkedCategory[] = $sender->CategoryModel->categories($linkedCategoryID);
+                $sender->CategoryModel->joinRecent($linkedCategory, $linkedCategoryID);
+                $linkedCategory = $linkedCategory[0];
+                $category['_CssClass'] = 'Aliased AliasedCategory';
+                $category['LastTitle'] = val('LastTitle', $linkedCategory);
+                $category['LastUrl'] = val('LastUrl', $linkedCategory);
+                $category['LastDateInserted'] = val('LastDateInserted', $linkedCategory);
+                $category['LastName'] = val('LastName', $linkedCategory);
+                $category['LastPhoto'] = val('LastPhoto', $linkedCategory);
+                $category['LastUserID'] = val('LastUserID', $linkedCategory);
+                $category['LastCategoryID'] = val('CategoryID', $linkedCategory);
+                $category['CountAllDiscussions'] = val('CountAllDiscussions', $linkedCategory);
+                $category['CountAllComments'] = val('CountAllComments', $linkedCategory);
+                $category['Name'] = val('Name', $linkedCategory);
+                $category['Description'] = val('Description', $linkedCategory);
+                $category['Linked'] = true;
+            }
+
+            if (val('LinkedDiscussion', $category)) {
+                // Linked discussion.
+                $category['_CssClass'] = 'Aliased AliasedDiscussion';
+                $category['LastTitle'] = null; // Set to null so that no LastDiscussion info will be displayed.
+                $category['CountAllDiscussions'] = false; // Set to false so that now Count info will be displayed.
+                $category['CountAllComments'] = false;
+                $category['Linked'] = true;
+            }
+        }
+    }
+
+
+    /**
+     * Redirect any request to a category that is aliased either to another category or a discussion.
+     *
+     * @param CategoriesController $sender
+     * @param CategoriesController $args
+     */
+    public function categoriesController_beforeCategoriesRender_handler($sender, $args) {
+        if ($sender->data('Category.LinkedCategoryID')) {
+            redirectTo(categoryUrl($sender->Data('Category'), 301));
+        }
+
+        if ($sender->data('Category.LinkedDiscussion')) {
+            redirectTo(categoryUrl($sender->Data('Category')), 301);
+        }
+    }
+}
+
+
+if (!function_exists("categoryUrl")) {
+
+   /**
+    * Override links to categories with either the URL of the LinkedCategory or LinkedDiscussion.
+    *
+    * @param string | array $category
+    * @param string | int $page The page number.
+    * @param bool $withDomain Whether to add the domain to the URL
+    * @return string The url to a category.
+    */
+    function categoryUrl($category, $page = '', $withDomain = true) {
+        static $px;
+        if (is_string($category)) {
+            $category = CategoryModel::categories($category);
+        }
+        $category = (array)$category;
+
+        // If there is a URL that links to a discussion it overrides the category or even a link to an alias category.
+        if (val('LinkedDiscussion', $category)) {
+            // SafeURL because you may be linking to another web property, another forum or knowledgebase.
+            return safeURL(val('LinkedDiscussion', $category));
+        }
+
+        // If there is a LinkedCategoryID use the LinkedCategory as the Category.
+        if ($linked = val('LinkedCategoryID', $category)) {
+            $category = CategoryModel::categories($linked);
+        }
+
+        // Build URL.
+        if (class_exists('SEOLinksPlugin')) {
+            // SEOLinks version
+            if (!isset($px)) {
+                $px = SEOLinksPlugin::Prefix();
+            }
+            $result = '/' . $px . rawurlencode($category['UrlCode']) . '/';
+            if ($page && $page > 1) {
+                $result .= 'p' . $page . '/';
+            }
+        } else {
+            // Normal version
+            $result = '/categories/'.rawurlencode($category['UrlCode']);
+            if ($page && $page > 1) {
+                $result .= '/p'.$page;
+            }
+        }
+
+        return url($result, $withDomain);
+    }
+}

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -25,7 +25,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      */
     public function structure() {
         Gdn::structure()->table('Category')
-            ->column('CustomLinkURL', 'varchar(255)', true)
+            ->column('RedirectURL', 'varchar(255)', true)
             ->set();
     }
 
@@ -37,14 +37,14 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      * @param SettingsController $args
      */
     public function settingsController_addEditCategory_handler($sender, $args) {
-        $sender->Data['_ExtendedFields']['CustomLinkURL'] = [
+        $sender->Data['_ExtendedFields']['RedirectURL'] = [
             'Control' => 'TextBox',
-            'Description' => 'Act as a link to a discussion, another category or any URL. Paste the full URL of the address.',
+            'Description' => 'Instead of acting as a category this will link to a discussion, another category or any URL when you add a full valid URL.',
             'Options' => ['IncludeNull' => 'None']
         ];
 
-        $sender->Form->validateRule('CustomLinkURL', 'validateWebAddress', t('Category Custom Link URL must be a valid Web Address'));
-        if ($sender->Form->getFormValue('CustomLinkURL')) {
+        $sender->Form->validateRule('RedirectURL', 'validateWebAddress', t('Redirect Link URL must be a valid Web Address'));
+        if ($sender->Form->getFormValue('RedirectURL')) {
             // Has to be displayed as Discussions for the BeforeCategoriesRender
             // to redirect any requests to the category.
             $sender->Form->setFormValue('DisplayAs', 'Discussions');
@@ -68,11 +68,11 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
         $categories =& $sender->Data['CategoryTree'];
 
         foreach ($categories as &$category) {
-            if (!val('CustomLinkURL', $category)) {
+            if (!val('RedirectURL', $category)) {
                 continue;
             }
 
-            if (val('CustomLinkURL', $category)) {
+            if (val('RedirectURL', $category)) {
                 // Linked discussion.
                 // Add CSS classes in case someone wants to display Aliased Categories differently.
                 $category['_CssClass'] = 'Aliased AliasedCategory';
@@ -92,7 +92,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      * @param CategoriesController $args
      */
     public function categoriesController_beforeCategoriesRender_handler($sender, $args) {
-        if ($sender->data('Category.CustomLinkURL')) {
+        if ($sender->data('Category.RedirectURL')) {
             redirectTo(categoryUrl($sender->Data('Category')), 301);
         }
     }
@@ -102,7 +102,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
 if (!function_exists("categoryUrl")) {
 
    /**
-    * Override links to categories with either the URL of the LinkedCategory or CustomLinkURL.
+    * Override links to categories with either the URL of the LinkedCategory or RedirectURL.
     *
     * @param string | array $category
     * @param string | int $page The page number.
@@ -117,9 +117,9 @@ if (!function_exists("categoryUrl")) {
         $category = (array)$category;
 
         // If there is a URL that links to a discussion it overrides the category or even a link to an alias category.
-        if (val('CustomLinkURL', $category)) {
+        if (val('RedirectURL', $category)) {
             // SafeURL because you may be linking to another web property, another forum or knowledgebase.
-            return safeURL(val('CustomLinkURL', $category));
+            return safeURL(val('RedirectURL', $category));
         }
 
         // Build URL.

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -79,24 +79,27 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
                 // Get linked category data.
                 $linkedCategory[] = $sender->CategoryModel->categories($linkedCategoryID);
                 $sender->CategoryModel->joinRecent($linkedCategory, $linkedCategoryID);
-                $linkedCategory = $linkedCategory[0];
+
+                // Capture the original name and description for display.
+                $categoryName = val('Name', $category);
+                $categoryDescription = val('Description', $category);
+
+                // Substitute the linked category for the current category.
+                if
+                $category = $linkedCategory[0];
+
+                // Add CSS classes in case someone wants to display Aliased Categories differently.
                 $category['_CssClass'] = 'Aliased AliasedCategory';
-                $category['LastTitle'] = val('LastTitle', $linkedCategory);
-                $category['LastUrl'] = val('LastUrl', $linkedCategory);
-                $category['LastDateInserted'] = val('LastDateInserted', $linkedCategory);
-                $category['LastName'] = val('LastName', $linkedCategory);
-                $category['LastPhoto'] = val('LastPhoto', $linkedCategory);
-                $category['LastUserID'] = val('LastUserID', $linkedCategory);
-                $category['LastCategoryID'] = val('CategoryID', $linkedCategory);
-                $category['CountAllDiscussions'] = val('CountAllDiscussions', $linkedCategory);
-                $category['CountAllComments'] = val('CountAllComments', $linkedCategory);
-                $category['Name'] = val('Name', $linkedCategory);
-                $category['Description'] = val('Description', $linkedCategory);
+
+                // Put back the original name and description of the category
+                $category['Name'] = $categoryName ? $categoryName : val('Name', $linkedCategory);
+                $category['Description'] = $categoryDescription ? $categoryDescription : val('Description', $linkedCategory);
                 $category['Linked'] = true;
             }
 
             if (val('LinkedDiscussion', $category)) {
                 // Linked discussion.
+                // Add CSS classes in case someone wants to display Aliased Categories differently.
                 $category['_CssClass'] = 'Aliased AliasedDiscussion';
                 $category['LastTitle'] = null; // Set to null so that no LastDiscussion info will be displayed.
                 $category['CountAllDiscussions'] = false; // Set to false so that now Count info will be displayed.

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -21,30 +21,30 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
 
 
     /**
-     * Add columns to the Category table to store LinkedDiscussion URLs.
+     * Add columns to the Category table to store CustomLinkURLs.
      */
     public function structure() {
         Gdn::structure()->table('Category')
-            ->column('LinkedDiscussion', 'varchar(255)', true)
+            ->column('CustomLinkURL', 'varchar(255)', true)
             ->set();
     }
 
 
     /**
-     * On the category add/edit page the dashboard, add a textbox to link a category to some other URI (e.g. a discussion).
+     * On the category add/edit page the dashboard, add a text box to link a category to some other URI (e.g. a discussion).
      *
      * @param SettingsController $sender
      * @param SettingsController $args
      */
     public function settingsController_addEditCategory_handler($sender, $args) {
-        $sender->Data['_ExtendedFields']['LinkedDiscussion'] = [
+        $sender->Data['_ExtendedFields']['CustomLinkURL'] = [
             'Control' => 'TextBox',
             'Description' => 'Act as a link to a discussion, another category or any URL. Paste the full URL of the address.',
             'Options' => ['IncludeNull' => 'None']
         ];
 
-        $sender->Form->validateRule('LinkedDiscussion', 'validateWebAddress', t('Linked Discussion must be a valid Web Address'));
-        if ($sender->Form->getFormValue('LinkedDiscussion')) {
+        $sender->Form->validateRule('CustomLinkURL', 'validateWebAddress', t('Category Custom Link URL must be a valid Web Address'));
+        if ($sender->Form->getFormValue('CustomLinkURL')) {
             // Has to be displayed as Discussions for the BeforeCategoriesRender
             // to redirect any requests to the category.
             $sender->Form->setFormValue('DisplayAs', 'Discussions');
@@ -53,7 +53,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
 
 
     /**
-     * Loop through all the categories and prepare data to display any LinkedDiscussions.
+     * Loop through all the categories and prepare data to display any CustomLinkURLs.
      *
      * @param CategoriesController $sender
      * @param CategoriesController $args
@@ -68,14 +68,14 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
         $categories =& $sender->Data['CategoryTree'];
 
         foreach ($categories as &$category) {
-            if (!val('LinkedDiscussion', $category)) {
+            if (!val('CustomLinkURL', $category)) {
                 continue;
             }
 
-            if (val('LinkedDiscussion', $category)) {
+            if (val('CustomLinkURL', $category)) {
                 // Linked discussion.
                 // Add CSS classes in case someone wants to display Aliased Categories differently.
-                $category['_CssClass'] = 'Aliased AliasedDiscussion';
+                $category['_CssClass'] = 'Aliased AliasedCategory';
                 $category['LastTitle'] = null; // Set to null so that no LastDiscussion info will be displayed.
                 $category['CountAllDiscussions'] = false; // Set to false so that now Count info will be displayed.
                 $category['CountAllComments'] = false;
@@ -92,7 +92,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
      * @param CategoriesController $args
      */
     public function categoriesController_beforeCategoriesRender_handler($sender, $args) {
-        if ($sender->data('Category.LinkedDiscussion')) {
+        if ($sender->data('Category.CustomLinkURL')) {
             redirectTo(categoryUrl($sender->Data('Category')), 301);
         }
     }
@@ -102,7 +102,7 @@ class CategoryAsLinkPlugin extends Gdn_Plugin {
 if (!function_exists("categoryUrl")) {
 
    /**
-    * Override links to categories with either the URL of the LinkedCategory or LinkedDiscussion.
+    * Override links to categories with either the URL of the LinkedCategory or CustomLinkURL.
     *
     * @param string | array $category
     * @param string | int $page The page number.
@@ -117,9 +117,9 @@ if (!function_exists("categoryUrl")) {
         $category = (array)$category;
 
         // If there is a URL that links to a discussion it overrides the category or even a link to an alias category.
-        if (val('LinkedDiscussion', $category)) {
+        if (val('CustomLinkURL', $category)) {
             // SafeURL because you may be linking to another web property, another forum or knowledgebase.
-            return safeURL(val('LinkedDiscussion', $category));
+            return safeURL(val('CustomLinkURL', $category));
         }
 
         // Build URL.


### PR DESCRIPTION
Sometimes Admins have want to funnel users who are looking through the categories to another part of the forum or to a specific post. 

This PR creates a feature that will allow admins, when creating or editing a category in the dashboard, to either attach an existing CategoryID or any valid URI that will be used to as the destination whenever a user clicks on or navigates to that category.