### PR TITLE
Update example addon's addon.json

### DIFF
--- a/plugins/example/addon.json
+++ b/plugins/example/addon.json
@@ -1,11 +1,10 @@
 {
+    "name": "Example Plugin",
     "description": "Provides an example Development Pattern for Vanilla 2 plugins by demonstrating how to insert discussion body excerpts into the discussions list.",
-    "version": "1.1",
-    "requiredTheme": false,
+    "version": "1.2.0",
     "hasLocale": false,
     "license": "GNU GPL2",
     "settingsUrl": "/plugin/example",
-    "settingsPermission": "Garden.Settings.Manage",
     "key": "example",
     "type": "addon",
     "authors": [
@@ -15,7 +14,7 @@
         }
     ],
     "require": {
-        "vanilla": ">=2.1"
+        "vanilla": ">=2.5"
     },
 	"icon": "example.png"
 }


### PR DESCRIPTION
- Add "name" key
- remove "settingsPermission" and "requiredTheme"

Also increased version number and required Vanilla version 2.5. "settingsPermission" was removed based on [that comment](https://open.vanillaforums.com/discussion/comment/243085/#Comment_243085) and the fact that this key isn't used anywhere in Vanilla