### PR TITLE
Redirector: Improve Lithium's 301 redirects

### DIFF
--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -249,7 +249,7 @@ class RedirectorPlugin extends Gdn_Plugin {
             trace("Looking up comment {$Vars['CommentID']}.");
             $CommentModel = new CommentModel();
             // If a legacy slug is provided (assigned during a merge), attempt to lookup the comment using it
-            if (isset($Get['legacy']) && Gdn::structure()->table('Comment')->columnExists('ForeignID')) {
+            if (isset($Get['legacy']) && Gdn::structure()->table('Comment')->columnExists('ForeignID') && $Filename !== 't5') {
                 $Comment = $CommentModel->getWhere(['ForeignID' => $Vars['CommentID']])->firstRow();
 
             } else {
@@ -399,6 +399,10 @@ class RedirectorPlugin extends Gdn_Plugin {
         } elseif (val('_arg2', $get) == 'm-p') { // Message => Comment
             $result = [
                 '_arg3' => 'CommentID',
+            ];
+        } elseif (val('_arg2', $get) == 'ta-p') { // Thread = Discussion
+            $result = [
+                '_arg3' => 'DiscussionID',
             ];
         } elseif (val('_arg2', $get) == 'td-p') { // Thread = Discussion
             $result = [

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -249,7 +249,7 @@ class RedirectorPlugin extends Gdn_Plugin {
             trace("Looking up comment {$Vars['CommentID']}.");
             $CommentModel = new CommentModel();
             // If a legacy slug is provided (assigned during a merge), attempt to lookup the comment using it
-            if (isset($Get['legacy']) && Gdn::structure()->table('Comment')->columnExists('ForeignID') && $Filename !== 't5') {
+            if (isset($Get['legacy']) && Gdn::structure()->table('Comment')->columnExists('ForeignID')) {
                 $Comment = $CommentModel->getWhere(['ForeignID' => $Vars['CommentID']])->firstRow();
 
             } else {
@@ -273,7 +273,7 @@ class RedirectorPlugin extends Gdn_Plugin {
 
             if (is_numeric($DiscussionID)) {
                 // If a legacy slug is provided (assigned during a merge), attempt to lookup the discussion using it
-                if (isset($Get['legacy']) && Gdn::structure()->table('Discussion')->columnExists('ForeignID')) {
+                if (isset($Get['legacy']) && Gdn::structure()->table('Discussion')->columnExists('ForeignID') && $Filename !== 't5') {
                     $Discussion = $DiscussionModel->getWhere(['ForeignID' => $DiscussionID])->firstRow();
                 } else {
                     $Discussion = $DiscussionModel->getID($Vars['DiscussionID']);


### PR DESCRIPTION
A customer that came from Lithium has been reporting some issues with the Redirector plugin. The problem is that discussions with `/ta-p/` and `/m-p/` are hitting 404's.

## The "/ta-p/" redirection problem

After looking at the plugin, I saw that we never implemented redirections for discussions with `/ta-p/` so URLs like the one below weren't redirecting. (It's currently redirecting because I created a temporary route)

https://community.rapidminer.com/t5/RapidMiner-Studio-Knowledge-Base/Real-Time-Financial-Data-via-Alpha-Venture-API-alternative-to/ta-p/41119

To fix that, I added the following condition to the `t5Filter` function.

```php
} elseif (val('_arg2', $get) == 'ta-p') {
    $result = [
       '_arg3' => 'DiscussionID',
    ];
}
```

It will now get the message id from the URL and try to match the discussion with the same id in Vanilla.

You can test that rule locally by turning on the redirector plugin. You will also need to append something like `/t5/category/discussion/ta-p/5` to the URL. Make sure that the discussion id you put in the end of the string exist in the database.

## The "/m-p/" redirection problem

While updating the plugin, I noticed that we were already handling redirects for URLs containing the "/m-p/" subfolder. If a comment with the provided id can't be found, we are looking in the discussion table, but we weren't doing the query on the right column.

```php
// If a legacy slug is provided (assigned during a merge), attempt to lookup the discussion using it
if (isset($Get['legacy']) && Gdn::structure()->table('Discussion')->columnExists('ForeignID')) {
    $Discussion = $DiscussionModel->getWhere(['ForeignID' => $DiscussionID])->firstRow();
} else {
    $Discussion = $DiscussionModel->getID($Vars['DiscussionID']);
}
```

The `ForeignID` column is ALWAYS part of the GDN_Discussion table, making the "else" unreachable in this case. When adding ` && $Filename !== 't5'` to the condition, we recover the discussion and the redirection is made properly.

Here is the URL provided by the client.

https://community.rapidminer.com/t5/RapidMiner-Studio-Forum/Downloading-historical-financial-data-since-change-of-Yahoo-API/m-p/39145

You can test this redirection the same way you would test the case above, but by appending `/t5/category/discussion/m-p/5` instead. You need to use a discussion id that doesn't have a comment with the same id.

Here is the GitHub issue for more information.

https://github.com/vanillaforums/rapidminer/issues/21