### PR TITLE
Fixed redirector bug for PunBB URLs

### DIFF
--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -602,25 +602,23 @@ class RedirectorPlugin extends Gdn_Plugin {
                 '_arg2' => 'Page'
             ];
         } else {
-            if (val('_arg3', $get) == '') {
-                // This is punbb another style topic
-                return [
-                    '_arg0' => 'DiscussionID'
-                ];
-            } else {
-                // This is an ipb style topic.
-                return [
-                    'p' => 'CommentID',
-                    '_arg0' => [
-                        'DiscussionID',
-                        'Filter' => [__CLASS__, 'removeID'],
-                    ],
-                    '_arg1' => [
-                        'Page',
-                        'Filter' => [__CLASS__, 'IPBPageNumber'],
-                    ],
-                ];
-            }
+            if (!isset($get['_arg3'])) {
++                return [
++                    '_arg0' => 'DiscussionID'
++                ];
++            } else {
++                return [
++                    'p' => 'CommentID',
++                    '_arg0' => [
++                        'DiscussionID',
++                        'Filter' => [__CLASS__, 'removeID'],
++                    ],
++                    '_arg1' => [
++                        'Page',
++                        'Filter' => [__CLASS__, 'IPBPageNumber'],
++                    ],
++                ];
++            }
         }
     }
 

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -602,18 +602,25 @@ class RedirectorPlugin extends Gdn_Plugin {
                 '_arg2' => 'Page'
             ];
         } else {
-            // This is an ipb style topic.
-            return [
-                'p' => 'CommentID',
-                '_arg0' => [
-                    'DiscussionID',
-                    'Filter' => [__CLASS__, 'removeID'],
-                ],
-                '_arg1' => [
-                    'Page',
-                    'Filter' => [__CLASS__, 'IPBPageNumber'],
-                ],
-            ];
+            if (val('_arg3', $get) == '') {
+                // This is punbb another style topic
+                return [
+                    '_arg0' => 'DiscussionID'
+                ];
+            } else {
+                // This is an ipb style topic.
+                return [
+                    'p' => 'CommentID',
+                    '_arg0' => [
+                        'DiscussionID',
+                        'Filter' => [__CLASS__, 'removeID'],
+                    ],
+                    '_arg1' => [
+                        'Page',
+                        'Filter' => [__CLASS__, 'IPBPageNumber'],
+                    ],
+                ];
+            }
         }
     }
 

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -604,22 +604,22 @@ class RedirectorPlugin extends Gdn_Plugin {
         } else {
             // This is an ipb style topic. we do fix here 
             if (!isset($get['_arg3'])) {
-+                return [
-+                    '_arg0' => 'DiscussionID'
-+                ];
-+            } else {
-+                return [
-+                    'p' => 'CommentID',
-+                    '_arg0' => [
-+                        'DiscussionID',
-+                        'Filter' => [__CLASS__, 'removeID'],
-+                    ],
-+                    '_arg1' => [
-+                        'Page',
-+                        'Filter' => [__CLASS__, 'IPBPageNumber'],
-+                    ],
-+                ];
-+            }
+                return [
+                    '_arg0' => 'DiscussionID'
+                ];
+            } else {
+                return [
+                    'p' => 'CommentID',
+                    '_arg0' => [
+                        'DiscussionID',
+                        'Filter' => [__CLASS__, 'removeID'],
+                    ],
+                    '_arg1' => [
+                        'Page',
+                        'Filter' => [__CLASS__, 'IPBPageNumber'],
+                    ],
+                ];
+            }
         }
     }
 

--- a/plugins/Redirector/class.redirector.plugin.php
+++ b/plugins/Redirector/class.redirector.plugin.php
@@ -602,6 +602,7 @@ class RedirectorPlugin extends Gdn_Plugin {
                 '_arg2' => 'Page'
             ];
         } else {
+            // This is an ipb style topic. we do fix here 
             if (!isset($get['_arg3'])) {
 +                return [
 +                    '_arg0' => 'DiscussionID'


### PR DESCRIPTION
https://github.com/vanilla/addons/issues/737

The redirector plugin does not redirect to the correct url when a discussion has a number in its name.

 **For example:**
```
domain.com/topic/1/test-number-3212
domain.com/topic/100/20th-year-anniversary
```
 **will be redirected to** 
```
domain.com/discussion/1/test-number-3212/p3212
domain.com/discussion/100/20th-year-anniversary/p20
```
 **Redirects will work properly otherwise.** 
what i do is that i added another if  statement into the old redirector to help check.
tested locally and it seem working fine
```
 if (val('_arg3', $get) == '') {
                // This is punbb another style topic
                return [
                    '_arg0' => 'DiscussionID'
                ];
```  