### PR TITLE
Bump plugin: Use setField instead of setProperty.

### DIFF
--- a/plugins/Bump/class.bump.plugin.php
+++ b/plugins/Bump/class.bump.plugin.php
@@ -45,7 +45,7 @@ class BumpPlugin extends Gdn_Plugin {
                 throw notFoundException('Discussion');
             }
             // Update DateLastComment & redirect
-            $sender->DiscussionModel->setProperty($discussionID, 'DateLastComment', Gdn_Format::toDateTime());
+            $sender->DiscussionModel->setField($discussionID, 'DateLastComment', Gdn_Format::toDateTime());
             $sender->jsonTarget('', '', 'Refresh');
             $sender->render('Blank', 'Utility', 'Dashboard');
         }


### PR DESCRIPTION
The `setField` function from the discussion model is a wrapper for `Gdn_Model::setField` which fires the `AfterSetField` event.

By replacing the `setProperty` call by `setField`, it is possible to hook into the AfterSetField event after a discussion is bumped. Both functions are used to update an existing records and produce the same results.