### PR TITLE
Fix CivilTongue addon not able to find words ending '$'.

### DIFF
--- a/plugins/CivilTongueEx/addon.json
+++ b/plugins/CivilTongueEx/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Civil Tongue Ex",
     "description": "A swear word filter for your forum. Making your forum safer for younger audiences.",
-    "version": "1.2",
+    "version": "1.2.1",
     "mobileFriendly": true,
     "settingsUrl": "/plugin/tongue",
     "settingsPermission": "Garden.Settings.Manage",

--- a/plugins/CivilTongueEx/addon.json
+++ b/plugins/CivilTongueEx/addon.json
@@ -6,6 +6,7 @@
     "settingsUrl": "/plugin/tongue",
     "settingsPermission": "Garden.Settings.Manage",
     "icon": "civil-tongue.png",
+    "usePopupSettings": false,
     "key": "civiltongueex",
     "type": "addon",
     "license": "GPL-2.0-only",

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -580,18 +580,16 @@ class CivilTonguePlugin extends Gdn_Plugin {
      *
      * @return string
      */
-    public function getReplacement(): string
-    {
+    public function getReplacement(): string {
         return $this->Replacement;
     }
 
     /**
      * Set the replacement string.
-     * 
+     *
      * @param mixed $replacement
      */
-    public function setReplacement($replacement): void
-    {
+    public function setReplacement($replacement): void {
         $this->Replacement = $replacement;
     }
 }

--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -20,7 +20,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
      */
     public function  __construct() {
         parent::__construct();
-        $this->Replacement = c('Plugins.CivilTongue.Replacement', '');
+        $this->setReplacement(c('Plugins.CivilTongue.Replacement', ''));
     }
 
     /**
@@ -312,7 +312,7 @@ class CivilTonguePlugin extends Gdn_Plugin {
                 $explodedWords = explode(';', $words);
                 foreach ($explodedWords as $word) {
                     if (trim($word)) {
-                        $patterns[] = '`\b'.preg_quote(trim($word), '`').'\b`isu';
+                        $patterns[] = '`(?<![\pL])'.preg_quote(trim($word), '`').'(?![\pL])`isu';
                     }
                 }
             }
@@ -573,5 +573,25 @@ class CivilTonguePlugin extends Gdn_Plugin {
             $args['Group']['Name'] = $this->replace($args['Group']['Name']);
             $args['Group']['Description'] = $this->replace($args['Group']['Description']);
         }
+    }
+
+    /**
+     * Get the replacement string.
+     *
+     * @return string
+     */
+    public function getReplacement(): string
+    {
+        return $this->Replacement;
+    }
+
+    /**
+     * Set the replacement string.
+     * 
+     * @param mixed $replacement
+     */
+    public function setReplacement($replacement): void
+    {
+        $this->Replacement = $replacement;
     }
 }

--- a/plugins/CivilTongueEx/tests/Models/CivilTongueExTest.php
+++ b/plugins/CivilTongueEx/tests/Models/CivilTongueExTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Patrick Kelly <patrick.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\Models;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Class CivilTongueExTest
+ */
+class CivilTongueExTest extends TestCase {
+    use SiteTestTrait {
+        setupBeforeClass as private siteTestBeforeClass;
+    }
+
+    /** @var  \CivilTonguePlugin */
+    private $plugin;
+
+    /** @var \Gdn_Configuration */
+    private $config;
+
+    /** @var string patterns saved in config. */
+    private $words;
+
+    /**
+     * Add CivilTongueEx plugin to addons.
+     */
+    public static function setupBeforeClass() {
+        self::$addons = ['vanilla', 'civiltongueex'];
+        static::siteTestBeforeClass();
+    }
+
+    /**
+     * Instantiate the plugin, config.
+     *
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function setUp() {
+        parent::setUp();
+        $this->plugin = new \CivilTonguePlugin();
+        $this->config = self::$container->get(\Gdn_Configuration::class);
+        $this->words = $this->config->get('Plugins.CivilTongue.Words', '');
+    }
+
+    /**
+     * Undo changes to config.
+     */
+    public function tearDown() {
+        $this->config->set('Plugins.CivilTongue.Words', $this->words, true, false);
+        parent::tearDown();
+    }
+
+    /**
+     * Test finding and replacing patterns with the CivilTongue plugin.
+     *
+     * @param string $patternList List of words to be replaced.
+     * @param string $text Sample text to be filtered.
+     * @param string $expected The text expected after it is filtered.
+     * @dataProvider providePatternList
+     *
+     */
+    public function testReplacePatterns(string $patternList, string $text, string $expected) {
+        $this->config->set('Plugins.CivilTongue.Words', $patternList, true, false);
+        $this->plugin->setReplacement('****');
+        $output = $this->plugin->replace($text);
+        $this->assertEquals($expected, $output);
+    }
+
+    /**
+     * Provide patterns, test text and expected results to the test.
+     *
+     * @return array Provider data.
+     */
+    public function providePatternList() {
+        $provider = [
+            ['poop;PoOp;$hit;a$$', 'this is poop the text.', 'this is **** the text.'],
+        ];
+        return $provider;
+    }
+}

--- a/plugins/CivilTongueEx/tests/Models/CivilTongueExTest.php
+++ b/plugins/CivilTongueEx/tests/Models/CivilTongueExTest.php
@@ -38,8 +38,8 @@ class CivilTongueExTest extends TestCase {
     /**
      * Instantiate the plugin, config.
      *
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
+     * @throws \Garden\Container\ContainerException Error while retrieving the entry.
+     * @throws \Garden\Container\NotFoundException No entry was found for this identifier.
      */
     public function setUp() {
         parent::setUp();

--- a/plugins/CivilTongueEx/tests/Models/CivilTongueExTest.php
+++ b/plugins/CivilTongueEx/tests/Models/CivilTongueExTest.php
@@ -79,7 +79,13 @@ class CivilTongueExTest extends TestCase {
      */
     public function providePatternList() {
         $provider = [
-            ['poop;PoOp;$hit;a$$', 'this is poop the text.', 'this is **** the text.'],
+            'General' => ['poop;$hit;a$$', 'This poop is the text.', 'This **** is the text.'],
+            'TextBeginsWithSwear' => ['poop;$hit;a$$', 'poop the text', '**** the text'],
+            'TextEndsWithSwear' => ['poop;$hit;a$$', 'The text is poop', 'The text is ****'],
+            'SwearEndsWithDollarSign' => ['poop;$hit;a$$', 'The text is a$$', 'The text is ****'],
+            'SwearStartsWithDollarSign' => ['poop;$hit;a$$', '$hit the text', '**** the text'],
+            'SwearHasDollarSign' => ['poop;$hit;a$$', '$hithead the text', '$hithead the text'],
+            'SwearHasCamelCase' => ['poop;$hit;a$$', 'PoOp the text', '**** the text'],
         ];
         return $provider;
     }


### PR DESCRIPTION
This PR will fix CivilTongue when trying to replace words that use ‘$’ at the beginning or end of a word. (ex. a$$, $hit). The dollar symbol is considered to be a word boundary so when trying to find a word that incorporates '$' as an 'S' at the beginning or end of a string it won't find it.

Also this PR creates a test.

### Testing steps.

 - Turn on the Civil Tongue Plugin
 - Add the words 'a$$; $hit' to the filtered words.
 - Add text to the site with the 'a$$' and '$hit' in them.
 - Check that they have been replaced with the replacement text.