### PR TITLE
Replace broken MathJax CDN. Update to MathJax version 2.7.5

### DIFF
--- a/plugins/MathJax/addon.json
+++ b/plugins/MathJax/addon.json
@@ -1,6 +1,6 @@
 {
     "description": "This plugin enables MathJax syntax in discussions and comments.",
-    "version": "1.1",
+    "version": "1.2",
     "mobileFriendly": true,
     "key": "mathjax",
     "type": "addon",
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "vanilla": ">=2.1"
+        "vanilla": ">=2.6"
     },
 	"icon": "mathjax.png"
 }

--- a/plugins/MathJax/class.mathjax.plugin.php
+++ b/plugins/MathJax/class.mathjax.plugin.php
@@ -50,8 +50,7 @@ class MathJaxPlugin extends Gdn_Plugin {
 </script>
 MATHJAX;
         $sender->Head->addString($mathJaxConfig);
-
-        $sender->addJsFile("https://cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?delayStartupUntil=onload");
+        $sender->addJsFile("https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?delayStartupUntil=onload");
         $sender->addJsFile("live.js", "plugins/MathJax");
     }
 


### PR DESCRIPTION
This fixes https://github.com/vanilla/addons/issues/677
MathJax shut down their own CDN and this PR simply changes CDN host to cloudflare