### PR TITLE
Initialize advanced search record types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    core: vanilla/core@dev:feature/name-sphinx
+    core: vanilla/core@2.2
     jobs: vanilla/jobs@1.1
 jobs:
     php_sphinx_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    core: vanilla/core@2.2
+    core: vanilla/core@dev:feature/name-sphinx
     jobs: vanilla/jobs@1.1
 jobs:
     php_sphinx_tests:

--- a/plugins/QnA/addon.json
+++ b/plugins/QnA/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Q&A",
     "description": "Users may designate a discussion as a Question and then officially accept one or more of the comments as the answer.",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "mobileFriendly": true,
     "settingsUrl": "/settings/qna",
     "icon": "qna.png",

--- a/plugins/QnA/addon.json
+++ b/plugins/QnA/addon.json
@@ -12,10 +12,10 @@
         {
             "name": "Todd Burry",
             "email": "todd@vanillaforums.com",
-            "homepage": "http://www.vanillaforums.org/profile/todd"
+            "homepage": "https://www.vanillaforums.org/profile/todd"
         }
     ],
     "require": {
-        "vanilla": ">=2.4"
+        "vanilla": ">=3.2"
     }
 }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1467,6 +1467,7 @@ class QnAPlugin extends Gdn_Plugin {
     public function searchResultSchema_init(Schema $schema) {
         $types = $schema->getField('properties.type.enum');
         $types[] = 'question';
+        $types[] = 'answer';
         $schema->setField('properties.type.enum', $types);
     }
 

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -92,8 +92,8 @@ class QnAPlugin extends Gdn_Plugin {
     /**
      * Add Javascript.
      *
-     * @param $sender
-     * @param $args
+     * @param Gdn_Controller $sender
+     * @param array $args
      */
     public function base_render_before($sender, $args) {
         if ($sender->MasterView == 'admin') {

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -78,13 +78,12 @@ class QnAPlugin extends Gdn_Plugin {
     /**
      * @param Container $dic
      */
-    public function container_init(Container $dic)
-    {
+    public function container_init(Container $dic) {
         /*
          * Register additional advanced search sphinx record types
          */
         $dic
-            ->rule(Vanilla\Contracts\Search\SearchRecordTypesProviderInterface::class)
+            ->rule(Vanilla\Contracts\Search\SearchRecordTypeProviderInterface::class)
             ->addCall('setType', [new SearchRecordTypeQuestion()])
             ->addCall('setType', [new SearchRecordTypeAnswer()])
         ;

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -7,6 +7,9 @@
 use Garden\Schema\Schema;
 use Garden\Web\Exception\ClientException;
 use Vanilla\ApiUtils;
+use Garden\Container\Container;
+use Vanilla\QnA\Models\SearchRecordTypeQuestion;
+use Vanilla\QnA\Models\SearchRecordTypeAnswer;
 
 /**
  * Adds Question & Answer format to Vanilla.
@@ -70,6 +73,21 @@ class QnAPlugin extends Gdn_Plugin {
         \Gdn::config()->touch('QnA.Points.Enabled', false);
         \Gdn::config()->touch('QnA.Points.Answer', 1);
         \Gdn::config()->touch('QnA.Points.AcceptedAnswer', 1);
+    }
+
+    /**
+     * @param Container $dic
+     */
+    public function container_init(Container $dic)
+    {
+        /*
+         * Register additional advanced search sphinx record types
+         */
+        $dic
+            ->rule(Vanilla\Contracts\Search\SearchRecordTypesProviderInterface::class)
+            ->addCall('setType', [new SearchRecordTypeQuestion()])
+            ->addCall('setType', [new SearchRecordTypeAnswer()])
+        ;
     }
 
     /**

--- a/plugins/QnA/models/SearchRecordTypeAnswer.php
+++ b/plugins/QnA/models/SearchRecordTypeAnswer.php
@@ -8,66 +8,41 @@
 namespace Vanilla\QnA\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+use Vanilla\Contracts\Search\SearchRecordTypeTrait;
 
 /**
  * Class SearchRecordTypeAnswer
  * @package Vanilla\QnA\Models
  */
 class SearchRecordTypeAnswer implements SearchRecordTypeInterface {
+    use SearchRecordTypeTrait;
+
     const PROVIDER_GROUP = 'sphinx';
 
     const TYPE = 'comment';
 
-    const CHECKBOX_ID = 'answer';
+    const API_TYPE_KEY = 'answer';
+
+    const SUB_KEY = 'answer';
 
     const CHECKBOX_LABEL = 'answers';
 
-    /**
-     * SearchRecordTypeAnswer constructor.
-     */
-    public function __construct() {
-        $this->key = self::TYPE;
-    }
+    const SPHINX_DTYPE = 101;
+
+    const SPHINX_INDEX = 'Comment';
+
+    const GUID_OFFSET = 2;
+
+    const GUID_MULTIPLIER = 10;
 
     /**
      * @inheritdoc
      */
-    public function getKey(): string {
-        return $this->key;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCheckBoxId(): string {
-        return self::TYPE.'_'.self::CHECKBOX_ID;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCheckBoxLabel(): string {
-        return self::CHECKBOX_LABEL;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getFeatures(): array {
-        return $this->structure;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getModel() {
-        return '';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getProviderGroup(): string {
-        return self::PROVIDER_GROUP;
+    public function getDocuments(array $IDs, \SearchModel $searchModel): array {
+        $result = $searchModel->getComments($IDs);
+        foreach ($result as &$record) {
+            $record['guid'] = $record['PrimaryID'] * self::GUID_MULTIPLIER + self::GUID_OFFSET;
+        }
+        return $result;
     }
 }

--- a/plugins/QnA/models/SearchRecordTypeAnswer.php
+++ b/plugins/QnA/models/SearchRecordTypeAnswer.php
@@ -41,6 +41,7 @@ class SearchRecordTypeAnswer implements SearchRecordTypeInterface {
     public function getDocuments(array $IDs, \SearchModel $searchModel): array {
         $result = $searchModel->getComments($IDs);
         foreach ($result as &$record) {
+            $record['type'] = self::SUB_KEY;
             $record['guid'] = $record['PrimaryID'] * self::GUID_MULTIPLIER + self::GUID_OFFSET;
         }
         return $result;

--- a/plugins/QnA/models/SearchRecordTypeAnswer.php
+++ b/plugins/QnA/models/SearchRecordTypeAnswer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Adam Charron <adam.c@vanillaforums.com>
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
@@ -9,6 +9,10 @@ namespace Vanilla\QnA\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
 
+/**
+ * Class SearchRecordTypeAnswer
+ * @package Vanilla\QnA\Models
+ */
 class SearchRecordTypeAnswer implements SearchRecordTypeInterface {
     const PROVIDER_GROUP = 'sphinx';
 

--- a/plugins/QnA/models/SearchRecordTypeAnswer.php
+++ b/plugins/QnA/models/SearchRecordTypeAnswer.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\QnA\Models;
+
+use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+
+class SearchRecordTypeAnswer implements SearchRecordTypeInterface {
+    const PROVIDER_GROUP = 'sphinx';
+
+    const TYPE = 'comment';
+
+    const CHECKBOX_ID = 'answer';
+
+    const CHECKBOX_LABEL = 'answers';
+
+    /**
+     * SearchRecordTypeAnswer constructor.
+     */
+    public function __construct() {
+        $this->key = self::TYPE;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getKey(): string {
+        return $this->key;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCheckBoxId(): string {
+        return self::TYPE.'_'.self::CHECKBOX_ID;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCheckBoxLabel(): string {
+        return self::CHECKBOX_LABEL;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFeatures(): array {
+        return $this->structure;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getModel() {
+        return '';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getProviderGroup(): string {
+        return self::PROVIDER_GROUP;
+    }
+}

--- a/plugins/QnA/models/SearchRecordTypeQuestion.php
+++ b/plugins/QnA/models/SearchRecordTypeQuestion.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Adam Charron <adam.c@vanillaforums.com>
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
@@ -9,6 +9,10 @@ namespace Vanilla\QnA\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
 
+/**
+ * Class SearchRecordTypeQuestion
+ * @package Vanilla\QnA\Models
+ */
 class SearchRecordTypeQuestion implements SearchRecordTypeInterface {
     const PROVIDER_GROUP = 'sphinx';
 

--- a/plugins/QnA/models/SearchRecordTypeQuestion.php
+++ b/plugins/QnA/models/SearchRecordTypeQuestion.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\QnA\Models;
+
+use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+
+class SearchRecordTypeQuestion implements SearchRecordTypeInterface {
+    const PROVIDER_GROUP = 'sphinx';
+
+    const TYPE = 'discussion';
+
+    const CHECKBOX_ID = 'question';
+
+    const CHECKBOX_LABEL = 'questions';
+
+    /**
+     * SearchRecordTypeQuestion constructor.
+     */
+    public function __construct() {
+        $this->key = self::TYPE;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getKey(): string {
+        return $this->key;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCheckBoxId(): string {
+        return self::TYPE.'_'.self::CHECKBOX_ID;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCheckBoxLabel(): string {
+        return self::CHECKBOX_LABEL;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFeatures(): array {
+        return $this->structure;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getModel() {
+        return '';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getProviderGroup(): string {
+        return self::PROVIDER_GROUP;
+    }
+}

--- a/plugins/QnA/models/SearchRecordTypeQuestion.php
+++ b/plugins/QnA/models/SearchRecordTypeQuestion.php
@@ -8,66 +8,41 @@
 namespace Vanilla\QnA\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+use Vanilla\Contracts\Search\SearchRecordTypeTrait;
 
 /**
  * Class SearchRecordTypeQuestion
  * @package Vanilla\QnA\Models
  */
 class SearchRecordTypeQuestion implements SearchRecordTypeInterface {
+    use SearchRecordTypeTrait;
+
     const PROVIDER_GROUP = 'sphinx';
 
     const TYPE = 'discussion';
 
-    const CHECKBOX_ID = 'question';
+    const API_TYPE_KEY = 'question';
+
+    const SUB_KEY = 'question';
 
     const CHECKBOX_LABEL = 'questions';
 
-    /**
-     * SearchRecordTypeQuestion constructor.
-     */
-    public function __construct() {
-        $this->key = self::TYPE;
-    }
+    const SPHINX_DTYPE = 1;
+
+    const SPHINX_INDEX = 'Discussion';
+
+    const GUID_OFFSET = 1;
+
+    const GUID_MULTIPLIER = 10;
 
     /**
      * @inheritdoc
      */
-    public function getKey(): string {
-        return $this->key;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCheckBoxId(): string {
-        return self::TYPE.'_'.self::CHECKBOX_ID;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCheckBoxLabel(): string {
-        return self::CHECKBOX_LABEL;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getFeatures(): array {
-        return $this->structure;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getModel() {
-        return '';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getProviderGroup(): string {
-        return self::PROVIDER_GROUP;
+    public function getDocuments(array $IDs, \SearchModel $searchModel): array {
+        $result = $searchModel->getDiscussions($IDs);
+        foreach ($result as &$record) {
+            $record['guid'] = $record['PrimaryID'] * self::GUID_MULTIPLIER + self::GUID_OFFSET;
+        }
+        return $result;
     }
 }

--- a/plugins/QnA/tests/APIv2/QnaTestHelperTrait.php
+++ b/plugins/QnA/tests/APIv2/QnaTestHelperTrait.php
@@ -30,7 +30,7 @@ trait QnaTestHelperTrait {
         $this->assertArrayHasKey('dateAccepted', $discussion['attributes']['question']);
         $this->assertArrayHasKey('dateAnswered', $discussion['attributes']['question']);
 
-        foreach($expectedAttributes as $attribute => $value) {
+        foreach ($expectedAttributes as $attribute => $value) {
             $this->assertEquals($value, $discussion['attributes']['question'][$attribute]);
         }
     }
@@ -51,7 +51,7 @@ trait QnaTestHelperTrait {
         $this->assertArrayHasKey('dateAccepted', $comment['attributes']['answer']);
         $this->assertArrayHasKey('acceptUserID', $comment['attributes']['answer']);
 
-        foreach($expectedAttributes as $attribute => $value) {
+        foreach ($expectedAttributes as $attribute => $value) {
             $this->assertEquals($value, $comment['attributes']['answer'][$attribute]);
         }
     }

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -47,7 +47,6 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
-
         saveToConfig('Plugins.Sphinx.Server', 'sphinx');
         saveToConfig('Plugins.Sphinx.UseDeltas', true);
 

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -48,7 +48,7 @@ class SearchQuestionTest extends AbstractAPIv2Test {
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
 
-        saveToConfig('Plugins.Sphinx.Server', 'sphinx');
+        saveToConfig('Plugins.Sphinx.Server', '127.0.0.1');
         saveToConfig('Plugins.Sphinx.UseDeltas', true);
 
         /** @var \Gdn_Session $session */

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -8,6 +8,9 @@
 use Garden\Schema\Schema;
 use VanillaTests\APIv2\AbstractAPIv2Test;
 
+/**
+ * Class SearchQuestionTest
+ */
 class SearchQuestionTest extends AbstractAPIv2Test {
 
     /** @var array */
@@ -123,7 +126,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
         }
     }
 
-
+    /**
+     * Call terminal sphinx reindex command line
+     */
     public static function sphinxReindex() {
         $sphinxHost = c('Plugins.Sphinx.Server');
         exec('curl '.$sphinxHost.':9399', $dockerResponse);
@@ -132,13 +137,13 @@ class SearchQuestionTest extends AbstractAPIv2Test {
         sleep(1);
     }
 
-
     /**
      * Test search scoped to discussions.
      */
     public function testRecordTypesDiscussion() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => 'discussion',
@@ -160,8 +165,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search scoped to discussion original type (not a question or poll).
      */
     public function testTypesDiscussion() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => 'discussion',
@@ -185,8 +191,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search scoped to comments.
      */
     public function testRecordTypesComment() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => 'discussion',
@@ -208,8 +215,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search scoped to question.
      */
     public function testRecordTypesQuestion() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => 'discussion',
@@ -232,8 +240,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search scoped to a discussion.
      */
     public function testExistingDiscussionID() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => self::$comment['rawBody'],
@@ -255,8 +264,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search scoped to a category.
      */
     public function testExistingCategoryID() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => 'discussion',
@@ -278,8 +288,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search by user IDs
      */
     public function testInsertUserIDs() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => self::$discussion['name'],
@@ -300,8 +311,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      * Test search by non-existing user IDs
      */
     public function testWrongInsertUserIDs() {
-        if (!self::$sphinxReindexed)
-            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+        if (!self::$sphinxReindexed) {
+            $this->fail('Can\'t reindex Sphinx indexes!' . "\n" . end(self::$dockerResponse));
+        }
 
         $params = [
             'query' => self::$discussion['name'],

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+use Garden\Schema\Schema;
+use VanillaTests\APIv2\AbstractAPIv2Test;
+
+class SearchQuestionTest extends AbstractAPIv2Test {
+
+    /** @var array */
+    protected static $category;
+
+    /** @var array */
+    protected static $questionCategory;
+
+    /** @var array */
+    protected static $discussion;
+
+    /** @var array */
+    protected static $question;
+
+    /** @var array */
+    protected static $discussionAugust;
+
+    /** @var array */
+    protected static $comment;
+
+    /** @var Schema */
+    protected static $searchResultSchema;
+
+    /** @var bool */
+    protected static $sphinxReindexed;
+
+    protected static $addons = ['vanilla', 'sphinx', 'advancedsearch', 'qna'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        parent::setupBeforeClass();
+
+        saveToConfig('Plugins.Sphinx.Server', 'sphinx');
+        saveToConfig('Plugins.Sphinx.UseDeltas', true);
+
+        /** @var \Gdn_Session $session */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
+        /** @var \CategoriesApiController $categoriesAPIController */
+        $categoriesAPIController = static::container()->get('CategoriesApiController');
+        /** @var \DiscussionsApiController $discussionsAPIController */
+        $discussionsAPIController = static::container()->get('DiscussionsApiController');
+        /** @var \CommentsApiController $commentAPIController */
+        $commentAPIController = static::container()->get('CommentsApiController');
+
+        /** @var PostController $postController */
+        $postController = static::container()->get(PostController::class);
+
+        $tmp = uniqid('category_');
+        self::$category = $categoriesAPIController->post([
+            'name' => $tmp,
+            'urlcode' => $tmp,
+        ]);
+
+        $tmp = uniqid('discussion_');
+        self::$discussion = $discussionsAPIController->post([
+            'name' => 'Discussion for tests '.$tmp,
+            'body' => $tmp,
+            'format' => 'markdown',
+            'categoryID' => self::$category['categoryID'],
+        ]);
+        self::$discussion['rawBody'] = $tmp;
+
+        self::$discussionAugust = $discussionsAPIController->post([
+            'name' => 'discussion for tests '.'August test 2019',
+            'body' => 'August test 2019',
+            'format' => 'markdown',
+            'categoryID' => self::$category['categoryID'],
+        ]);
+
+        $tmp = uniqid('comment_');
+        self::$comment = $commentAPIController->post([
+            'body' => $tmp,
+            'format' => 'markdown',
+            'discussionID' => self::$discussion['discussionID'],
+        ]);
+        self::$comment['rawBody'] = $tmp;
+
+        self::$questionCategory = $categoriesAPIController->post([
+            'name' => 'Question Test',
+            'urlcode' => 'questiontest',
+        ]);
+
+
+        /** @var SearchApiController $searchAPIController */
+        $searchAPIController = static::container()->get('SearchApiController');
+        self::$searchResultSchema = $searchAPIController->fullSchema();
+
+        $session->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp() {
+        parent::setUp();
+
+        if (empty(self::$question)) {
+            $tmp = uniqid('question_discussion_');
+
+            self::$question = $this->api()->post('discussions/question', [
+                'categoryID' => self::$questionCategory['categoryID'],
+                'name' => 'discussion Test Question '.$tmp,
+                'body' => 'Hello world!',
+                'format' => 'markdown',
+            ]);
+
+            self::$question['rawBody'] = $tmp;
+            self::SphinxReindex();
+        }
+    }
+
+
+    public static function sphinxReindex() {
+        $sphinxHost = c('Plugins.Sphinx.Server');
+        exec('curl '.$sphinxHost.':9399', $dockerResponse);
+        self::$dockerResponse = $dockerResponse;
+        self::$sphinxReindexed = ('Sphinx reindexed.' === end($dockerResponse));
+        sleep(1);
+    }
+
+
+    /**
+     * Test search scoped to discussions.
+     */
+    public function testRecordTypesDiscussion() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => 'discussion',
+            'recordTypes' => 'discussion',
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(3, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+        $this->assertRowsEqual(['recordType' => 'discussion'], $results[0]);
+    }
+
+    /**
+     * Test search scoped to discussion original type (not a question or poll).
+     */
+    public function testTypesDiscussion() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => 'discussion',
+            'recordTypes' => 'discussion',
+            'types' => 'discussion',
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(2, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+        $this->assertRowsEqual(['recordType' => 'discussion'], $results[0]);
+    }
+
+
+    /**
+     * Test search scoped to comments.
+     */
+    public function testRecordTypesComment() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => 'discussion',
+            'recordTypes' => 'comment',
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(1, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+        $this->assertRowsEqual(['recordType' => 'comment'], $results[0]);
+    }
+
+    /**
+     * Test search scoped to question.
+     */
+    public function testRecordTypesQuestion() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => 'discussion',
+            'recordTypes' => 'discussion',
+            'types' => 'question'
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+        $this->assertEquals(1, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+        $this->assertRowsEqual(['recordType' => 'discussion'], $results[0]);
+        $this->assertRowsEqual(['type' => 'question'], $results[0]);
+    }
+
+    /**
+     * Test search scoped to a discussion.
+     */
+    public function testExistingDiscussionID() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => self::$comment['rawBody'],
+            'discussionID' => self::$discussion['discussionID'],
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(1, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+        $this->assertRowsEqual(['recordType' => 'comment'], $results[0]);
+    }
+
+    /**
+     * Test search scoped to a category.
+     */
+    public function testExistingCategoryID() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => 'discussion',
+            'categoryID' => self::$category['categoryID'],
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(3, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+    }
+
+    /**
+     * Test search by user IDs
+     */
+    public function testInsertUserIDs() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => self::$discussion['name'],
+            'insertUserIDs' => '1, 2',
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(4, count($results));
+        foreach ($results as $result) {
+            self::$searchResultSchema->validate($result);
+        }
+    }
+
+    /**
+     * Test search by non-existing user IDs
+     */
+    public function testWrongInsertUserIDs() {
+        if (!self::$sphinxReindexed)
+            $this->fail('Can\'t reindex Sphinx indexes!'."\n".end(self::$dockerResponse));
+
+        $params = [
+            'query' => self::$discussion['name'],
+            'insertUserIDs' => 404,
+        ];
+        $response = $this->api()->get('/search?'.http_build_query($params));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $results = $response->getBody();
+
+        $this->assertEquals(0, count($results));
+    }
+}

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -37,7 +37,7 @@ class SearchQuestionTest extends AbstractAPIv2Test {
     /** @var bool */
     protected static $sphinxReindexed;
 
-    protected static $addons = ['vanilla', 'sphinx', 'advancedsearch', 'qna'];
+    protected static $addons = ['vanilla', 'sphinx', 'qna'];
 
     /**
      * {@inheritdoc}
@@ -45,7 +45,7 @@ class SearchQuestionTest extends AbstractAPIv2Test {
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
 
-        saveToConfig('Plugins.Sphinx.Server', 'sphinx');
+        saveToConfig('Plugins.Sphinx.Server', '127.0.0.1');
         saveToConfig('Plugins.Sphinx.UseDeltas', true);
 
         /** @var \Gdn_Session $session */

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -48,7 +48,7 @@ class SearchQuestionTest extends AbstractAPIv2Test {
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
 
-        saveToConfig('Plugins.Sphinx.Server', '127.0.0.1');
+        saveToConfig('Plugins.Sphinx.Server', 'sphinx');
         saveToConfig('Plugins.Sphinx.UseDeltas', true);
 
         /** @var \Gdn_Session $session */

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -47,7 +47,6 @@ class SearchQuestionTest extends AbstractAPIv2Test {
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
-        saveToConfig('Plugins.Sphinx.Server', 'sphinx');
         saveToConfig('Plugins.Sphinx.UseDeltas', true);
 
         /** @var \Gdn_Session $session */

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -37,6 +37,9 @@ class SearchQuestionTest extends AbstractAPIv2Test {
     /** @var bool */
     protected static $sphinxReindexed;
 
+    /** @var bool */
+    protected static $dockerResponse;
+
     protected static $addons = ['vanilla', 'sphinx', 'qna'];
 
     /**


### PR DESCRIPTION
Initialize advanced search record types: `question` and `answer`

Relates to: https://github.com/vanilla/vanilla/issues/9318