### PR TITLE
[Backport] Fix recalculateDiscussionQnA logic and use it where relevant

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -314,7 +314,8 @@ class QnAPlugin extends Gdn_Plugin {
      * @param array $args Event arguments.
      */
     public function commentModel_beforeUpdateCommentCount_handler($sender, $args) {
-        $discussion =& $args['Discussion'];
+        // Merge the updated counts to the discussion.
+        $discussion = $args['Counts'] + $args['Discussion'];
 
         // Bail out if this isn't a comment on a question.
         if (strtolower($discussion['Type']) !== 'question') {

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -321,15 +321,9 @@ class QnAPlugin extends Gdn_Plugin {
             return;
         }
 
-        // Mark the question as answered.
-        if (!empty($args['Insert']) && !$discussion['Sink'] && !in_array($discussion['QnA'], ['Answered', 'Accepted'])) {
-            $sender->SQL->set('QnA', 'Answered');
-        } elseif (!isset($args['Insert'])) {
-            // This is not an edit so recalculate the QnA value entirely.
-            $set = $this->recalculateDiscussionQnA($discussion, true);
-            if (!empty($set)) {
-                $sender->SQL->set($set);
-            }
+        // Recalculate the Question state.
+        if (!empty($args['Insert'])) {
+            $this->recalculateDiscussionQnA($discussion);
         }
     }
 
@@ -567,10 +561,10 @@ class QnAPlugin extends Gdn_Plugin {
             ['DiscussionID' => val('DiscussionID', $discussion), 'QnA is not null' => ''], 'QnA, DateAccepted', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
 
         if (!$row) {
-            if (val('CountComments', $discussion) > 0) {
-                $set['QnA'] = 'Unanswered';
-            } else {
+            if (val('CountComments', $discussion, 0) > 0) {
                 $set['QnA'] = 'Answered';
+            } else {
+                $set['QnA'] = 'Unanswered';
             }
 
             $set['DateAccepted'] = null;

--- a/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
+++ b/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
@@ -185,7 +185,7 @@ class CommentsAnswerTest extends AbstractAPIv2Test {
         $this->assertIsAnswer($response->getBody(), ['status' => 'pending']);
 
         $updatedQuestion = $this->getQuestion($question['discussionID']);
-        $this->assertIsQuestion($updatedQuestion, ['status' => 'unanswered']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'answered']);
     }
 
     /**


### PR DESCRIPTION
Backport #620 and #627 which fixed https://github.com/vanilla/addons/issues/616