### PR TITLE
Qna: Accepting answer results in external link warning

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -525,7 +525,7 @@ class QnAPlugin extends Gdn_Plugin {
                 $this->fireEvent('AfterAccepted');
             }
         }
-        redirectTo("/discussion/comment/{$comment['CommentID']}#Comment_{$comment['CommentID']}");
+        redirectTo("/discussion/comment/{$comment['CommentID']}#Comment_{$comment['CommentID']}", 302, false);
     }
 
     /**


### PR DESCRIPTION
closes [#652](https://github.com/vanilla/addons/issues/652)

### Details

When a discussion is changed to type Question, accepting an answer results in an external link warning.

### To replicate

- Change any discussion type to QnA
- Accept an answer