### PR TITLE
Fix double url() call

### DIFF
--- a/plugins/AuthorSelector/class.authorselector.plugin.php
+++ b/plugins/AuthorSelector/class.authorselector.plugin.php
@@ -16,7 +16,7 @@ class AuthorSelectorPlugin extends Gdn_Plugin {
         $discussion = $args['Discussion'];
         if (Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $discussion->PermissionCategoryID)) {
             $label = t('Change Author');
-            $url = url("/discussion/author?discussionid={$discussion->DiscussionID}");
+            $url = url("/discussion/author?discussionid={$discussion->DiscussionID}", true);
 
             // Deal with inconsistencies in how options are passed
             if (isset($sender->Options)) {


### PR DESCRIPTION
Fixes https://github.com/vanilla/addons/issues/615
Bug was introduced by https://github.com/vanilla/addons/pull/605

The result of `url()` is sent to `anchor()` which calls `url()` again if the link is not absolute. This causes problems in certain cases. ie Subcommunities.