### PR TITLE
Backport: Fix necro datetime patch

### DIFF
--- a/plugins/necro/class.necro.plugin.php
+++ b/plugins/necro/class.necro.plugin.php
@@ -66,7 +66,7 @@ class NecroPlugin extends Gdn_Plugin {
      */
     protected function setNecro($discussionID) {
         Gdn::sql()->update('Discussion')
-            ->set('DateRevived', date('U'))
+            ->set('DateRevived', Gdn_Format::toDateTime())
             ->where('DiscussionID', $discussionID)
             ->put();
     }


### PR DESCRIPTION
Original: https://github.com/vanilla/addons/pull/591

This is causing fatal errors & blocking post bumping. 
Patch is an isolated change.