### PR TITLE
Fix looping when JSConnect fails and site has Private Community turned on.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -563,6 +563,18 @@ class JsConnectPlugin extends Gdn_Plugin {
             $get = arrayTranslate($sender->Request->get(), ['client_id', 'display']);
 
             $sender->addDefinition('JsAuthenticateUrl', self::connectUrl($provider, true));
+            if ($provider['TestMode'] ?? false) {
+                $sender->addDefinition('JsConnectTestMode', true);
+            }
+
+            if (gdn::config('Garden.PrivateCommunity') && $provider['IsDefault']) {
+                // jsconnect.js needs to know to not to redirect if there is an error
+                // and PrivateCommunity is on and this is the only log in method,
+                // this causes a loop.
+                $sender->addDefinition('PrivateCommunity', true);
+                $sender->addDefinition('GenericSSOErrorMessage', gdn::translate('An error has occurred, please try again.'));
+            }
+
             $sender->addJsFile('jsconnect.js', 'plugins/jsconnect');
             $sender->setData('Title', t('Connecting...'));
             $sender->Form->Action = url('/entry/connect/jsconnect?'.http_build_query($get));


### PR DESCRIPTION
Closes: #776 

This PR will fix looping when trying to log in by passing a flag to the JSConnect JavaScript if it is a Private Community which will not redirect the browser if there is an error.

Also, this PR will add console logging if an Admin has put the JSConnect plugin in Test Mode.

## To test
 1. Turn on JSConnect, 
 2. configure it to be the Defualt method to log in. 
 3. Put Forum into Private Community mode. Break your JSConnect authentication provider so that it does not return a `UniqueID`.
 4. Try to log in.
 5. Observe insane loop.
 6. Checkout this branch.
 7. Observe an error message when it fails.

## Test console logging.
 1. Configure your JSConnect to be in Test Mode.
 2. Observe that when you log in, in the console log there is the Authentication response received. 