### PR TITLE
Fix jsConnect can be default provider when disabled

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -28,15 +28,6 @@ class JsConnectPlugin extends SSOAddon {
     private const AUTHENTICATION_SCHEME = 'jsconnect';
 
     /**
-     * Get the AuthenticationSchemeAlias value.
-     *
-     * @return string The AuthenticationSchemeAlias.
-     */
-    protected function getAuthenticationScheme(): string {
-        return self::AUTHENTICATION_SCHEME;
-    }
-
-    /**
      * @var \Garden\Web\Cookie
      */
     private $cookie;
@@ -54,6 +45,15 @@ class JsConnectPlugin extends SSOAddon {
         parent::__construct();
         $this->cookie = $cookie;
         $this->userModel = $userModel;
+    }
+
+    /**
+     * Get the AuthenticationSchemeAlias value.
+     *
+     * @return string The AuthenticationSchemeAlias.
+     */
+    protected function getAuthenticationSchemeAlias(): string {
+        return self::AUTHENTICATION_SCHEME;
     }
 
     /**

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -13,7 +13,7 @@ use Vanilla\Utility\CamelCaseScheme;
 /**
  * Class JsConnectPlugin
  */
-class JsConnectPlugin extends Gdn_Plugin {
+class JsConnectPlugin extends SSOAddon {
 
     const DEFAULT_SECRET_LENGTH = 64;
 
@@ -25,6 +25,16 @@ class JsConnectPlugin extends Gdn_Plugin {
     const ACTION_SIGN_IN = 'signin';
     const ACTION_REGISTER = 'register';
     const FIELD_PROVIDER_CLIENT_ID = 'AuthenticationKey';
+    private const AUTHENTICATION_SCHEME = 'jsconnect';
+
+    /**
+     * Get the AuthenticationSchemeAlias value.
+     *
+     * @return string The AuthenticationSchemeAlias.
+     */
+    protected function getAuthenticationScheme(): string {
+        return self::AUTHENTICATION_SCHEME;
+    }
 
     /**
      * @var \Garden\Web\Cookie
@@ -305,7 +315,7 @@ class JsConnectPlugin extends Gdn_Plugin {
         if ($client_id !== null) {
             $where = [self::FIELD_PROVIDER_CLIENT_ID => $client_id];
         } else {
-            $where = ['AuthenticationSchemeAlias' => 'jsconnect'];
+            $where = ['AuthenticationSchemeAlias' => self::AUTHENTICATION_SCHEME];
         }
 
         $sql = Gdn::sql();


### PR DESCRIPTION
Depends on vanilla/vanilla#10423
Partially addresses vanilla/support#1618
Closes #788

This PR fixes a problem where jsConnect could be the default authentication provider even when disabled. The jsconnect class now extends SSOAddon rather than Gdn_Plugin, which provides a method to set the `Gdn_UserAuthenticationProvider`'s 'IsDefault' value to 0 for any provider matching the jsConnect 'AuthenticationSchemeAlias'.

### TO TEST
1. Set up a jsConnect provider.
1. Set the 'IsDefault' value in the `Gdn_UserAuthenticationProvider` table to 1.
1. Disable the jsConnect addon and verify that the 'IsDefault' value is still 1.
1. Check out this branch.
1. Repeat steps 1-3, except this time verify that the 'IsDefault' value changes to 0.