### PR TITLE
Fix discussion URLs in vBulletin format not always being detected by Redirector

### DIFF
--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -529,19 +529,14 @@ class RedirectorPlugin extends Gdn_Plugin {
             ]
         ];
 
-        if (isset($get['t'])) {
-            $data['t'] = [
-                'DiscussionID',
-                'Filter' => [__CLASS__, 'removeID']
-            ];
-            self::vbFriendlyUrlID($get, 't');
-        } elseif (!isset($get['p'])) {
+        if (isset($get['t']) || !isset($get['p'])) {
             $data['t'] = [
                 'DiscussionID',
                 'Filter' => [__CLASS__, 'removeID']
             ];
             self::vbFriendlyUrlID($get, 't');
         }
+        
         return $data;
 
     }

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -535,6 +535,12 @@ class RedirectorPlugin extends Gdn_Plugin {
                 'Filter' => [__CLASS__, 'removeID']
             ];
             self::vbFriendlyUrlID($get, 't');
+        } elseif (!isset($get['p'])) {
+            $data['t'] = [
+                'DiscussionID',
+                'Filter' => [__CLASS__, 'removeID']
+            ];
+            self::vbFriendlyUrlID($get, 't');
         }
         return $data;
 


### PR DESCRIPTION
We are currently handling a migration from vBulletin. Site used vBulletin basic friendly URLs.

https://www.vbulletin.com/docs/html/main/options_seofriendly_urls

The current implementation seems to be mishandling the discussion case. We want to recover the discussion ID when the `t=`  parameter is not set or more specifically is not part of the URL.

This new implementation handles it correctly while preventing us from sending us to the discussion when the link is actually a comment. 