### PR TITLE
Add threshold to QnA recalculation through dba/counts

### DIFF
--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -81,6 +81,14 @@ class QnaModel extends Gdn_Model {
     private function recalculateDiscussionQnABatches($numberOfBatchesDone, $latestID) {
         $perBatch = 1000;
 
+
+        // Make sure we don't kill a database.
+        $count = Gdn::sql()->getCount('Discussion', ['Type' => 'Question']);
+        $threshold = c('Database.AlterTableThreshold', 250000);
+        if ($count > $threshold)  {
+            return ['Error' => 'Amount of questions is exceeding the database threshold of '.$threshold.'.'];
+        }
+
         // Get min and max discussionID for questions
         $result = Gdn::sql()
             ->select('DiscussionID', 'max', 'MaxValue')

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -86,7 +86,7 @@ class QnaModel extends Gdn_Model {
         $count = Gdn::sql()->getCount('Discussion', ['Type' => 'Question']);
         $threshold = c('Database.AlterTableThreshold', 250000);
         if ($count > $threshold)  {
-            return ['Error' => 'Amount of questions is exceeding the database threshold of '.$threshold.'.'];
+            throw new Exception('Amount of questions is exceeding the database threshold of '.$threshold.'.');
         }
 
         // Get min and max discussionID for questions

--- a/plugins/QnA/models/class.qnamodel.php
+++ b/plugins/QnA/models/class.qnamodel.php
@@ -81,7 +81,6 @@ class QnaModel extends Gdn_Model {
     private function recalculateDiscussionQnABatches($numberOfBatchesDone, $latestID) {
         $perBatch = 1000;
 
-
         // Make sure we don't kill a database.
         $count = Gdn::sql()->getCount('Discussion', ['Type' => 'Question']);
         $threshold = c('Database.AlterTableThreshold', 250000);


### PR DESCRIPTION
Add a check to the alter table threshold config setting on the Discussion.QnA recalculation. Simply a database safety measure.