### PR TITLE
Include announced questions in discussions/unanswered

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -793,6 +793,7 @@ class QnAPlugin extends Gdn_Plugin {
 
             if ($unanswered) {
                 $args['Wheres']['Type'] = 'Question';
+                $args['Wheres']['Announce'] ='All';
                 $this->discussionModel->SQL->beginWhereGroup()
                     ->where('d.QnA', null)
                     ->orWhereIn('d.QnA', ['Unanswered', 'Rejected'])


### PR DESCRIPTION
**Issue**
Currently in questions which have been announced will not display in the discussions::unanswered endpoint. 

**Solution**
In the DiscussionModel::GetWhere method we are removing announcements 

https://github.com/vanilla/vanilla/blob/221d0bd4f4c29e13d71f762528f6c7ecf01f83c0/applications/vanilla/models/class.discussionmodel.php#L754.  

In order to include announcements we can add the condition in the where statement as described 

https://github.com/vanilla/vanilla/blob/221d0bd4f4c29e13d71f762528f6c7ecf01f83c0/applications/vanilla/models/class.discussionmodel.php#L650

 **To test**

1. Create a new question. Verify that it shows up in the 'Unanswered' queue.
2. Announce that thread (in Its Category and Recent
3. Discussions). The question will still count against the number in unanswered, but the thread will no longer show if you look at the queue.
4. Removing the Question status fixes the count, and removing its Announcement status allows it to appear in the unanswered queue.

Verify QnA functions as normally.

1. Create question with and without announcements.
2. Answer questions and verify that queue is accurate.

Closes vanilla/support#374
