### PR TITLE
User option to disable/enable QnA notifications

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1385,9 +1385,9 @@ class QnAPlugin extends Gdn_Plugin {
      * @param ProfileController $sender
      */
     public function profileController_afterPreferencesDefined_handler($sender) {
-        $sender->Preferences['Notifications']['Email.AnswerAccepted'] = t('Notify me when people accept my answer');
-        $sender->Preferences['Notifications']['Popup.AnswerAccepted'] = t('Notify me when people accept my answer');
-        $sender->Preferences['Notifications']['Email.QuestionAnswered'] = t('Notify me when people answer my question');
-        $sender->Preferences['Notifications']['Popup.QuestionAnswered'] = t('Notify me when people answer my question');
+        $sender->Preferences['Notifications']['Email.AnswerAccepted'] = t('Notify me when people accept my answer.');
+        $sender->Preferences['Notifications']['Popup.AnswerAccepted'] = t('Notify me when people accept my answer.');
+        $sender->Preferences['Notifications']['Email.QuestionAnswered'] = t('Notify me when people answer my question.');
+        $sender->Preferences['Notifications']['Popup.QuestionAnswered'] = t('Notify me when people answer my question.');
     }
 }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -304,7 +304,7 @@ class QnAPlugin extends Gdn_Plugin {
             ]
         ];
 
-        $activityModel->queue($activity,'QuestionAnswered');
+        $activityModel->queue($activity, 'QuestionAnswered');
         $activityModel->saveQueue();
     }
 
@@ -1385,9 +1385,9 @@ class QnAPlugin extends Gdn_Plugin {
      * @param ProfileController $sender
      */
     public function profileController_afterPreferencesDefined_handler($sender) {
-        $sender->Preferences['Notifications']['Email.AnswerAccepted'] = t( 'Notify me when people accept my answer');
-        $sender->Preferences['Notifications']['Popup.AnswerAccepted'] = t( 'Notify me when people accept my answer');
-        $sender->Preferences['Notifications']['Email.QuestionAnswered'] = t( 'Notify me when people answer my question');
-        $sender->Preferences['Notifications']['Popup.QuestionAnswered'] = t( 'Notify me when people answer my question');
+        $sender->Preferences['Notifications']['Email.AnswerAccepted'] = t('Notify me when people accept my answer');
+        $sender->Preferences['Notifications']['Popup.AnswerAccepted'] = t('Notify me when people accept my answer');
+        $sender->Preferences['Notifications']['Email.QuestionAnswered'] = t('Notify me when people answer my question');
+        $sender->Preferences['Notifications']['Popup.QuestionAnswered'] = t('Notify me when people answer my question');
     }
 }


### PR DESCRIPTION
Closes [#3](https://github.com/vanilla/support/issues/3)

**What Changed**

I added notification preferences for QnA when:

- A question is answered 
- An answer is accepted
