### PR TITLE
HipChat: Add comment notifications

### DIFF
--- a/plugins/HipChat/addon.json
+++ b/plugins/HipChat/addon.json
@@ -1,6 +1,6 @@
 {
-    "description": "HipChat integration, first version: Posts every new discussion to HipChat. Requires cURL.",
-    "version": "0.3",
+    "description": "HipChat integration. Posts every new discussion & (optionally) comment to HipChat. Requires cURL.",
+    "version": "0.4",
     "license": "GNU GPL2",
     "settingsUrl": "/settings/hipchat",
     "settingsPermission": "Garden.Settings.Manage",


### PR DESCRIPTION
I'm adding the ability to opt into notifications for all comments in addition to existing always-on notifications for all discussions. Default is false for backwards compatibility.

I've also changed the locales to specify the action being taken. These codes aren't in locales yet anyway, and this isn't in use on cloud outside our staff forum so I don't think that's necessary right now.

Also did a couple minor code cleanups, incremented to 0.4, and updated the addon description.

I plan to backport this since it's only used by us and therefore a safe change.