### PR TITLE
Fix conflict with Bump plugin

### DIFF
--- a/plugins/NoIndex/class.noindex.plugin.php
+++ b/plugins/NoIndex/class.noindex.plugin.php
@@ -21,7 +21,7 @@ class NoIndexPlugin extends Gdn_Plugin {
             $sender->Options .= wrap(anchor($label, $url, 'NoIndex'), 'li');
          }
          else {
-            $args['DiscussionOptions']['Bump'] = [
+            $args['DiscussionOptions']['NoIndex'] = [
                'Label' => $label,
                'Url' => $url,
                'Class' => 'NoIndex'


### PR DESCRIPTION
If you are using NoIndex addon and Bump addon, you can't use bump if you enable it after NoIndex because NoIndex plugin has the same attribute