### PR TITLE
Backport: More improvements in logging to JSConnect.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -417,6 +417,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             // Validate the signature.
             $CalculatedSignature = signJsConnect($JsData, $client_id, val('AssociationSecret', $Provider), val('HashType', $Provider, 'md5'));
             if ($CalculatedSignature != $Signature) {
+                Logger::event('jsconnect_error', Logger::ERROR, 'Invalid Signature', ['Data' => $JsData, 'ClientID' => $client_id, 'Secret' => val('AssociationSecret', $Provider), 'HashType' => val('HashType', $Provider, 'md5')]);
                 throw new Gdn_UserException(t("Signature invalid."), 400);
             }
         }
@@ -522,7 +523,7 @@ class JsConnectPlugin extends Gdn_Plugin {
                     $message = t('Your sso timed out.', 'Your sso timed out during the request. Please try again.');
                 }
 
-                Logger::event('jsconnect_error', Logger::ERROR, 'JSConnect Timed Out', ['Message' => $message]);
+                Logger::event('jsconnect_error', Logger::ERROR, 'Redirecting to error page.', ['Data' => $jsData, 'ErrorMessage' => $message]);
                 Gdn::dispatcher()
                     ->passData('Exception', $message ? htmlspecialchars($message) : htmlspecialchars($error))
                     ->dispatch('home/error');

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -523,7 +523,7 @@ class JsConnectPlugin extends Gdn_Plugin {
                     $message = t('Your sso timed out.', 'Your sso timed out during the request. Please try again.');
                 }
 
-                Logger::event('jsconnect_error', Logger::ERROR, 'Redirecting to error page.', ['Data' => $jsData, 'ErrorMessage' => $message]);
+                Logger::event('jsconnect_error', Logger::ERROR, 'Displaying Error Page.', ['Data' => $jsData, 'ErrorMessage' => $message]);
                 Gdn::dispatcher()
                     ->passData('Exception', $message ? htmlspecialchars($message) : htmlspecialchars($error))
                     ->dispatch('home/error');


### PR DESCRIPTION
Backport #623 

> We recently added logging to JSConnect but we mis-named one log entry and we missed the most important one: Signature error.

> This PR will a log where there is a signature error and renames the generic error that comes back from the authenticating server.