### PR TITLE
Fix AuthorSelector ChangeAuthor-Link

### DIFF
--- a/plugins/AuthorSelector/class.authorselector.plugin.php
+++ b/plugins/AuthorSelector/class.authorselector.plugin.php
@@ -16,7 +16,7 @@ class AuthorSelectorPlugin extends Gdn_Plugin {
         $discussion = $args['Discussion'];
         if (Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $discussion->PermissionCategoryID)) {
             $label = t('Change Author');
-            $url = "/discussion/author?discussionid={$discussion->DiscussionID}";
+            $url = url("/discussion/author?discussionid={$discussion->DiscussionID}");
 
             // Deal with inconsistencies in how options are passed
             if (isset($sender->Options)) {


### PR DESCRIPTION
The link for the ChangeAuthor-link needs to be build with the `url()` function.