### PR TITLE
Backport: Add no-cache header to jsconnect

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -522,6 +522,7 @@ class JsConnectPlugin extends Gdn_Plugin {
      * @throws /Exception Throws an exception when the jsConnect provider is not found.
      */
     public function entryController_jsConnect_create($sender, $action = '', $target = '') {
+        $sender->setHeader('Cache-Control', \Vanilla\Web\CacheControlMiddleware::NO_CACHE);
         // Clear the nonce from the stash if any!
         Gdn::session()->stash('jsConnectNonce');
 


### PR DESCRIPTION
Backport: https://github.com/vanilla/addons/pull/771
Issue: https://github.com/vanilla/support/issues/1312