### PR TITLE
Fix jsConnect can still be default provider when disabled

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -188,7 +188,7 @@ class JsConnectPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Calculat the querystring for connecting.
+     * Calculate the querystring for connecting.
      *
      * @param array $provider
      * @param ?string $target
@@ -644,6 +644,21 @@ class JsConnectPlugin extends Gdn_Plugin {
         Gdn::request()->pathAndQuery($url);
         Gdn::dispatcher()->dispatch();
         $args['Handled'] = true;
+    }
+
+    /**
+     * Set the 'IsDefault' field to zero before disabling to prevent conflicts.
+     *
+     * @param Gdn_Controller $sender The Controller info.
+     * @param Gdn_Controller $args Event args.
+     */
+    public function settingsController_beforeDisablePlugin_handler($sender, $args) {
+        if (isset($args['PluginName'])) {
+            $authenticationProvider = new Gdn_AuthenticationProviderModel();
+            $providerData = Gdn_AuthenticationProviderModel::getProviderByScheme($args['PluginName']);
+            $providerData['IsDefault'] = 0;
+            $authenticationProvider->save($providerData);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #788  
Partially addresses vanilla/support#1618.

If jsConnect is set as the default connection method, it remains so even if you disable it, which can cause conflicts and confusion. This PR makes sure the 'IsDefault' field is set to 0 whenever the plugin is disabled.

### TO TEST
After checking out this branch:
1. Turn on jsConnect plugin and set it as the default connection method.
1. Disable the jsConnect plugin.
1. Look at the 'IsDefault' field in the `GDN_UserAuthenticationProvider` table and verify that it is set to 0.