### PR TITLE
QnA: add functionality to have notifications enabled by default

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -89,6 +89,12 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function structure() {
         include __DIR__.'/structure.php';
+        touchConfig([
+            'Preferences.Email.AnswerAccepted' => 1,
+            'Preferences.Popup.AnswerAccepted' => 1,
+            'Preferences.Email.QuestionAnswered' => 1,
+            'Preferences.Popup.QuestionAnswered' => 1
+        ]);
     }
 
     /**


### PR DESCRIPTION
closes [#667](https://github.com/vanilla/addons/issues/667)

Details in the referenced issue.

### To Test

- Run utility/update.
- Register a new user.
- New user should have notifications enabled by default.

![screen shot 2018-11-15 at 11 40 46 am](https://user-images.githubusercontent.com/31856281/48567575-506b1400-e8cb-11e8-9c6a-7c8a0217919f.png)


