### PR TITLE
ShareThisPlugin - Remove hidden Attribute from LinkedIn Button

### DIFF
--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -33,12 +33,12 @@ class ShareThisPlugin extends Gdn_Plugin {
       <div class="ShareThisButtonWrapper Right">
          <span class="st_twitter_hcount ShareThisButton" st_via="{$viaHandle}" displayText="Tweet"></span>
          <span class="st_facebook_hcount ShareThisButton" displayText="Facebook"></span>
-         <span class="st_linkedin_hcount ShareThisButton Hidden" displayText="LinkedIn"></span>
+         <span class="st_linkedin_hcount ShareThisButton " displayText="LinkedIn"></span>
          <span class="st_googleplus_hcount ShareThisButton Hidden" displayText="Google +"></span>
          <span class="st_reddit_hcount ShareThisButton Hidden" displayText="Reddit"></span>
          <span class="st_pinterest_hcount ShareThisButton Hidden" displayText="Pinterest"></span>
          <span class="st_email_hcount ShareThisButton" displayText="Email"></span>
-         <span class="st_sharethis_hcountShareThisButton" displayText="ShareThis"></span>
+         <span class="st_sharethis_hcount ShareThisButton Hidden" displayText="ShareThis"></span>
       </div>
 SHARETHIS;
 


### PR DESCRIPTION
Currently the Linked button is being hidden from the ShareThis bar.  This a patch, ShareThis is deprecating their old implementation, and vanilla will no longer support the integration.

Closes vanilla/support#120