### PR TITLE
Fix JSConnect being able to provide data to other plugins in the connection process.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -480,6 +480,9 @@ class JsConnectPlugin extends Gdn_Plugin {
         $Sender->setData('Verified', true);
         $Sender->setData('Trusted', val('Trusted', $Provider, true)); // this is a trusted connection.
         $Sender->setData('SSOUser', $JsData);
+
+        $Sender->EventArguments['Profile'] = $Form->formValues();
+        $Sender->EventArguments['Form'] = $Form;
     }
 
     /**


### PR DESCRIPTION
Other plugins that hook into the connection process need certain profile data that is being passed. This PR passes the Form object and the Profile received from JSConnect as event arguments for other plugins to use.

This PR is dependant on https://github.com/vanilla/vanilla/pull/8984