### PR TITLE
Fix necro addon datetime usage

### DIFF
--- a/plugins/necro/class.necro.plugin.php
+++ b/plugins/necro/class.necro.plugin.php
@@ -66,7 +66,7 @@ class NecroPlugin extends Gdn_Plugin {
      */
     protected function setNecro($discussionID) {
         Gdn::sql()->update('Discussion')
-            ->set('DateRevived', date('U'))
+            ->set('DateRevived', Gdn_Format::toDateTime())
             ->where('DiscussionID', $discussionID)
             ->put();
     }


### PR DESCRIPTION
Apparently we used to allow Linux timestamps in these fields. Now they fatal and stop the discussion from bumping.