### PR TITLE
Update Sitemaps and Invisibility Cloak to use core robots.txt

### DIFF
--- a/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
+++ b/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
@@ -8,16 +8,29 @@
  */
 class InvisibilityCloakPlugin extends Gdn_Plugin {
 
+    /** @var Gdn_Configuration */
+    private $configuration;
+
     /**
-     * robots.txt.
+     * Addon constructor.
+     *
+     * @param Gdn_Configuration $configuration
      */
-    public function rootController_robots_create($sender) {
-        header("Content-Type: text/plain");
-        echo "User-agent: *\nDisallow: /";
+    public function __construct(Gdn_Configuration $configuration) {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Hook into the startup event.
+     */
+    public function gdn_dispatcher_appStartup_handler() {
+        $this->configuration->set("Robots.Invisible", true, true, false);
     }
 
     /**
      * No bots meta tag.
+     *
+     * @param object $sender
      */
     public function base_render_before($sender) {
         if ($sender->Head) {

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -9,6 +9,8 @@ You should have received a copy of the GNU General Public License along with Gar
 Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 */
 
+use Vanilla\Web\Robots;
+
 class SitemapsPlugin extends Gdn_Plugin {
     /**
      * @var \Garden\EventManager
@@ -100,28 +102,12 @@ class SitemapsPlugin extends Gdn_Plugin {
     }
 
     /**
-     * @param Gdn_Controller $sender
+     * Hook into the site's robots.txt generation.
+     *
+     * @param Robots $robots
      */
-    public function utilityController_robots_create($sender) {
-        // Clear the session to mimic a crawler.
-        Gdn::session()->UserID = 0;
-        Gdn::session()->User = false;
-        $sender->deliveryMethod(DELIVERY_METHOD_XHTML);
-        $sender->deliveryType(DELIVERY_TYPE_VIEW);
-        $sender->setHeader('Content-Type', 'text/plain');
-
-        $robots = new \Vanilla\Web\Robots();
-        $robots->addSitemap('/sitemapindex.xml');
-        $robots->addRule(c('Sitemap.Robots.Rules', 'User-agent: *
-Disallow: /entry/
-Disallow: /messages/
-Disallow: /profile/comments/
-Disallow: /profile/discussions/
-Disallow: /search/'));
-        $sender->setData('robots', $robots);
-        $this->eventManager->fire('robots_init', $robots);
-
-        $sender->render('Robots', '', 'plugins/Sitemaps');
+    public function robots_init(Robots $robots) {
+        $robots->addSitemap("/sitemapindex.xml");
     }
 
     /**

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -88,7 +88,6 @@ class SitemapsPlugin extends Gdn_Plugin {
     public function structure() {
         Gdn::router()->setRoute('sitemapindex.xml', '/utility/sitemapindex.xml', 'Internal');
         Gdn::router()->setRoute('sitemap-(.+)', '/utility/sitemap/$1', 'Internal');
-        Gdn::router()->setRoute('robots.txt', '/utility/robots', 'Internal');
     }
 
 


### PR DESCRIPTION
With vanilla/vanilla#8744, core support for robots.txt is added. This support is essentially a migration of the functionality from Sitemaps. Because of that, Sitemaps has been updated to remove the redundant functionality. Additionally, Invisibility Cloak has been refactored to use the new `Robots.Invisible` config, instead of attempting to create its own robots.txt endpoint.

No functional changes should be apparent after this update. Sitemaps and Invisibility Cloak should return the same robots.txt as they did before these changes.

Closes vanilla/vanilla#8576