### PR TITLE
Backport: Fix the Category as Link Addon so it works with Subcommunities.

### DIFF
--- a/plugins/categoryaslink/README.md
+++ b/plugins/categoryaslink/README.md
@@ -1,0 +1,31 @@
+# Category As Link
+
+Some Forum admins would like to be able to display what appears to be a Category in the list of Categories but that is, in fact, a link to another Category or even another page on another web property (e.g another forum, a knowledge base, a wiki, etc.).
+
+***This Plugin's priority is set to high because the categoryUrl() function has to execute before the categoryUrl() in the SubCommunities plugin.***
+
+### Category As Link
+
+- **Summary:** Allow admins to configure a Category so that it links to another URL instead of displaying a Category.
+- **Use case:** When a Forum wants to be able to direct users to another web property from the list of Categories on their Forum.
+- **Description:** 
+	- Add a column to the Category table to store the RedirectURL that a Category should link to instead of the Category page.
+	- Add an interface on the Category add/edit page in the dashboard to capture the URL.
+	- Add CSS classes to Categories that are being displayed as links ("Aliased AliasedCategory"), remove all the count data.
+	- Override the CategoryURL function to change the URL to the RedirectURL
+	- Redirect to the RedirectURL when someone requests the Category. 
+- **Configs set or added:** none
+- **Events used:**
+	- `addEditCategory`: Inject HTML interface to capture the RedirectURL of Category.
+	- `categoriesController_render_before`: Loop through Category Tree data and add CSS properties and remove the properties like Discussion Count and Comment Count when displaying link Categories.
+	- `beforeCategoriesRender`: If a requested Category has a RedirectUrl, redirect it with a 301 code.
+- **Setup steps:**
+    1. Turn on the plugin.
+    2. Either add or edit a Category.
+    3. Input a link to another Category or anothe site.
+    4. If you put a site from another domain, make sure to add it to Trusted Domains in the Security section of the Dashboard.
+- **QA steps:**
+    1. Follow the steps of Setup above.
+    2. Navigate to a linked Category and click on it.
+    3. Link to other domains, make sure that the Trusted Domains is working.
+    4. Try to request a linked Category directly to make sure you are sent to the RedirectURL.

--- a/plugins/categoryaslink/addon.json
+++ b/plugins/categoryaslink/addon.json
@@ -4,6 +4,7 @@
     "version": "1.0",
     "key": "categoryaslink",
     "type": "addon",
+    "priority": 1000,
     "authors": [
         {
             "name": "Patrick Kelly",

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -122,9 +122,8 @@ if (!function_exists("categoryUrl")) {
             return safeURL(val('RedirectUrl', $category));
         }
 
-        // Build URL.
+        // SEOLinks version.
         if (class_exists('SEOLinksPlugin')) {
-            // SEOLinks version
             if (!isset($px)) {
                 $px = SEOLinksPlugin::Prefix();
             }
@@ -132,12 +131,19 @@ if (!function_exists("categoryUrl")) {
             if ($page && $page > 1) {
                 $result .= 'p' . $page . '/';
             }
-        } else {
-            // Normal version
-            $result = '/categories/'.rawurlencode($category['UrlCode']);
-            if ($page && $page > 1) {
-                $result .= '/p'.$page;
-            }
+            return $result;
+        }
+
+        // Subcommunities version.
+        if (class_exists('SubcommunitiesPlugin')) {
+            $path = '/categories/'.rawurlencode(val('UrlCode', $category));
+            return SubcommunitiesPlugin::subcommunityURL(val('categoryID', $category), $path, $withDomain, $page);
+        }
+
+        // Normal version.
+        $result = '/categories/'.rawurlencode($category['UrlCode']);
+        if ($page && $page > 1) {
+            $result .= '/p'.$page;
         }
 
         return url($result, $withDomain);

--- a/plugins/categoryaslink/class.categoryaslink.plugin.php
+++ b/plugins/categoryaslink/class.categoryaslink.plugin.php
@@ -122,8 +122,13 @@ if (!function_exists("categoryUrl")) {
             return safeURL(val('RedirectUrl', $category));
         }
 
-        // SEOLinks version.
-        if (class_exists('SEOLinksPlugin')) {
+        $categoryURL = '';
+        if (class_exists('SubcommunitiesPlugin')) {
+            // Subcommunities version.
+            $path = '/categories/'.rawurlencode(val('UrlCode', $category));
+            $categoryURL = SubcommunitiesPlugin::subcommunityURL(val('categoryID', $category), $path, $withDomain, $page);
+        } elseif (class_exists('SEOLinksPlugin')) {
+            // SEOLinks version.
             if (!isset($px)) {
                 $px = SEOLinksPlugin::Prefix();
             }
@@ -131,21 +136,15 @@ if (!function_exists("categoryUrl")) {
             if ($page && $page > 1) {
                 $result .= 'p' . $page . '/';
             }
-            return $result;
+            $categoryURL = url($result, $withDomain);
+        } else {
+            // Normal version.
+            $result = '/categories/'.rawurlencode($category['UrlCode']);
+            if ($page && $page > 1) {
+                $result .= '/p'.$page;
+            }
+            $categoryURL = url($result, $withDomain);
         }
-
-        // Subcommunities version.
-        if (class_exists('SubcommunitiesPlugin')) {
-            $path = '/categories/'.rawurlencode(val('UrlCode', $category));
-            return SubcommunitiesPlugin::subcommunityURL(val('categoryID', $category), $path, $withDomain, $page);
-        }
-
-        // Normal version.
-        $result = '/categories/'.rawurlencode($category['UrlCode']);
-        if ($page && $page > 1) {
-            $result .= '/p'.$page;
-        }
-
-        return url($result, $withDomain);
+        return $categoryURL;
     }
 }


### PR DESCRIPTION
Backport PR #639 

This PR fixes the fact that the Category as Link plugin doesn't work when subcommunities are turned on by doing two things:

Making the Category as Link fire first (changing the priority)
Using the Subcommunities way of constructing the URL if Subcommunities are turned on.