### PR TITLE
Mark the Share This addon as hidden

### DIFF
--- a/plugins/ShareThis/addon.json
+++ b/plugins/ShareThis/addon.json
@@ -17,5 +17,6 @@
             "email": "brendan@vanillaforums.com",
             "homepage": "http://www.dropthedigibomb.com"
         }
-    ]
+    ],
+    "hidden": true
 }


### PR DESCRIPTION
The addon is deprecated. I’m hiding it in vfoptions, but also here.