### PR TITLE
[QnA]: Fix checking of curation manage permission when accepting/rejecting a…

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -264,10 +264,10 @@ class QnAPlugin extends Gdn_Plugin {
             return;
         }
 
-        if (!Gdn::session()->checkRankedPermission('Garden.Curation.Manage')) {
-            if (!Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $discussion->PermissionCategoryID)) {
-                return;
-            }
+        $permissionDiscussion = Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $discussion->PermissionCategoryID);
+        $permissionCuration = Gdn::session()->checkRankedPermission('Garden.Curation.Manage');
+        if (!($permissionDiscussion || $permissionCuration)) {
+            return;
         }
         $args['CommentOptions']['QnA'] = ['Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?commentid='.$comment->CommentID, 'Class' => 'Popup'];
     }

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -264,10 +264,11 @@ class QnAPlugin extends Gdn_Plugin {
             return;
         }
 
-        if (!Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $discussion->PermissionCategoryID)) {
-            return;
+        if (!Gdn::session()->checkRankedPermission('Garden.Curation.Manage')) {
+            if (!Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $discussion->PermissionCategoryID)) {
+                return;
+            }
         }
-
         $args['CommentOptions']['QnA'] = ['Label' => t('Q&A').'...', 'Url' => '/discussion/qnaoptions?commentid='.$comment->CommentID, 'Class' => 'Popup'];
     }
 
@@ -641,8 +642,9 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         $discussion = $this->discussionModel->getID(val('DiscussionID', $comment), DATASET_TYPE_ARRAY);
-
-        $sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $discussion));
+        if (!Gdn::session()->checkRankedPermission('Garden.Curation.Manage')){
+            $sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $discussion));
+        }
 
         if ($sender->Form->authenticatedPostBack(true)) {
             $newQnA = $sender->Form->getFormValue('QnA');

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -642,7 +642,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         $discussion = $this->discussionModel->getID(val('DiscussionID', $comment), DATASET_TYPE_ARRAY);
-        if (!Gdn::session()->checkRankedPermission('Garden.Curation.Manage')){
+        if (!Gdn::session()->checkRankedPermission('Garden.Curation.Manage')) {
             $sender->permission('Vanilla.Discussions.Edit', true, 'Category', val('PermissionCategoryID', $discussion));
         }
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/656

### Details

Users with Garden.Curation.Manage can accept answers, however, they cannot reject them or set them to unasnwered because of https://github.com/vanilla/addons/blob/master/plugins/QnA/class.qna.plugin.php#L267

We are checking if users have Vanilla.Discussions.Edit

### To Test

As a user, create a question, add an answer
With another user that has curation manage permission try to edit the question