### PR TITLE
Add userContent class onto signatures

### DIFF
--- a/plugins/Pockets/library/class.pocket.php
+++ b/plugins/Pockets/library/class.pocket.php
@@ -317,5 +317,4 @@ class Pocket {
             $model->save($pocket);
         }
     }
-
 }

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -662,7 +662,7 @@ EOT;
             $this->fireEvent('FilterContent');
 
             if ($userSignature) {
-                echo "<div class=\"Signature UserSignature {$sigClasses}\">{$userSignature}</div>";
+                echo "<div class=\"Signature UserSignature userContent {$sigClasses}\">{$userSignature}</div>";
             }
         }
     }


### PR DESCRIPTION
Reference vanilla/vanilla#6673
Related vanilla/internal#1464
Related vanilla/vanilla#6758

Adds user content class for non-plaintext content created by users. This class is used for some styles related the rich editor.