### PR TITLE
Make sure that the target is not empty before setting it

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -533,7 +533,9 @@ class JsConnectPlugin extends Gdn_Plugin {
             $sender->setData('Title', t('Connecting...'));
             $sender->Form->Action = url('/entry/connect/jsconnect?'.http_build_query($get));
             $sender->Form->addHidden('JsConnect', '');
-            $sender->Form->addHidden('Target', $target);
+            if (!empty($target)) {
+                $sender->Form->addHidden('Target', safeURL($target));
+            }
 
             $sender->MasterView = 'empty';
             $sender->render('JsConnect', '', 'plugins/jsconnect');


### PR DESCRIPTION
Fix an infinite redirection bug. safeUrl('') default to the current page.