### PR TITLE
Fix admins can be marked as trolls

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -27,6 +27,16 @@ class TrollManagementPlugin extends Gdn_Plugin {
     static $trolls = null;
 
     /**
+     * @var Gdn_Session.
+     */
+    private $session;
+
+    public function __construct(Gdn_Session $session) {
+        parent::__construct();
+        $this->session = $session;
+    }
+
+    /**
      * Setup: on enable
      */
     public function setup() {
@@ -74,38 +84,41 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * Validates the current user's permissions & transientkey and then marks a user as a troll.
      *
      * @param UserController $sender
+     * @throws \Garden\Web\Exception\ForbiddenException
+     * @throws Exception
      */
     public function userController_markTroll_create($sender, $userID, $troll = true) {
         $sender->permission('Garden.Moderation.Manage');
 
         $trollUserID = $userID;
         // Make sure the user doesn't have the same permission.
-        $userModel = new UserModel();
-        if ($userModel->checkPermission($trollUserID, 'Garden.Moderation.Manage')) {
-            throw new \Garden\Web\Exception\ForbiddenException('You cannot ban someone with the Garden.Moderation.Manage permission');
+//        $userModel = new UserModel();
+//        if ($userModel->checkPermission($trollUserID, 'Garden.Moderation.Manage')) {
+//            throw new \Garden\Web\Exception\ForbiddenException('You cannot mark someone with the Garden.Moderation.Manage permission as a troll.');
+//        }
+        if ($this->session->hasHigherPermissionLevel('Garden.Moderation.Manage', $trollUserID)) {
+            // Validate the transient key && permissions
+            // Make sure we are posting back.
+            if (!$sender->Request->isAuthenticatedPostBack()) {
+                throw permissionException('Javascript');
+            }
+
+            $trolls = self::getTrolls();
+
+            // Toggle troll value in DB
+            if (in_array($trollUserID, $trolls)) {
+                Gdn::sql()->update('User', ['Troll' => 0], ['UserID' => $trollUserID])->put();
+                unset($trolls[array_search($trollUserID, $trolls)]);
+            } else {
+                Gdn::sql()->update('User', ['Troll' => 1], ['UserID' => $trollUserID])->put();
+                $trolls[] = $trollUserID;
+            }
+
+            self::setTrolls($trolls);
+
+            $sender->jsonTarget('', '', 'Refresh');
+            $sender->render('Blank', 'Utility', 'Dashboard');
         }
-
-        // Validate the transient key && permissions
-        // Make sure we are posting back.
-        if (!$sender->Request->isAuthenticatedPostBack()) {
-            throw permissionException('Javascript');
-        }
-
-        $trolls = self::getTrolls();
-
-        // Toggle troll value in DB
-        if (in_array($trollUserID, $trolls)) {
-            Gdn::sql()->update('User', ['Troll' => 0], ['UserID' => $trollUserID])->put();
-            unset($trolls[array_search($trollUserID, $trolls)]);
-        } else {
-            Gdn::sql()->update('User', ['Troll' => 1], ['UserID' => $trollUserID])->put();
-            $trolls[] = $trollUserID;
-        }
-
-        self::setTrolls($trolls);
-
-        $sender->jsonTarget('', '', 'Refresh');
-        $sender->render('Blank', 'Utility', 'Dashboard');
     }
 
     /**

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -103,9 +103,15 @@ class TrollManagementPlugin extends Gdn_Plugin {
 
         $trollUserID = $userID;
         // Make sure the user has a higher permission level than the user they want to mark as a troll.
-        if (!$this->session->hasHigherPermissionLevel('Garden.Moderation.Manage', $trollUserID)) {
-            throw permissionException();
+        $trollPermissions = $sender->UserModel->getPermissions($trollUserID);
+        $rankCompare = Gdn_Session()::getPermissions()->compareRankTo($trollPermissions);
+        if ($rankCompare < 0) {
+            throw forbiddenException('@', t('You are not allowed to mark a user that has higher permissions than you as a troll'));
         }
+        if ($rankCompare === 0) {
+            throw forbiddenException('@', t('You are not allowed to mark a user with the same permission level as you as a troll'));
+        }
+
             // Validate the transient key && permissions
             // Make sure we are posting back.
         if (!$sender->Request->isAuthenticatedPostBack()) {

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -5,6 +5,9 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
  */
 
+use Garden\Container\ContainerException;
+use Garden\Container\NotFoundException;
+
 /**
  * Troll Management Features
  *
@@ -87,8 +90,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param int|string $userID The userID number.
      * @param boolean $troll Whether to mark the user as a troll.
      * @throws Gdn_UserException Throws user exception.
-     * @throws \Garden\Container\ContainerException Throws exception if there's a problem getting a container.
-     * @throws \Garden\Container\NotFoundException Throws exception if there's a problem getting a container.
+     * @throws ContainerException Throws exception if there's a problem getting a container.
+     * @throws NotFoundException Throws exception if there's a problem getting a container.
      */
     public function userController_markTroll_create($sender, $userID, $troll = true) {
         $sender->permission('Garden.Moderation.Manage');

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -34,6 +34,11 @@ class TrollManagementPlugin extends Gdn_Plugin {
      */
     private $session;
 
+    /**
+     * TrollManagementPlugin constructor.
+     *
+     * @param Gdn_Session $session Injected session.
+     */
     public function __construct(Gdn_Session $session) {
         parent::__construct();
         $this->session = $session;

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -79,6 +79,11 @@ class TrollManagementPlugin extends Gdn_Plugin {
         $sender->permission('Garden.Moderation.Manage');
 
         $trollUserID = $userID;
+        // Make sure the user doesn't have the same permission.
+        $userModel = new UserModel();
+        if ($userModel->checkPermission($trollUserID, 'Garden.Moderation.Manage')) {
+            throw new \Garden\Web\Exception\ForbiddenException('You cannot ban someone with the Garden.Moderation.Manage permission');
+        }
 
         // Validate the transient key && permissions
         // Make sure we are posting back.

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -103,13 +103,13 @@ class TrollManagementPlugin extends Gdn_Plugin {
 
         $trollUserID = $userID;
         // Make sure the user has a higher permission level than the user they want to mark as a troll.
-        $trollPermissions = $sender->UserModel->getPermissions($trollUserID);
-        $rankCompare = Gdn_Session()::getPermissions()->compareRankTo($trollPermissions);
+        $trollPermissions = $sender->userModel->getPermissions($trollUserID);
+        $rankCompare = $this->session->getPermissions()->compareRankTo($trollPermissions);
         if ($rankCompare < 0) {
-            throw forbiddenException('@', t('You are not allowed to mark a user that has higher permissions than you as a troll'));
+            throw forbiddenException('@'.t('You are not allowed to mark a user that has higher permissions than you as a troll'));
         }
         if ($rankCompare === 0) {
-            throw forbiddenException('@', t('You are not allowed to mark a user with the same permission level as you as a troll'));
+            throw forbiddenException('@'.t('You are not allowed to mark a user with the same permission level as you as a troll'));
         }
 
             // Validate the transient key && permissions

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -106,14 +106,14 @@ class TrollManagementPlugin extends Gdn_Plugin {
         $trollPermissions = $sender->userModel->getPermissions($trollUserID);
         $rankCompare = $this->session->getPermissions()->compareRankTo($trollPermissions);
         if ($rankCompare < 0) {
-            throw forbiddenException('@'.t('You are not allowed to mark a user that has higher permissions than you as a troll'));
+            throw forbiddenException('@'.t('You are not allowed to mark a user that has higher permissions than you as a troll.'));
         }
         if ($rankCompare === 0) {
-            throw forbiddenException('@'.t('You are not allowed to mark a user with the same permission level as you as a troll'));
+            throw forbiddenException('@'.t('You are not allowed to mark a user with the same permission level as you as a troll.'));
         }
 
-            // Validate the transient key && permissions
-            // Make sure we are posting back.
+        // Validate the transient key && permissions
+        // Make sure we are posting back.
         if (!$sender->Request->isAuthenticatedPostBack()) {
             throw permissionException('Javascript');
         }


### PR DESCRIPTION
This PR depends on vanilla/vanilla#10284
This partially addresses vanilla/support#1571

It is possible to mark and Admin or Moderator as a troll. This PR adds a permission check before the user is marked as a troll and throws an exception if they have the `Moderation.Manage` permission.