### PR TITLE
Fix HipChat comment author data

### DIFF
--- a/plugins/HipChat/class.hipchat.plugin.php
+++ b/plugins/HipChat/class.hipchat.plugin.php
@@ -98,8 +98,12 @@ class HipChatPlugin extends Gdn_Plugin {
         $discussionModel = new DiscussionModel();
         $discussion = $discussionModel->getID($args['CommentData']['DiscussionID'], DATASET_TYPE_ARRAY);
 
+        // Get the comment data fresh so we don't get polluted info.
+        $commentModel = new CommentModel();
+        $comment = $commentModel->getID(val('CommentID', $args));
+
         // Prep HipChat message.
-        $author = Gdn::userModel()->getID(val('InsertUserID', $discussion));
+        $author = Gdn::userModel()->getID(val('InsertUserID', $comment));
         $message = sprintf(
             '%1$s commented on %2$s',
             userAnchor($author),


### PR DESCRIPTION
Currently HipChat is reporting comments as being from the discussion author (OP) rather than the actual comment author. This grabs the comment data so we can derive the true author. The hook data around this is super brittle so I decided to get it from the database directly.