### PR TITLE
Add the up-to-date discussion's counts to the question record before recalculating it

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -314,7 +314,8 @@ class QnAPlugin extends Gdn_Plugin {
      * @param array $args Event arguments.
      */
     public function commentModel_beforeUpdateCommentCount_handler($sender, $args) {
-        $discussion =& $args['Discussion'];
+        // Merge the updated counts to the discussion.
+        $discussion = $args['Counts'] + $args['Discussion'];
 
         // Bail out if this isn't a comment on a question.
         if (strtolower($discussion['Type']) !== 'question') {

--- a/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
+++ b/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
@@ -185,7 +185,7 @@ class CommentsAnswerTest extends AbstractAPIv2Test {
         $this->assertIsAnswer($response->getBody(), ['status' => 'pending']);
 
         $updatedQuestion = $this->getQuestion($question['discussionID']);
-        $this->assertIsQuestion($updatedQuestion, ['status' => 'unanswered']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'answered']);
     }
 
     /**


### PR DESCRIPTION
By fixing `recalculateDiscussionQnA()` in this [PR](https://github.com/vanilla/addons/pull/620/files#diff-b96a190297fb9e48f8391f75e7da42d3R564) we ended up finding that the discussion record doesn't contains the updated counts on it which makes `recalculateDiscussionQnA()` not assigning the proper `QnA` value in certain cases.