### PR TITLE
Fix Burner Blocker not hooking into registrations

### DIFF
--- a/plugins/burnerblocker/class.burnerblocker.plugin.php
+++ b/plugins/burnerblocker/class.burnerblocker.plugin.php
@@ -80,7 +80,7 @@ class BurnerBlockerPlugin extends Gdn_Plugin {
      * @param $sender UserModel Triggering object.
      * @param $args array Event arguments.
      */
-    public function userModel_beforeRegister_handler($sender, &$args) {
+    public function userModel_beforeRegister_handler($sender, $args) {
         // Get the user's email domain.
         $email = val('Email', $args['RegisteringUser']);
         $domain = substr($email, strpos($email, '@')+1);


### PR DESCRIPTION
Attempting to use Burner Blocker currently throws a notice when a user registers and the primary hook is never actually fired.

```
Parameter 2 to BurnerBlockerPlugin::userModel_beforeRegister_handler() expected to be a reference, value given
```

This update alters the hook function's signature to expect a value, not a reference. Since the elements in `$args` are already references, the intended functionality is unaffected.

Closes #566