### PR TITLE
Add cache options to SQL driver to cache getProviders query response 

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -207,13 +207,19 @@ class JsConnectPlugin extends Gdn_Plugin {
      * @return array|mixed
      */
     public static function getProvider($client_id = null) {
+        $sqlCacheKey = 'getProvider:';
         if ($client_id !== null) {
+            $sqlCacheKey .= 'AuthenticationKey:'.$client_id;
             $where = ['AuthenticationKey' => $client_id];
         } else {
+            $sqlCacheKey .= 'AuthenticationSchemeAlias:jsconnect';
             $where = ['AuthenticationSchemeAlias' => 'jsconnect'];
         }
 
-        $result = Gdn::sql()->getWhere('UserAuthenticationProvider', $where)->resultArray();
+        $sql = Gdn::sql();
+        $sql->cache($sqlCacheKey, null, [Gdn_Cache::FEATURE_EXPIRY => 900]);
+        $result = $sql->getWhere('UserAuthenticationProvider', $where)->resultArray();
+
         foreach ($result as &$row) {
             $attributes = dbdecode($row['Attributes']);
             if (is_array($attributes)) {

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -690,8 +690,6 @@ class JsConnectPlugin extends Gdn_Plugin {
 
         $client_id = $sender->Request->get('client_id');
 
-        Gdn::cache()->remove(self::getProviderSqlCacheKey($client_id));
-
         Gdn::locale()->setTranslation('AuthenticationKey', 'Client ID');
         Gdn::locale()->setTranslation('AssociationSecret', 'Secret');
         Gdn::locale()->setTranslation('AuthenticateUrl', 'Authentication Url');
@@ -717,6 +715,7 @@ class JsConnectPlugin extends Gdn_Plugin {
                 $form->setFormValue('AuthenticationSchemeAlias', 'jsconnect');
 
                 if ($form->save(['ID' => $client_id])) {
+                    Gdn::cache()->remove(self::getProviderSqlCacheKey($client_id));
                     $sender->setRedirectTo('/settings/jsconnect');
                 }
             }


### PR DESCRIPTION
Add cache options to SQL driver to cache getProviders query response for 15 min.
That allows app to avoid unnecessary DB connection to be initialized in some cases.

I've discussed this patch with @DaazKu. 
His opinion - we should provide wider solution with some global scope but not only apply to jsconnect plugin.


Fixes: https://github.com/vanilla/vanilla-patches/issues/387