### PR TITLE
Authenticate the postback in the no index addon

### DIFF
--- a/plugins/NoIndex/addon.json
+++ b/plugins/NoIndex/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "No Index",
     "description": "Allows moderators & curators to mark a discussion as noindex/noarchive.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "mobileFriendly": true,
     "key": "noindex",
     "type": "addon",


### PR DESCRIPTION
The no index addon was not checking for an authenticated post back which is a narrow CSRF vulnerability. This PR also cleans up the spacing in the method and updates the parameter to the current best practice.

Closes https://github.com/vanilla/vanilla-patches/issues/268.