### PR TITLE
Add translation codes and strings to ignore plugin

### DIFF
--- a/plugins/Ignore/locale/en.php
+++ b/plugins/Ignore/locale/en.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+$Definition['IgnoreListMeter'] = 'Ignore list is <b>%s%%</b> full (<b>%d/%d</b>).';
+$Definition['IgnoreListRevoke'] = 'Revoke <b>%s</b>\'s ignore list privileges?';
+$Definition['IgnoreListUnlimited'] = '<b>Unlimited</b> list, ignored <b>%d</b> %s';

--- a/plugins/Ignore/views/ignore.php
+++ b/plugins/Ignore/views/ignore.php
@@ -10,7 +10,7 @@ $Restricted = $this->data('IgnoreRestricted');
 
 ?>
 <?php if ($this->data('ForceEditing', FALSE)): ?>
-   <div class="Warning"><?php echo sprintf(t("You are viewing %s's ignore list"),$this->data('ForceEditing')); ?></div>
+   <div class="Warning"><?php echo sprintf(t('You are viewing %s\'s ignore list'),$this->data('ForceEditing')); ?></div>
 <?php endif; ?>
 
 <?php if ($NumIgnoredUsers): ?>
@@ -47,22 +47,22 @@ $Restricted = $this->data('IgnoreRestricted');
 $NumIgnoreLimit = $this->data('IgnoreLimit');
 if ($NumIgnoreLimit != 'infinite'):
    $IgnoreListPercent = round(($NumIgnoredUsers / $NumIgnoreLimit) * 100, 2);
-   echo wrap(sprintf(t("Ignore list is <b>%s%%</b> full (<b>%d/%d</b>)."), $IgnoreListPercent, $NumIgnoredUsers, $NumIgnoreLimit), 'div');
+   echo wrap(sprintf(t('IgnoreListMeter'), $IgnoreListPercent, $NumIgnoredUsers, $NumIgnoreLimit), 'div');
 else:
-   echo wrap(sprintf(t("<b>Unlimited</b> list, ignored <b>%d</b> %s"), $NumIgnoredUsers, plural($NumIgnoredUsers, 'person','people')), 'div');
+   echo wrap(sprintf(t('IgnoreListUnlimited'), $NumIgnoredUsers, plural($NumIgnoredUsers, 'person','people')), 'div');
 endif;
 ?>
 
 <?php if ($Restricted): ?>
    <?php $ReferTo = ($this->data('ForceEditing') ? sprintf(t("%s is"), $this->data('ForceEditing')) : t("You are")); ?>
    <div class="Info">
-      <?php echo sprintf(t("%s prohibited from using the ignore feature."),$ReferTo); ?>
+      <?php echo sprintf(t('%s prohibited from using the ignore feature.'),$ReferTo); ?>
       <?php if ($Moderator && $this->data('ForceEditing', TRUE)):
          echo anchor('Restore', "/user/ignorelist/allow/{$this->User->UserID}/".Gdn_Format::url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']);
       endif; ?>
    </div>
 <?php elseif ($Moderator && $this->data('ForceEditing', TRUE)): ?>
-   <div class="Warning"><?php echo sprintf(t("Revoke <b>%s</b>'s ignore list privileges?"), $this->data('ForceEditing')); ?> <?php echo anchor('Revoke', "/user/ignorelist/revoke/{$this->User->UserID}/".Gdn_Format::url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']); ?></div>
+   <div class="Warning"><?php echo sprintf(t('IgnoreListRevoke'), $this->data('ForceEditing')); ?> <?php echo anchor('Revoke', "/user/ignorelist/revoke/{$this->User->UserID}/".Gdn_Format::url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']); ?></div>
 <?php endif; ?>
 
 <?php if (!$this->data('ForceEditing') && !$Restricted): ?>

--- a/plugins/Ignore/views/ignore.php
+++ b/plugins/Ignore/views/ignore.php
@@ -54,9 +54,11 @@ endif;
 ?>
 
 <?php if ($Restricted): ?>
-   <?php $ReferTo = ($this->data('ForceEditing') ? sprintf(t("%s is"), $this->data('ForceEditing')) : t("You are")); ?>
    <div class="Info">
-      <?php echo sprintf(t('%s prohibited from using the ignore feature.'),$ReferTo); ?>
+      <?php if ($this->data('ForceEditing')):
+         echo sprintf(t('%s is prohibited from using the ignore feature.'));
+            else: echo t('You are prohibited from using the ignore feature.');
+      endif; ?>
       <?php if ($Moderator && $this->data('ForceEditing', TRUE)):
          echo anchor('Restore', "/user/ignorelist/allow/{$this->User->UserID}/".Gdn_Format::url($this->User->Name), 'Ignore Hijack', ['id' => 'revoke']);
       endif; ?>


### PR DESCRIPTION
Complements vanilla/locales#280.

Addresses vanilla/support#1616.

This PR adds translation codes and strings to the ignore plugin.