### PR TITLE
Add API capabilities to QnA addon

### DIFF
--- a/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
+++ b/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\APIv2;
+
+require_once(__DIR__.'/QnaTestHelperTrait.php');
+
+/**
+ * Test managing answers with the /api/v2/comments endpoint.
+ */
+class CommentsAnswerTest extends AbstractAPIv2Test {
+
+    use QnaTestHelperTrait;
+
+    private static $category;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        self::$addons = ['vanilla', 'qna'];
+        parent::setupBeforeClass();
+
+        /**
+         * @var \Gdn_Session $session
+         */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
+        /** @var \CategoriesApiController $categoryAPIController */
+        $categoryAPIController = static::container()->get('CategoriesApiController');
+
+        self::$category = $categoryAPIController->post([
+            'name' => 'answerTest',
+            'urlcode' => 'answertest',
+        ]);
+
+        $session->end();
+    }
+
+    /**
+     * Create a question.
+     *
+     * @return array The question.
+     */
+    protected function createQuestion() {
+        $record = [
+            'categoryID' => self::$category['categoryID'],
+            'name' => 'Test Question For Answer',
+            'body' => 'Hello world!',
+            'format' => 'markdown',
+        ];
+        $response = $this->api()->post('discussions/question', $record);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        return $response->getBody();
+    }
+
+    /**
+     * Get a question.
+     *
+     * @param int $discussionID
+     * @return array The question.
+     */
+    protected function getQuestion($discussionID) {
+        $response = $this->api()->get("discussions/$discussionID");
+        $this->assertEquals(200, $response->getStatusCode());
+
+        return $response->getBody();
+    }
+
+    /**
+     * Test answer creation.
+     *
+     * @param int $discussionID If omitted the answer will be created on a new Question.
+     * @return mixed
+     */
+    public function testPostAnswer($discussionID = null) {
+        if ($discussionID === null) {
+            $question = $this->createQuestion();
+            $discussionID = $question['discussionID'];
+        }
+
+        $record = [
+            'discussionID' => $discussionID,
+            'body' => 'Hello world!',
+            'format' => 'markdown',
+        ];
+        $response = $this->api()->post('comments', $record);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $body = $response->getBody();
+
+        $this->assertTrue(is_int($body['commentID']));
+        $this->assertTrue($body['commentID'] > 0);
+
+        $this->assertRowsEqual($record, $body);
+
+        $this->assertIsAnswer($body);
+
+        $question = $this->getQuestion($discussionID);
+        $this->assertIsQuestion($question, ['status' => 'answered']);
+
+        return $body;
+    }
+
+    /**
+     * Test getting an answer.
+     *
+     * @depends testPostAnswer
+     */
+    public function testGetAnswer() {
+        $answer = $this->testPostAnswer();
+        $commentID = $answer['commentID'];
+
+        $response = $this->api()->get("comments/{$commentID}");
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = $response->getBody();
+        $this->assertIsAnswer($body, ['status' => 'pending']);
+    }
+
+    /**
+     * Test accepting an answer.
+     *
+     * @depends testPostAnswer
+     */
+    public function testAcceptAnswer() {
+        $question = $this->createQuestion();
+        $answer = $this->testPostAnswer($question['discussionID']);
+
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'accepted',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertIsAnswer($response->getBody(), ['status' => 'accepted']);
+
+        $updatedQuestion = $this->getQuestion($question['discussionID']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'accepted']);
+    }
+
+    /**
+     * Test rejecting an answer.
+     *
+     * @depends testPostAnswer
+     */
+    public function testRejectAnswer() {
+        $question = $this->createQuestion();
+        $answer = $this->testPostAnswer($question['discussionID']);
+
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'rejected',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertIsAnswer($response->getBody(), ['status' => 'rejected']);
+
+        $updatedQuestion = $this->getQuestion($question['discussionID']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'rejected']);
+    }
+
+    /**
+     * Test accepting and then setting back an answer to pending.
+     *
+     * @depends testPostAnswer
+     */
+    public function testResetAnswer() {
+        $question = $this->createQuestion();
+        $answer = $this->testPostAnswer($question['discussionID']);
+
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'accepted',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'pending',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertIsAnswer($response->getBody(), ['status' => 'pending']);
+
+        $updatedQuestion = $this->getQuestion($question['discussionID']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'unanswered']);
+    }
+
+    /**
+     * Test accepting and then rejecting an answer.
+     *
+     * @depends testPostAnswer
+     */
+    public function testAcceptRejectAnswer() {
+        $question = $this->createQuestion();
+        $answer = $this->testPostAnswer($question['discussionID']);
+
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'accepted',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'rejected',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertIsAnswer($response->getBody(), ['status' => 'rejected']);
+
+        $updatedQuestion = $this->getQuestion($question['discussionID']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'rejected']);
+    }
+}

--- a/plugins/QnA/tests/APIv2/DiscussionsQuestionTest.php
+++ b/plugins/QnA/tests/APIv2/DiscussionsQuestionTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\APIv2;
+
+require_once(__DIR__.'/QnaTestHelperTrait.php');
+
+/**
+ * Test managing questions with the /api/v2/discussions endpoint.
+ */
+class DiscussionsQuestionTest extends AbstractAPIv2Test {
+
+    use QnaTestHelperTrait;
+
+    /** @var int Category containing questions. */
+    private static $category;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        self::$addons = ['vanilla', 'qna'];
+        parent::setupBeforeClass();
+
+        /**
+         * @var \Gdn_Session $session
+         */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
+        /** @var \CategoriesApiController $categoryAPIController */
+        $categoryAPIController = static::container()->get('CategoriesApiController');
+
+        self::$category = $categoryAPIController->post([
+            'name' => 'QuestionTest',
+            'urlcode' => 'questiontest',
+        ]);
+
+        $session->end();
+    }
+
+    /**
+     * Test /discussion/<id> includes question metadata.
+     */
+    public function testGetQuestion() {
+        $row = $this->testPostQuestion();
+        $discussionID = $row['discussionID'];
+
+        $response = $this->api()->get("discussions/{$discussionID}");
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = $response->getBody();
+        $this->assertIsQuestion($body, ['status' => 'unanswered']);
+
+        return $body;
+    }
+
+    /**
+     * Verify an question can be created with the discussions endpoint.
+     */
+    public function testPostQuestion() {
+        $record = [
+            'categoryID' => self::$category['categoryID'],
+            'name' => 'Test Question',
+            'body' => 'Hello world!',
+            'format' => 'markdown',
+        ];
+        $response = $this->api()->post('discussions/question', $record);
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $body = $response->getBody();
+        $this->assertEquals('question', $body['type']);
+
+        $this->assertTrue(is_int($body['discussionID']));
+        $this->assertTrue($body['discussionID'] > 0);
+
+        $this->assertRowsEqual($record, $body);
+
+        return $body;
+    }
+
+    /**
+     * Verify questions can be queried from the discussions index.
+     */
+    public function testDiscussionsIndexQuestion() {
+        // Add one discussion normal discussion to make sure that the index is properly filtered.
+        $this->api()->post('discussions', [
+            'categoryID' => self::$category['categoryID'],
+            'name' => 'Test Discussion',
+            'body' => 'Hello world!',
+            'format' => 'markdown',
+        ]);
+
+        $indexPosts = 5;
+        for ($i = 1; $i <= $indexPosts; $i++) {
+            $this->testPostQuestion();
+        }
+
+        $response = $this->api()->get('discussions', ['type' => 'question']);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $questions = $response->getBody();
+        $this->assertNotEmpty($questions);
+        foreach ($questions as $question) {
+            $this->assertIsQuestion($question);
+        }
+    }
+}

--- a/plugins/QnA/tests/APIv2/QnaTestHelperTrait.php
+++ b/plugins/QnA/tests/APIv2/QnaTestHelperTrait.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Trait QnaTestHelperTrait
+ */
+trait QnaTestHelperTrait {
+    /**
+     * Assert an array has all necessary question fields.
+     *
+     * @param array $discussion
+     * @param array $expectedAttributes
+     */
+    protected function assertIsQuestion($discussion, $expectedAttributes = []) {
+        $this->assertInternalType('array', $discussion);
+
+        $this->assertArrayHasKey('type', $discussion);
+        $this->assertEquals('question', $discussion['type']);
+
+        $this->assertArrayHasKey('attributes', $discussion);
+        $this->assertArrayHasKey('question', $discussion['attributes']);
+
+        $this->assertArrayHasKey('status', $discussion['attributes']['question']);
+        $this->assertArrayHasKey('dateAccepted', $discussion['attributes']['question']);
+        $this->assertArrayHasKey('dateAnswered', $discussion['attributes']['question']);
+
+        foreach($expectedAttributes as $attribute => $value) {
+            $this->assertEquals($value, $discussion['attributes']['question'][$attribute]);
+        }
+    }
+
+    /**
+     * Assert an array has all necessary answer fields.
+     *
+     * @param array $comment
+     * @param array $expectedAttributes
+     */
+    protected function assertIsAnswer($comment, $expectedAttributes = []) {
+        $this->assertInternalType('array', $comment);
+
+        $this->assertArrayHasKey('attributes', $comment);
+        $this->assertArrayHasKey('answer', $comment['attributes']);
+
+        $this->assertArrayHasKey('status', $comment['attributes']['answer']);
+        $this->assertArrayHasKey('dateAccepted', $comment['attributes']['answer']);
+        $this->assertArrayHasKey('acceptUserID', $comment['attributes']['answer']);
+
+        foreach($expectedAttributes as $attribute => $value) {
+            $this->assertEquals($value, $comment['attributes']['answer'][$attribute]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vanilla/internal/issues/1166

Depends on https://github.com/vanilla/vanilla/pull/6646, https://github.com/vanilla/vanilla/pull/6635, https://github.com/vanilla/vanilla/pull/6634

- Expose question metadata in discussion attributes field
- Expose answer metadata in comments attributes field
- Add POST /discussions/question to allow to create questions.
- Add PATCH /comments/answer to allow to update answers metadata