### PR TITLE
Backport: add infrastructure template to SearchRecordType models in QnA plugin (release/2019.014)

### DIFF
--- a/plugins/QnA/models/SearchRecordTypeAnswer.php
+++ b/plugins/QnA/models/SearchRecordTypeAnswer.php
@@ -19,6 +19,8 @@ class SearchRecordTypeAnswer implements SearchRecordTypeInterface {
 
     const PROVIDER_GROUP = 'sphinx';
 
+    const INFRASTRUCTURE_TEMPLATE = 'standard';
+
     const TYPE = 'comment';
 
     const API_TYPE_KEY = 'answer';

--- a/plugins/QnA/models/SearchRecordTypeQuestion.php
+++ b/plugins/QnA/models/SearchRecordTypeQuestion.php
@@ -19,6 +19,8 @@ class SearchRecordTypeQuestion implements SearchRecordTypeInterface {
 
     const PROVIDER_GROUP = 'sphinx';
 
+    const INFRASTRUCTURE_TEMPLATE = 'standard';
+
     const TYPE = 'discussion';
 
     const API_TYPE_KEY = 'question';

--- a/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
+++ b/plugins/QnA/tests/Sphinx/SearchQuestionTest.php
@@ -40,7 +40,7 @@ class SearchQuestionTest extends AbstractAPIv2Test {
     /** @var bool */
     protected static $dockerResponse;
 
-    protected static $addons = ['vanilla', 'sphinx', 'qna'];
+    protected static $addons = ['vanilla', 'advancedsearch', 'sphinx', 'qna'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
backporting https://github.com/vanilla/addons/pull/747