### PR TITLE
Backport: Update OpenID curl option to not follow.

### DIFF
--- a/plugins/OpenID/class.lightopenid.php
+++ b/plugins/OpenID/class.lightopenid.php
@@ -147,7 +147,7 @@ class LightOpenID {
         $params = http_build_query($params, '', '&');
         $curl = curl_init($url.($method == 'GET' && $params ? '?'.$params : ''));
         curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($curl, CURLOPT_HEADER, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Permanently set the cURL option for following 3xx redirects to false.