### PR TITLE
Fix: category discussion type setting not respected when creating a question

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1113,14 +1113,12 @@ class QnAPlugin extends Gdn_Plugin {
      * @param PostController $sender Sending controller instance.
      */
     public function postController_question_create($sender, $categoryUrlCode = '') {
-        $category = false;
-        if ($categoryUrlCode != '') {
-            $categoryModel = new CategoryModel();
-            $category = (array)$categoryModel->getByCode($categoryUrlCode);
-            $category = $categoryModel::permissionCategory($category);
-            $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
-            $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
-        }
+        $categoryModel = new CategoryModel();
+        $category = (array)$categoryModel->getByCode($categoryUrlCode);
+        $category = $categoryModel::permissionCategory($category);
+        $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
+        $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
+
         if ($category &&  !$isAllowedQuestion && $isAllowedTypes) {
             $sender->Form->addError(t('You are not allowed to post a question in this category.'));
         }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1113,16 +1113,16 @@ class QnAPlugin extends Gdn_Plugin {
      * @param PostController $sender Sending controller instance.
      */
     public function postController_question_create($sender, $categoryUrlCode = '') {
-        $requestCategoryID = GDN::Request()->post('CategoryID');
-        $category = CategoryModel::categories($requestCategoryID);
-
-        if ($category && isset($category['AllowedDiscussionTypes'])) {
-            foreach($category['AllowedDiscussionTypes'] as $allowedDiscussionType) {
-                $allowedType[] = $allowedDiscussionType;
-            }
-            if (!in_array('Question', $allowedType)) {
-                $sender->Form->addError('You are not allowed to post a question in this category.');
-            }
+        $category = false;
+        if ($categoryUrlCode != '') {
+            $categoryModel = new CategoryModel();
+            $category = (array)$categoryModel->getByCode($categoryUrlCode);
+            $category = $categoryModel::permissionCategory($category);
+            $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
+            $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
+        }
+        if ($category &&  !$isAllowedQuestion && $isAllowedTypes) {
+            $sender->Form->addError(t('You are not allowed to post a question in this category.'));
         }
         // Create & call PostController->discussion()
         $sender->View = PATH_PLUGINS . '/QnA/views/post.php';

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1118,7 +1118,7 @@ class QnAPlugin extends Gdn_Plugin {
             $category = (array)$categoryModel->getByCode($categoryUrlCode);
             $category = $categoryModel::permissionCategory($category);
             $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
-            $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
+            $isAllowedQuestion = in_array('Question', $category['AllowedDiscussionTypes']);
         }
 
         if ($category && !$isAllowedQuestion && $isAllowedTypes) {

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1121,7 +1121,7 @@ class QnAPlugin extends Gdn_Plugin {
             $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
         }
 
-        if ($category &&  !$isAllowedQuestion && $isAllowedTypes) {
+        if ($category && !$isAllowedQuestion && $isAllowedTypes) {
             $sender->Form->addError(t('You are not allowed to post a question in this category.'));
         }
         // Create & call PostController->discussion()

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1114,10 +1114,12 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function postController_question_create($sender, $categoryUrlCode = '') {
         $categoryModel = new CategoryModel();
-        $category = (array)$categoryModel->getByCode($categoryUrlCode);
-        $category = $categoryModel::permissionCategory($category);
-        $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
-        $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
+        if ($categoryUrlCode != '') {
+            $category = (array)$categoryModel->getByCode($categoryUrlCode);
+            $category = $categoryModel::permissionCategory($category);
+            $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
+            $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
+        }
 
         if ($category &&  !$isAllowedQuestion && $isAllowedTypes) {
             $sender->Form->addError(t('You are not allowed to post a question in this category.'));

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1113,10 +1113,21 @@ class QnAPlugin extends Gdn_Plugin {
      * @param PostController $sender Sending controller instance.
      */
     public function postController_question_create($sender, $categoryUrlCode = '') {
-            // Create & call PostController->discussion()
-            $sender->View = PATH_PLUGINS . '/QnA/views/post.php';
-            $sender->setData('Type', 'Question');
-            $sender->discussion($categoryUrlCode);
+        $requestCategoryID = GDN::Request()->post('CategoryID');
+        $category = CategoryModel::categories($requestCategoryID);
+
+        if ($category && isset($category['AllowedDiscussionTypes'])) {
+            foreach($category['AllowedDiscussionTypes'] as $allowedDiscussionType) {
+                $allowedType[] = $allowedDiscussionType;
+            }
+            if (!in_array('Question', $allowedType)) {
+                $sender->Form->addError('You are not allowed to post a question in this category.');
+            }
+        }
+        // Create & call PostController->discussion()
+        $sender->View = PATH_PLUGINS . '/QnA/views/post.php';
+        $sender->setData('Type', 'Question');
+        $sender->discussion($categoryUrlCode);
     }
 
     /**

--- a/plugins/QnA/views/post.php
+++ b/plugins/QnA/views/post.php
@@ -21,6 +21,7 @@ if (c('Vanilla.Categories.Use') && is_object($this->Category)) {
             $options = [
                 'Value' => val('CategoryID', $this->Category),
                 'IncludeNull' => true,
+                'PermFilter' => ['AllowedDiscussionTypes' => 'Question'],
                 'DiscussionType' => 'Question',
             ];
             echo '<div class="P">';

--- a/plugins/QnA/views/post.php
+++ b/plugins/QnA/views/post.php
@@ -21,7 +21,7 @@ if (c('Vanilla.Categories.Use') && is_object($this->Category)) {
             $options = [
                 'Value' => val('CategoryID', $this->Category),
                 'IncludeNull' => true,
-                'PermFilter' => ['AllowedDiscussionTypes' => 'Question'],
+                'DiscussionType' => 'Question',
             ];
             echo '<div class="P">';
                 echo '<div class="Category">';


### PR DESCRIPTION
related [#426](https://github.com/vanilla/support/issues/426)

### Issue

When a category has custom permissions that does not allow questions, users can still for post a question in the category by browsing to post/question/no-question-category

### Case QnA

When a new question is created, [the QnA addon's postController_question_create hook](https://github.com/vanilla/addons/blob/d483877ea17a8578f891be621a71e15b4783bc16/plugins/QnA/class.qna.plugin.php#L1115) is called that calls [`PostController::discussion`](https://github.com/vanilla/vanilla/blob/4df04723ba501b050951ef1c4afd51d92d072391/applications/vanilla/controllers/class.postcontroller.php#L112). We're not checking the allowed discussion types when creating the discussion. 

### Proposed Fix - To stop force posting
In [the QnA addon's postController_question_create hook](https://github.com/vanilla/addons/blob/d483877ea17a8578f891be621a71e15b4783bc16/plugins/QnA/class.qna.plugin.php#L1115) we can get the category and check if the allowed discussion type is a question, since we are in the QnA plugin. Otherwise, we can throw an exception.

```
        $categoryModel = new CategoryModel();
        $category = (array)$categoryModel->getByCode($categoryUrlCode);
        $category = $categoryModel::permissionCategory($category);
        $isAllowedTypes = isset($category['AllowedDiscussionTypes']);
        $isAllowedQuestion = in_array('Question', $category['allowedDiscussionType']);
        if ($category &&  !$isAllowedQuestion && $isAllowedTypes) {
            $sender->Form->addError(t('You are not allowed to post a question in this category.'));
        }
```
### DiscussionType

in [QnA/views/post.php#L24](https://github.com/vanilla/addons/blob/master/plugins/QnA/views/post.php#L24) we are using   'PermFilter' => ['AllowedDiscussionTypes' => 'Question'], after that we call categoryDropDown('CategoryID', $options); categoryDropDown then tries to get the discussiontypes in [class.form.php#L500](https://github.com/vanilla/vanilla/blob/master/library/core/class.form.php#L500) which return nothing since we sent `'PermFilter' => ['AllowedDiscussionTypes' => 'Question']` instead of `'DiscussionType'  => 'Question']`
### Case Polls

Similar to QnA, we can check for allowed discussion types in [the Polls addon's postController_poll_create hook](https://github.com/vanilla/internal/blob/d42027f7b53f25e07459afeb5e4a7fe419d96766/plugins/Polls/class.polls.plugin.php#L275).

![Screen Shot 2019-05-31 at 11 22 56 AM](https://user-images.githubusercontent.com/31856281/58716203-7b641380-8396-11e9-8f11-14822e77c946.png)


### To Test

- [ ] Create a Category that is only restricted to (Discussions) - i'll call it no-questions
- [ ] from the dropdown on the main page, click new question (you should only see categories that allow questions)
- [ ] try again, this time go to post/question/no-question (you should get an error)
- [ ] Repeat the above using sub-communties