### PR TITLE
Add question states recalculation to dba/counts

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1381,6 +1381,7 @@ class QnAPlugin extends Gdn_Plugin {
 
     /**
      * Add option to dba/counts to recalculate QnA state of discussions(questions).
+     * 
      * @param DBAController $sender
      */
     public function dbaController_countJobs_handler($sender) {

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1378,4 +1378,11 @@ class QnAPlugin extends Gdn_Plugin {
         $types[] = 'question';
         $schema->setField('properties.type.enum', $types);
     }
+
+    public function dbaController_countJobs_handler($sender) {
+        $name = "Recalculate Discussion.QnA";
+        // We name the table QnA and not Discussion because the model is instantiated from the table name in DBAModel.
+        $url = "/dba/counts.json?".http_build_query(['table' => 'QnA', 'column' => 'QnA']);
+        $sender->Data['Jobs'][$name] = $url;
+    }
 }

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -12,7 +12,7 @@ class QnaModel extends Gdn_Model {
     public function counts($column) {
         $result = ['Complete' => true];
 
-        switch($column) {
+        switch ($column) {
             // Discussion table, QnA column will be updated.
             case 'QnA':
                 $request = Gdn::request()->get();
@@ -105,13 +105,13 @@ class QnaModel extends Gdn_Model {
 
         $currentBatch = array_column($currentBatch, 'DiscussionID', 'DiscussionID');
 
-        $latestID = key(array_slice($currentBatch,-1,1,TRUE));
+        $latestID = key(array_slice($currentBatch, -1, 1, true));
 
         $this->recalculateDiscussionsQnA($currentBatch);
 
         $numberOfBatchesDone++;
 
-        if ($totalBatches == $numberOfBatchesDone) {
+        if ($totalBatches === $numberOfBatchesDone) {
             return ['Complete' => true];
         }
 

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -1,10 +1,5 @@
 <?php
 /**
- * @copyright 2009-2018 Vanilla Forums Inc.
- * @license Proprietary
- */
-
-/**
  * Class QnaModel
  */
 class QnaModel extends Gdn_Model {

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -111,7 +111,7 @@ class QnaModel extends Gdn_Model {
 
         $numberOfBatchesDone++;
 
-        if ($totalBatches === $numberOfBatchesDone) {
+        if ($totalBatches == $numberOfBatchesDone) {
             return ['Complete' => true];
         }
 

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+/**
+ * Class QnaModel
+ */
+class QnaModel extends Gdn_Model {
+    /**
+     * Update Q&A counts through the dba/counts endpoint.
+     *
+     * @param string $column
+     * @return array $results Formatted to match what "dba.js" expects
+     */
+    public function counts($column) {
+        $result = ['Complete' => true];
+
+        switch($column) {
+            // Discussion table, QnA column will be updated.
+            case 'QnA':
+                $request = Gdn::request()->get();
+                $result = $this->recalculateDiscussionQnABatches($request['NumberOfBatchesDone'] ?? 0, $request['LatestID'] ?? 0);
+            break;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Recalculate the QnA state of discussions.
+     * There is 4 possible QnA states for questions, Unanswered, Answered, Rejected and Accepted.
+     * There is 3 possible QnA states for comments, Accepted, Rejected and NULL (Untreated).
+     *
+     * @param array $discussionIDs discussions to be recalculated
+     * @throws Exception | Being thrown from the put method of the sql object
+     */
+    private function recalculateDiscussionsQnA($discussionIDs) {
+        // Updating questions with accepted answers.
+        Gdn::sql()
+            ->update('Discussion d')
+            ->join('Comment c', 'c.DiscussionID = d.DiscussionID and c.QnA = \'Accepted\'')
+            ->set('d.QnA', 'Accepted')
+            ->whereIn('d.DiscussionID', $discussionIDs)
+            ->put();
+
+        // Updating questions with no answers.
+        Gdn::sql()
+            ->update('Discussion d')
+            ->leftJoin('Comment c', 'c.DiscussionID = d.DiscussionID')
+            ->set('d.QnA', 'Unanswered')
+            ->where(['c.CommentID is null' => ''])
+            ->whereIn('d.DiscussionID', $discussionIDs)
+            ->put();
+
+        // Updating questions with untreated answers but no accepted answer.
+        Gdn::sql()
+            ->update('Discussion d')
+            ->join('Comment c', 'c.DiscussionID = d.DiscussionID and c.QnA is null')
+            ->leftJoin('Comment c1', 'c1.DiscussionID = d.DiscussionID and c1.QnA = \'Accepted\'')
+            ->set('d.QnA', 'Answered')
+            ->where(['c1.CommentID is null' => ''])
+            ->whereIn('d.DiscussionID', $discussionIDs)
+            ->put();
+
+        // Updating questions with ONLY rejected answers.
+        Gdn::sql()
+            ->update('Discussion d')
+            ->join('Comment c', 'c.DiscussionID = d.DiscussionID and c.QnA = \'Rejected\'')
+            ->leftJoin('Comment c1', 'c1.DiscussionID = d.DiscussionID and (c1.QnA = \'Accepted\' OR c1.QnA is null)')
+            ->set('d.QnA', 'Rejected')
+            ->where(['c1.CommentID is null' => ''])
+            ->whereIn('d.DiscussionID', $discussionIDs)
+            ->put();
+    }
+
+    /**
+     * Preparing batches of discussions (questions) and triggering recalculation of their QnA state.
+     * Updating records in batches of 1000 to make sure we don't lock the table for too long.
+     *
+     * @param integer $numberOfBatchesDone number of batches already processed
+     * @param integer $latestID latest discussionID we treated
+     * @return array current state of QnA recalculation. Formatted to match what "dba.js" expects
+     */
+    private function recalculateDiscussionQnABatches($numberOfBatchesDone, $latestID) {
+        $perBatch = 1000;
+
+        // Get min and max discussionID for questions
+        $result = Gdn::sql()
+            ->select('DiscussionID', 'max', 'MaxValue')
+            ->select('DiscussionID', 'min', 'MinValue')
+            ->from('Discussion')
+            ->where(['Type' => 'Question'])
+            ->get()->firstRow(DATASET_TYPE_ARRAY);
+
+        $totalBatches = ceil(($result['MaxValue'] - $result['MinValue']) / $perBatch);
+
+        $currentBatch = Gdn::sql()
+            ->select('DiscussionID')
+            ->from('Discussion')
+            ->where([
+                'DiscussionID >' => $latestID,
+                'Type' => 'Question',
+            ])
+            ->orderBy('DiscussionID')
+            ->limit($perBatch)
+            ->get()
+            ->resultArray();
+
+        $currentBatch = array_column($currentBatch, 'DiscussionID', 'DiscussionID');
+
+        $latestID = key(array_slice($currentBatch,-1,1,TRUE));
+
+        $this->recalculateDiscussionsQnA($currentBatch);
+
+        $numberOfBatchesDone++;
+
+        if ($totalBatches == $numberOfBatchesDone) {
+            return ['Complete' => true];
+        }
+
+        return [
+            'Percent' => round($numberOfBatchesDone / $totalBatches * 100) . '%',
+            'Args' => [
+                'NumberOfBatchesDone' => $numberOfBatchesDone,
+                'LatestID' => $latestID,
+            ],
+        ];
+    }
+}

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -17,7 +17,7 @@ class QnaModel extends Gdn_Model {
             case 'QnA':
                 $request = Gdn::request()->get();
                 $result = $this->recalculateDiscussionQnABatches($request['NumberOfBatchesDone'] ?? 0, $request['LatestID'] ?? 0);
-            break;
+                break;
         }
 
         return $result;


### PR DESCRIPTION
The goal here was to add an option to recalculate the current QnA state of all questions through the `dba/counts` endpoint.

Relevant information on the PR
---
* Recalculation happens in batches of 1000 questions at a time to prevent locking the table for too long.
* There is no "capping" on how many questions you can update. (Should we add one?)
* I tried optimizing queries as much as possible, as an example 100,000 questions with 200,000 answers take about 2 minutes to fully update on my local.
* On the UI you can see a "progress" in percentage to preventing feeling like the job is stuck.
* You can refer to the `recalculateDiscussionsQnA()` method to see the logic I used to update the records.
