### PR TITLE
Add basic HTTP authentication options to invisibility cloak

### DIFF
--- a/plugins/InvisibilityCloak/addon.json
+++ b/plugins/InvisibilityCloak/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Invisibility Cloak",
     "description": "Hide your forum from the prying eyes of search engines and bots while you set it up.",
-    "version": "1.0",
+    "version": "1.1",
     "key": "invisibilitycloak",
     "type": "addon",
     "authors": [
@@ -13,5 +13,8 @@
     "require": {
         "vanilla": ">=2.1"
     },
-    "icon": "invisibility_cloak.png"
+    "icon": "invisibility_cloak.png",
+    "settingsUrl": "/settings/invisibility-cloak",
+    "settingsPermission": "Garden.Settings.Manage",
+    "usePopupSettings": true
 }

--- a/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
+++ b/plugins/InvisibilityCloak/class.invisibilitycloak.plugin.php
@@ -25,6 +25,10 @@ class InvisibilityCloakPlugin extends Gdn_Plugin {
      */
     public function gdn_dispatcher_appStartup_handler() {
         $this->configuration->set("Robots.Invisible", true, true, false);
+
+        if (!Gdn::session()->checkPermission('Garden.Settings.Manage')) {
+            $this->checkAuthentication();
+        }
     }
 
     /**
@@ -35,6 +39,51 @@ class InvisibilityCloakPlugin extends Gdn_Plugin {
     public function base_render_before($sender) {
         if ($sender->Head) {
             $sender->Head->addTag('meta', ['name' => 'robots', 'content' => 'noindex,noarchive']);
+        }
+    }
+
+    /**
+     * Settings for the addon.
+     *
+     * @param SettingsController $sender
+     */
+    public function settingsController_invisibilityCloak_create(SettingsController $sender) {
+        $sender->permission('Garden.Settings.Manage');
+
+        $cf = new ConfigurationModule($sender);
+        $cf->initialize([
+            'Username' => [
+                'Config' => 'Plugins.InvisibilityCloak.Username',
+            ],
+            'Password' => [
+                'Config' => 'Plugins.InvisibilityCloak.Password',
+                'Options' => ['type' => 'password'],
+            ],
+        ]);
+
+        $sender->title('Title', t('Invisibility Cloak Settings'));
+        $sender->setData('Description', t('You can protect your site with an HTTP username/password during development.'));
+        $cf->renderAll();
+    }
+
+    /**
+     * Check basic HTTP authentication against configured values.
+     */
+    private function checkAuthentication(): void {
+        $configUsername = Gdn::config('Plugins.InvisibilityCloak.Username', '');
+        $configPassword = Gdn::config('Plugins.InvisibilityCloak.Password', '');
+        if (!empty($configUsername) || !empty($configPassword)) {
+            $username = Gdn::request()->getValueFrom(Gdn_Request::INPUT_SERVER, 'PHP_AUTH_USER');
+            $password = Gdn::request()->getValueFrom(Gdn_Request::INPUT_SERVER, 'PHP_AUTH_PW');
+
+            if (!hash_equals($configUsername, $username) ||
+                !hash_equals($configPassword, $password)
+            ) {
+                header('WWW-Authenticate: Basic realm="Community"');
+                header('Unauthorized', true, 401);
+                echo 'The site is currently username/password protected for development.';
+                exit;
+            }
         }
     }
 }


### PR DESCRIPTION
This feature allows administrators to protect an entire site during development or staging.