### PR TITLE
Fix signature not showing on Q&A answers

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -553,6 +553,15 @@ EOT;
     }
 
     /**
+     * Load signatures.
+     *
+     * @param $sender
+     */
+    public function discussionController_beforeDiscussionRender_handler($sender) {
+        $this->signatures($sender);
+    }
+
+    /**
      *
      *
      * @param $sender


### PR DESCRIPTION
Fixes https://github.com/vanilla/addons/issues/560

The problem was that comments were filtered out in Q&A `discussionController_beforeDiscussionRender_handler()` which interfered with the signatures are fetched. To fix this issue the filtering was moved to a later event and the signature fetching was moved to an earlier event!