### PR TITLE
Hide signatures of deleted or banned users

### DIFF
--- a/plugins/Signatures/addon.json
+++ b/plugins/Signatures/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Signatures",
     "description": "Users may create custom signatures that appear after each of their comments.",
-    "version": "1.6.1",
+    "version": "1.7",
     "requiredTheme": false,
     "hasLocale": true,
     "registerPermissions": {

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -594,10 +594,9 @@ EOT;
 
         $sourceUserID = val('InsertUserID', $data);
         $user = Gdn::userModel()->getID($sourceUserID, DATASET_TYPE_ARRAY);
-        if (val('HideSignature', $user, false)) {
+        if (!empty($user['HideSignature']) || !empty($user['Deleted']) || !empty($user['Banned'])) {
             return;
         }
-
 
         $signature = $this->signatures($sender, $sourceUserID);
 


### PR DESCRIPTION
Users can be deleted or banned for having signatures that are offensive or abusive. Hiding their signatures is a sensible tweak.

In the case of deleted users, they can have their data deleted, but not always.

Closes https://github.com/vanilla/support/issues/842