### PR TITLE
Add the signature to error logs when logging a signature error in JSConnect.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -417,7 +417,7 @@ class JsConnectPlugin extends Gdn_Plugin {
             // Validate the signature.
             $CalculatedSignature = signJsConnect($JsData, $client_id, val('AssociationSecret', $Provider), val('HashType', $Provider, 'md5'));
             if ($CalculatedSignature != $Signature) {
-                Logger::event('jsconnect_error', Logger::ERROR, 'Invalid Signature', ['Data' => $JsData, 'ClientID' => $client_id, 'Secret' => val('AssociationSecret', $Provider), 'HashType' => val('HashType', $Provider, 'md5')]);
+                Logger::event('jsconnect_error', Logger::ERROR, 'Invalid Signature', ['Data' => $JsData, 'Signature' => $Signature, 'ClientID' => $client_id, 'Secret' => val('AssociationSecret', $Provider), 'HashType' => val('HashType', $Provider, 'md5')]);
                 throw new Gdn_UserException(t("Signature invalid."), 400);
             }
         }


### PR DESCRIPTION
We recently added logging to JSConnect to allow us to debug.  We record the data that is used to generate a signature when the signature fails but we don't record the signature itself for comparison.

We strip out certain elements from the passed JSData array including the signatures and the version.  In this PR we log the JSData before and after it has had these elements stripped out.

Also in this PR, we will log JSData that has passed all validation so that we can know what a successful log in looks like.