### PR TITLE
Fix Q&A APIv2 schema augmentation

### DIFF
--- a/plugins/QnA/addon.json
+++ b/plugins/QnA/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Q&A",
     "description": "Users may designate a discussion as a Question and then officially accept one or more of the comments as the answer.",
-    "version": "1.4",
+    "version": "1.4.1",
     "mobileFriendly": true,
     "settingsUrl": "/settings/qna",
     "icon": "qna.png",

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1224,11 +1224,20 @@ class QnAPlugin extends Gdn_Plugin {
      * @param Schema $schema
      */
     public function discussionSchema_init(Schema $schema) {
-        $schema->merge(Schema::parse([
-            'attributes' => Schema::parse([
-                'question?' => $this->fullQuestionMetaDataSchema(),
-            ]),
-        ]));
+        $attributes = $schema->getField('properties.attributes');
+
+        // Add to an existing "attributes" field or create a new one?
+        if ($attributes instanceof Schema) {
+            $attributes->merge(Schema::parse([
+                'question?' => $this->fullQuestionMetaDataSchema()
+            ]));
+        } else {
+            $schema->merge(Schema::parse([
+                'attributes?' => Schema::parse([
+                    'question?' => $this->fullQuestionMetaDataSchema()
+                ])
+            ]));
+        }
     }
 
     /**


### PR DESCRIPTION
If another addon has augmented the discussion attribute schema then the Q&A addon would wipe that change out. This if statement offers a check for a targeted augmentation.