### PR TITLE
Replace deprecated touchConfig usage

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -67,9 +67,9 @@ class QnAPlugin extends Gdn_Plugin {
     public function setup() {
         $this->structure();
 
-        touchConfig('QnA.Points.Enabled', false);
-        touchConfig('QnA.Points.Answer', 1);
-        touchConfig('QnA.Points.AcceptedAnswer', 1);
+        \Gdn::config()->touch('QnA.Points.Enabled', false);
+        \Gdn::config()->touch('QnA.Points.Answer', 1);
+        \Gdn::config()->touch('QnA.Points.AcceptedAnswer', 1);
     }
 
     /**
@@ -89,7 +89,7 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function structure() {
         include __DIR__.'/structure.php';
-        touchConfig([
+        \Gdn::config()->touch([
             'Preferences.Email.AnswerAccepted' => 1,
             'Preferences.Popup.AnswerAccepted' => 1,
             'Preferences.Email.QuestionAnswered' => 1,
@@ -1387,7 +1387,7 @@ class QnAPlugin extends Gdn_Plugin {
 
     /**
      * Add option to dba/counts to recalculate QnA state of discussions(questions).
-     * 
+     *
      * @param DBAController $sender
      */
     public function dbaController_countJobs_handler($sender) {


### PR DESCRIPTION
Following https://github.com/vanilla/vanilla/pull/7960 the global `touchConfig` method is deprecated.

PR replacing usages in core: https://github.com/vanilla/vanilla/pull/8203

This PR updates `touchConfig` usage to be `Gdn::config()->touch()` instead.