### PR TITLE
Add priority to Role Title addon

### DIFF
--- a/plugins/RoleTitle/addon.json
+++ b/plugins/RoleTitle/addon.json
@@ -2,6 +2,7 @@
     "name": "Role Titles",
     "description": "Lists users' roles under their name and adds role-specific CSS classes to their comments for theming.",
     "version": "1.1",
+    "priority": 1100,
     "mobileFriendly": true,
     "registerPermissions": false,
     "icon": "role_titles.png",


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/232

Forces RoleTitle to load after Q&A.