### PR TITLE
Fix Signature max length check

### DIFF
--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -259,7 +259,7 @@ class SignaturesPlugin extends Gdn_Plugin {
         $maxLength = self::getMaximumTextLength();
         if ($maxLength !== null && $maxLength > 0) {
             $maxLength = intval($maxLength);
-            $format = config('Plugin.Signatures.Format', Gdn_Format::defaultFormat());
+            $format = isset($fields['Format']) ? $fields['Format'] : Gdn_Format::defaultFormat();
             $body = val('Plugin.Signatures.Sig', $fields, '');
             $plainTextLength = $this->formatService->getPlainTextLength($body, $format);
 

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -22,6 +22,8 @@
  * @package Addons
  */
 
+use \Vanilla\Formatting\FormatService;
+
 class SignaturesPlugin extends Gdn_Plugin {
 
     const Unlimited = 'Unlimited';
@@ -31,9 +33,16 @@ class SignaturesPlugin extends Gdn_Plugin {
     /** @var bool */
     public $Disabled = false;
 
+    /** @var FormatService  */
+    private $formatService;
+
     /** @var array List of config settings can be overridden by sessions in other plugins */
     private $overriddenConfigSettings = ['MaxNumberImages', 'MaxLength'];
 
+    public function __construct(FormatService $formatService) {
+        parent::__construct();
+        $this->formatService = $formatService;
+    }
 
     /**
      * Add mapper methods
@@ -248,12 +257,13 @@ class SignaturesPlugin extends Gdn_Plugin {
             $maxLength = intval($maxLength);
             $format = config('Plugin.Signatures.Format', Gdn_Format::defaultFormat());
             $body = val('Plugin.Signatures.Sig', $fields, '');
-            $formatted = Gdn_Format::to($body, $format);
-            $plainText = trim(Gdn_format::text($formatted));
+            //$formatted = Gdn_Format::to($body, $format);
+            //$plainText = trim(Gdn_format::text($formatted));
+            $plainTextLength = $this->formatService->getPlainTextLength($body, $format);
 
             // Validate the amount of text.
-            $length = strlen($plainText);
-            $difference = $length - $maxLength;
+            //$length = strlen($plainText);
+            $difference = $plainTextLength - $maxLength;
             if ($difference > 0) {
                 $sender->Form->addError(sprintf(
                     t('ValidateLength'),

--- a/plugins/Signatures/class.signatures.plugin.php
+++ b/plugins/Signatures/class.signatures.plugin.php
@@ -39,6 +39,10 @@ class SignaturesPlugin extends Gdn_Plugin {
     /** @var array List of config settings can be overridden by sessions in other plugins */
     private $overriddenConfigSettings = ['MaxNumberImages', 'MaxLength'];
 
+    /**
+     * SignaturesPlugin constructor.
+     * @param FormatService $formatService
+     */
     public function __construct(FormatService $formatService) {
         parent::__construct();
         $this->formatService = $formatService;
@@ -257,12 +261,9 @@ class SignaturesPlugin extends Gdn_Plugin {
             $maxLength = intval($maxLength);
             $format = config('Plugin.Signatures.Format', Gdn_Format::defaultFormat());
             $body = val('Plugin.Signatures.Sig', $fields, '');
-            //$formatted = Gdn_Format::to($body, $format);
-            //$plainText = trim(Gdn_format::text($formatted));
             $plainTextLength = $this->formatService->getPlainTextLength($body, $format);
 
-            // Validate the amount of text.
-            //$length = strlen($plainText);
+            // Validate the amount of text
             $difference = $plainTextLength - $maxLength;
             if ($difference > 0) {
                 $sender->Form->addError(sprintf(


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/728

**Steps to test:**
- Enable Signature addon
- Set the maximum number of characters to 5
- Try and update a signature to 0 or 1 characters
- You will get a "Signature is X characters too long" error
- Checkout this branch try again to see the issue resolve

**Further testing:**
- Try the same process above in a different posting format