### PR TITLE
Set disqus plugin to hidden

### DIFF
--- a/plugins/Disqus/addon.json
+++ b/plugins/Disqus/addon.json
@@ -5,6 +5,7 @@
     "mobileFriendly": true,
     "settingsUrl": "/settings/disqus",
     "settingsPermission": "Garden.Settings.Manage",
+    "hidden": true,
     "icon": "disqus_sign_in.png",
     "socialConnect": true,
     "key": "disqus",


### PR DESCRIPTION
related https://github.com/vanilla/vanilla-patches/issues/642
This PR sets the plugin to hidden as requested in the referenced issue.