### PR TITLE
Fix broken SSO in Steam Connect

### DIFF
--- a/plugins/SteamConnect/README.md
+++ b/plugins/SteamConnect/README.md
@@ -2,5 +2,7 @@
 
 Allow users to sign in with their Steam Account.
 
+https://steamcommunity.com/dev
+
 ---
 Copyright &copy; 2014 [Becky Van Bussel](http://vanillaforums.com).

--- a/plugins/SteamConnect/class.steamconnect.plugin.php
+++ b/plugins/SteamConnect/class.steamconnect.plugin.php
@@ -12,37 +12,49 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * This will run when you "Enable" the plugin
      *
-     * @since  1.0.0
-     * @access public
      * @return bool
      */
     public function setup() {
 
     }
 
+    /**
+     * Check whether this addon has enough configuration to work.
+     *
+     * @return mixed
+     */
     public function isConfig() {
         return c('Plugins.SteamConnect.APIKey', FALSE);
     }
 
+    /**
+     * Retrieve the URL to start an auth request.
+     *
+     * @param bool $popup
+     * @return string
+     */
     protected function _AuthorizeHref($popup = FALSE) {
         $url = url('/entry/openid', TRUE);
         $urlParts = explode('?', $url);
         parse_str(getValue(1, $urlParts, ''), $query);
-        $query['url'] = 'http://steamcommunity.com/openid';
+        $query['url'] = 'https://steamcommunity.com/openid';
         $path = '/'.Gdn::request()->path();
         $query['Target'] = getValue('Target', $_GET, $path ? $path : '/');
-        if ($popup)
+        if ($popup) {
             $query['display'] = 'popup';
+        }
 
         $result = $urlParts[0].'?'.http_build_query($query);
         return $result;
     }
 
-
-    /// Plugin Event Handlers ///
-
+    /**
+     * Add Steam as an option to the normal signin page.
+     *
+     * @param $sender
+     * @param $args
+     */
     public function entryController_signIn_handler($sender, $args) {
-
         if (isset($sender->Data['Methods']) && $this->isConfig()) {
             $url = $this->_AuthorizeHref();
 
@@ -56,22 +68,44 @@ class SteamConnectPlugin extends Gdn_Plugin {
         }
     }
 
+    /**
+     * Add Steam-Connect button to MeModule
+     *
+     * @param Gdn_Controller $sender
+     * @param array $args
+     */
     public function base_signInIcons_handler($sender, $args) {
         if ($this->isConfig()) {
             echo "\n".$this->_GetButton();
         }
     }
 
+    /**
+     * Inject a sign-in icon into the ME menu.
+     *
+     * @param Gdn_Controller $sender.
+     * @param Gdn_Controller $args.
+     */
     public function base_beforeSignInButton_handler($sender, $args) {
         if ($this->isConfig()) {
             echo "\n".$this->_GetButton();
         }
     }
 
+    /**
+     * Insert css file for custom styling of signin button/icon.
+     *
+     * @param AssetModel $sender
+     */
     public function assetModel_styleCss_handler($sender) {
         $sender->addCssFile('steam-connect.css', 'plugins/SteamConnect');
     }
 
+    /**
+     * Build-A-Button.
+     *
+     * @return string
+     */
     private function _GetButton() {
         if ($this->isConfig()) {
             $url = $this->_AuthorizeHref();
@@ -79,14 +113,24 @@ class SteamConnectPlugin extends Gdn_Plugin {
         }
     }
 
+    /**
+     * Add Steam-Connect button to default mobile theme.
+     *
+     * @param $sender
+     */
     public function base_beforeSignInLink_handler($sender) {
         if (!Gdn::session()->isValid() && $this->isConfig()) {
             echo "\n".wrap($this->_GetButton(), 'li', ['class' => 'Connect SteamConnect']);
         }
     }
 
+    /**
+     * Capture the user's UniqueID being sent back from provider and saving it to the session.
+     *
+     * @param $sender
+     * @param $args
+     */
     public function openIDPlugin_afterConnectData_handler($sender, $args) {
-
         $form = $args['Form'];
         $openID = $args['OpenID'];
         $steamID = $this->getSteamID($openID);
@@ -121,18 +165,29 @@ class SteamConnectPlugin extends Gdn_Plugin {
         }
     }
 
+    /**
+     * Get steam id
+     *
+     * @param $openID
+     * @return mixed
+     */
     public function getSteamID($openID) {
-        $ptn = "/^http:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";
+        $ptn = "/^https?:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";
         preg_match($ptn, $openID->identity, $matches);
         return $matches[1];
     }
 
+    /**
+     * Steam connect settings page.
+     *
+     * @param SettingsControler $sender
+     */
     public function settingsController_steamConnect_create($sender) {
         $sender->permission('Garden.Settings.Manage');
 
         $aPIKeyDescription =  '<div class="info">'.sprintf(t('A %s is necessary for this plugin to work.'), t('Steam Web API Key')).' '
             .sprintf(t('Don\'t have a %s?'), t('Steam Web API Key'))
-            .' <a href="http://steamcommunity.com/dev/apikey">'.t('Get one here.').'</a></div>';
+            .' <a href="https://steamcommunity.com/dev/apikey">'.t('Get one here.').'</a></div>';
 
         $conf = new ConfigurationModule($sender);
         $conf->initialize([

--- a/plugins/SteamConnect/class.steamconnect.plugin.php
+++ b/plugins/SteamConnect/class.steamconnect.plugin.php
@@ -168,7 +168,7 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Get steam id
      *
-     * @param  array $openID
+     * @param object $openID
      * @return string|null
      */
     public function getSteamID($openID) {

--- a/plugins/SteamConnect/class.steamconnect.plugin.php
+++ b/plugins/SteamConnect/class.steamconnect.plugin.php
@@ -51,8 +51,8 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Add Steam as an option to the normal signin page.
      *
-     * @param $sender
-     * @param $args
+     * @param EntryController $sender
+     * @param array $args
      */
     public function entryController_signIn_handler($sender, $args) {
         if (isset($sender->Data['Methods']) && $this->isConfig()) {
@@ -71,7 +71,7 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Add Steam-Connect button to MeModule
      *
-     * @param Gdn_Controller $sender
+     * @param MeModule $sender
      * @param array $args
      */
     public function base_signInIcons_handler($sender, $args) {
@@ -84,7 +84,7 @@ class SteamConnectPlugin extends Gdn_Plugin {
      * Inject a sign-in icon into the ME menu.
      *
      * @param Gdn_Controller $sender.
-     * @param Gdn_Controller $args.
+     * @param array $args.
      */
     public function base_beforeSignInButton_handler($sender, $args) {
         if ($this->isConfig()) {
@@ -104,7 +104,7 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Build-A-Button.
      *
-     * @return string
+     * @return string|null
      */
     private function _GetButton() {
         if ($this->isConfig()) {
@@ -116,7 +116,7 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Add Steam-Connect button to default mobile theme.
      *
-     * @param $sender
+     * @param DiscussionsController $sender
      */
     public function base_beforeSignInLink_handler($sender) {
         if (!Gdn::session()->isValid() && $this->isConfig()) {
@@ -127,8 +127,8 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Capture the user's UniqueID being sent back from provider and saving it to the session.
      *
-     * @param $sender
-     * @param $args
+     * @param OpenIDPlugin $sender
+     * @param array $args
      */
     public function openIDPlugin_afterConnectData_handler($sender, $args) {
         $form = $args['Form'];
@@ -168,8 +168,8 @@ class SteamConnectPlugin extends Gdn_Plugin {
     /**
      * Get steam id
      *
-     * @param $openID
-     * @return mixed
+     * @param  array $openID
+     * @return string|null
      */
     public function getSteamID($openID) {
         $ptn = "/^https?:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";


### PR DESCRIPTION
closes #647 

The error "uniqueID is required" was because we were trying to match `http://steamcommunity.com/.. `with the received` https://steamcommunity.com/.. `

[class.steamconnect.plugin.php#L125](https://github.com/vanilla/addons/blob/master/plugins/SteamConnect/class.steamconnect.plugin.php#L125 )