### PR TITLE
Require vanilla 3.1 for the latest sitemaps plugin

### DIFF
--- a/plugins/Sitemaps/addon.json
+++ b/plugins/Sitemaps/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Sitemaps",
     "description": "Creates an XML sitemap based on http://www.sitemaps.org.",
-    "version": "2.2",
+    "version": "2.2.1",
     "mobileFriendly": true,
     "requiredTheme": false,
     "hasLocale": true,
@@ -20,6 +20,6 @@
         }
     ],
     "require": {
-        "vanilla": ">=2.5"
+        "vanilla": ">=3.1"
     }
 }


### PR DESCRIPTION
Since this plugin requires the latest events when we moved Robots.txt into core, I've updated the minimum required version of Vanilla to release an updated version of the addon to OSS.