### PR TITLE
Add no-cache header to jsconnect

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -522,6 +522,7 @@ class JsConnectPlugin extends Gdn_Plugin {
      * @throws /Exception Throws an exception when the jsConnect provider is not found.
      */
     public function entryController_jsConnect_create($sender, $action = '', $target = '') {
+        $sender->setHeader('Cache-Control', \Vanilla\Web\CacheControlMiddleware::NO_CACHE);
         // Clear the nonce from the stash if any!
         Gdn::session()->stash('jsConnectNonce');
 


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1312

The issue seems to be caused because `entry/jsconnect` was being cached for around 2 minutes, so when then client SSO requested it was returning a nonce that no longer existed. (Nonce is deleted as soon as it's used).

I guess the way of testing this is verifying if `entry/jsconnect` is returning `Cache-Control: no-cache` header. You can try setting up https://github.com/vanilla/stub-sso-providers too and testing against it too.