### PR TITLE
Fix JSConnect to allow for strings as AuthenticationKeys.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -206,7 +206,7 @@ class JsConnectPlugin extends Gdn_Plugin {
      * @param int|null $client_id
      * @return string
      */
-    public static function getProviderSqlCacheKey(?int $client_id) {
+    public static function getProviderSqlCacheKey($client_id) {
         $key = 'getProvider:';
         if ($client_id !== null) {
             $key .= 'AuthenticationKey:'.$client_id;


### PR DESCRIPTION
This PR will close #691 

Remove the type declaration for the parameter being passed to the getProviderSqlCacheKey() method in JSConnect.

To recreate:

 1) Turn on the JSConnect plugin.
 2) Create a JSConnect Connection.
 3) For Client ID choose a string.
 4) Save.
 5) Try to edit it, you will get a fatal error.

To test: 

 1) Check out this branch.
 2) Recreate the steps above.
 3) You should get an edit screen.