### PR TITLE
QnA: Change permission to AcceptAnswer to Garden.Curation.Manage

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -224,7 +224,7 @@ class QnAPlugin extends Gdn_Plugin {
 
         $qnA = valr('Comment.QnA', $args);
 
-        if ($qnA && ($qnA == 'Accepted' || Gdn::session()->checkPermission('Garden.Moderation.Manage'))) {
+        if ($qnA && ($qnA == 'Accepted' || Gdn::session()->checkRankedPermission('Garden.Curation.Manage'))) {
             $title = t("QnA $qnA Answer", "$qnA Answer");
             echo ' <span class="Tag QnA-Box QnA-'.$qnA.'" title="'.htmlspecialchars($title).'"><span>'.$title.'</span></span> ';
         }
@@ -363,7 +363,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         // Check permissions.
-        $canAccept = Gdn::session()->checkPermission('Garden.Moderation.Manage');
+        $canAccept = Gdn::session()->checkRankedPermission('Garden.Curation.Manage');
         $canAccept |= Gdn::session()->UserID == val('InsertUserID', $discussion);
 
         if (!$canAccept) {
@@ -422,8 +422,8 @@ class QnAPlugin extends Gdn_Plugin {
         $discussion = Gdn::sql()->getWhere('Discussion', ['DiscussionID' => $comment['DiscussionID']])->firstRow(DATASET_TYPE_ARRAY);
 
         // Check for permission.
-        if (!(Gdn::session()->UserID == val('InsertUserID', $discussion) || Gdn::session()->checkPermission('Garden.Moderation.Manage'))) {
-            throw permissionException('Garden.Moderation.Manage');
+        if (!(Gdn::session()->UserID == val('InsertUserID', $discussion) || Gdn::session()->checkRankedPermission('Garden.Curation.Manage'))) {
+            throw permissionException('Garden.Curation.Manage');
         }
         if (!Gdn::session()->validateTransientKey($sender->Request->get('tkey'))) {
             throw permissionException();


### PR DESCRIPTION
This allows roles with the Garden.Curation.Manage permission or higher to accept answers for questions that they didn't ask.  Previously it was only roles with Garden.Moderation.Manage.

AcceptAnswer is a reactiontype that uses this permission.  User can react with this permission.

https://github.com/vanilla/internal/blob/2297d4283299b990d0f9190cabe4af2102fea962/plugins/Reactions/class.reactionmodel.php#L928

To Test:

1. Create a role Garden.Curation.Manage permission.
2. Apply this role to a user (usera)
3. Create a question another user. (userb)
4. With another user answer the question. (userc)
5. Verify that you receive the "Did this answer the question?" span attached to answer. (usera)
6. Verify that accepting answer works.
_Backwards Compatibility_
7. Repeat steps with a user with Garder.Moderation.Manage
8. Repeat steps by trying to accept answers on a question that you've posted.

Requires vanilla/vanilla#8380
Closes vanilla/support#187