### PR TITLE
Fix Civil Tongue Ex pattern matching boundaries

### DIFF
--- a/plugins/CivilTongueEx/Library/ContentFilter.php
+++ b/plugins/CivilTongueEx/Library/ContentFilter.php
@@ -51,7 +51,7 @@ class ContentFilter {
                 $explodedWords = explode(';', $words);
                 foreach ($explodedWords as $word) {
                     if (trim($word)) {
-                        $patterns[] = '`(?<![\pL])'.preg_quote(trim($word), '`').'(?![\pL])`isu';
+                        $patterns[] = '`(?<![\pL\pN])'.preg_quote(trim($word), '`').'(?![\pL\pN])`isu';
                     }
                 }
             }


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1526

**Steps to test:**
- Find a Youtube link with 'ni' in the url (ex: https://youtu.be/Di11gCVW1nI)
- Make sure your civil tongue addon includes 'ni' as a word to be replaced.
- Post youtube link in comment or discussion
- Observe how it gets filtered.
- Checkout this branch and refresh the page.