### PR TITLE
Fix discussion Q&A status for edited and deleted comments

### DIFF
--- a/plugins/QnA/addon.json
+++ b/plugins/QnA/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Q&A",
     "description": "Users may designate a discussion as a Question and then officially accept one or more of the comments as the answer.",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "mobileFriendly": true,
     "settingsUrl": "/settings/qna",
     "icon": "qna.png",


### PR DESCRIPTION
- When a rejected comment is edited it used to mark the question answered. Now editing a comment leaves the Q&A status alone.
- When deleting a comment or doing anything else that causes the comment count to recalculate the full Q&A status is recalculated for the question which should be more robust.

Closes vanilla/support#5