### PR TITLE
Fix recalculation of discussions QnA state

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -554,8 +554,9 @@ class QnAPlugin extends Gdn_Plugin {
         $set = [];
 
         // Look for at least one accepted answer/comment.
-        $acceptedComment = Gdn::sql()->getWhere('Comment',
-            ['DiscussionID' => val('DiscussionID', $discussion), 'QnA' => 'Accepted'], '', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
+        $acceptedComment = Gdn::sql()->getWhere(
+            'Comment', ['DiscussionID' => val('DiscussionID', $discussion), 'QnA' => 'Accepted'], '', 'asc', 1
+        )->firstRow(DATASET_TYPE_ARRAY);
 
         if ($acceptedComment) {
             $set['QnA'] = 'Accepted';
@@ -563,16 +564,18 @@ class QnAPlugin extends Gdn_Plugin {
             $set['DateOfAnswer'] = $acceptedComment['DateInserted'];
         } else {
             // Look for at least one untreated answer/comment.
-            $answeredCommment = Gdn::sql()->getWhere('Comment',
-                ['DiscussionID' => val('DiscussionID', $discussion), 'QnA is null' => ''], '', 'asc', 1)->firstRow(DATASET_TYPE_ARRAY);
-            if ($answeredCommment) {
+            $answeredComment = Gdn::sql()->getWhere(
+                'Comment', ['DiscussionID' => val('DiscussionID', $discussion), 'QnA is null' => ''], '', 'asc', 1
+            )->firstRow(DATASET_TYPE_ARRAY);
+
+            $countComments = val('CountComments', $discussion, 0);
+
+            if ($answeredComment) {
                 $set['QnA'] = 'Answered';
                 $set['DateAccepted'] = null;
-                $set['DateOfAnswer'] = null;
-            } else if (val('CountComments', $discussion, 0) > 0) {
+            } else if ($countComments > 0) {
                 $set['QnA'] = 'Rejected';
                 $set['DateAccepted'] = null;
-                $set['DateOfAnswer'] = null;
             } else {
                 $set['QnA'] = 'Unanswered';
                 $set['DateAccepted'] = null;

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -576,6 +576,7 @@ class QnAPlugin extends Gdn_Plugin {
             } else if ($countComments > 0) {
                 $set['QnA'] = 'Rejected';
                 $set['DateAccepted'] = null;
+                $set['DateOfAnswer'] = null;
             } else {
                 $set['QnA'] = 'Unanswered';
                 $set['DateAccepted'] = null;

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -449,12 +449,7 @@ class QnAPlugin extends Gdn_Plugin {
             Gdn::sql()->put('Comment', $CommentSet, ['CommentID' => $comment['CommentID']]);
 
             // Update the discussion.
-            if ($discussion['QnA'] != $qna && (!$discussion['QnA'] || in_array($discussion['QnA'], ['Unanswered', 'Answered', 'Rejected']))) {
-                Gdn::sql()->put(
-                    'Discussion',
-                    $discussionSet,
-                    ['DiscussionID' => $comment['DiscussionID']]);
-            }
+           $this->recalculateDiscussionQnA($discussion);
 
             // Determine QnA change
             if ($comment['QnA'] != $qna) {


### PR DESCRIPTION
Closes https://github.com/vanilla/addons/issues/643.

Refactored the `recalculateDiscussionQnA()` function based on the logic established in https://github.com/vanilla/addons/issues/643.

Also, removed the faulty separate logic to set the discussion's QnA state when an answer is treated as helpful or not, now using the refactored `recalculateDiscussionQnA()`. The discussion state is now being set to the correct state regardless of how many answers remain to be treated.