### PR TITLE
Remove the Transient Key from the URL in the Language Selector.

### DIFF
--- a/plugins/Multilingual/class.multilingual.plugin.php
+++ b/plugins/Multilingual/class.multilingual.plugin.php
@@ -128,13 +128,14 @@ class MultilingualPlugin extends Gdn_Plugin {
     /**
      * Allow user to set their preferred locale via link-click.
      */
-    public function profileController_setLocale_create($sender, $locale, $tK) {
+    public function profileController_setLocale_create($sender, $locale) {
         if (!Gdn::session()->UserID) {
             throw permissionException('Garden.SignIn.Allow');
         }
 
+        $tk = gdn::request()->post('TransientKey');
         // Check intent.
-        if (!Gdn::session()->validateTransientKey($tK)) {
+        if (!Gdn::session()->validateTransientKey($tk)) {
             redirectTo($_SERVER['HTTP_REFERER']);
         }
 

--- a/plugins/Multilingual/modules/class.localechoosermodule.php
+++ b/plugins/Multilingual/modules/class.localechoosermodule.php
@@ -17,9 +17,9 @@ class LocaleChooserModule extends Gdn_Module {
      * Build footer link to change locale.
      */
     public function buildLocaleLink($name, $urlCode) {
-        $url = 'profile/setlocale/'.$urlCode.'/'.Gdn::session()->transientKey();
+        $url = 'profile/setlocale/'.$urlCode;
 
-        return wrap(anchor($name, $url), 'span', ['class' => 'LocaleOption '.$name.'Locale']);
+        return wrap(anchor($name, $url, 'js-hijack'), 'span', ['class' => 'LocaleOption '.$name.'Locale']);
     }
 
     /**


### PR DESCRIPTION
We have links to change a user's language preference by GET request that pass the Transient Key in the address. This can be considered a security vulnerability because it exposes the Transient Key in logs, etc.

This PR adds the `.js-hijack` class to the link to change the language so that the flyout.js will then turn that GET request into a POST request and pass the Transient Key with it.

### Test

- Turn on the Multilingual Plugin, configure a few languages in the Locales section.
- Look at the URL of the Footer.
- See that the TransientKey is one of the parameters.
- Checkout this branch.
- See that the Transient Key is no longer there.
- Click on the link and make sure that the language is changed.
