### PR TITLE
Add test to cover questions after an answer has been rejected

### DIFF
--- a/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
+++ b/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
@@ -211,4 +211,43 @@ class CommentsAnswerTest extends AbstractAPIv2Test {
         $updatedQuestion = $this->getQuestion($question['discussionID']);
         $this->assertIsQuestion($updatedQuestion, ['status' => 'rejected']);
     }
+
+    /**
+     * Test rejecting an answer and then resubmitting an answer.
+     *
+     * @depends testPostAnswer
+     */
+    public function testResetRejectedQuestionStatus() {
+        $question = $this->createQuestion();
+        $answer = $this->testPostAnswer($question['discussionID']);
+
+        $response = $this->api()->patch('comments/answer/'.$answer['commentID'], [
+            'status' => 'rejected',
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $updatedQuestion = $this->getQuestion($question['discussionID']);
+        $this->assertIsQuestion($updatedQuestion, ['status' => 'rejected']);
+
+        $answerAgain = $this->testPostAnswer($question['discussionID']);
+        $commentID = $answerAgain['commentID'];
+
+        $response = $this->api()->get("comments/{$commentID}");
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = $response->getBody();
+        $this->assertIsAnswer($body, ['status' => 'pending']);
+
+        $answeredQuestion = $this->getQuestion($question['discussionID']);
+        $this->assertIsQuestion($answeredQuestion, ['status' => 'answered']);
+    }
+
+    /**
+     * Test that question created has a status of unanswered
+     *
+     * @depends testPostAnswer
+     */
+    public function testUnansweredQuestion() {
+        $question = $this->createQuestion();
+        $this->assertIsQuestion($question, ['status' => 'unanswered']);
+    }
 }

--- a/plugins/QnA/tests/APIv2/DiscussionsQuestionTest.php
+++ b/plugins/QnA/tests/APIv2/DiscussionsQuestionTest.php
@@ -75,6 +75,7 @@ class DiscussionsQuestionTest extends AbstractAPIv2Test {
 
         $body = $response->getBody();
         $this->assertEquals('question', $body['type']);
+        $this->assertIsQuestion($body, ['status' => 'unanswered']);
 
         $this->assertTrue(is_int($body['discussionID']));
         $this->assertTrue($body['discussionID'] > 0);
@@ -110,4 +111,5 @@ class DiscussionsQuestionTest extends AbstractAPIv2Test {
             $this->assertIsQuestion($question);
         }
     }
+
 }


### PR DESCRIPTION
This test that after a question has an rejected answer then another answer is posted that the question's status will be **answered**.  An additional test to verify that the status of a posted question 
is **unanswered**.  Tests to validate the date accepted and date answered fields were also added

Closed #646


