### PR TITLE
Fix discussion API failure when no question status is set

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1317,7 +1317,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         $discussion['attributes']['question'] = [
-            'status' => strtolower($discussion['qnA']),
+            'status' => isset($discussion['qnA']) ? strtolower($discussion['qnA']) : 'unanswered',
             'dateAccepted' => $discussion['dateAccepted'],
             'dateAnswered' => $discussion['dateOfAnswer'],
             "acceptedAnswers" => $acceptedAnswers,

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1317,7 +1317,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         $discussion['attributes']['question'] = [
-            'status' => isset($discussion['qnA']) ? strtolower($discussion['qnA']) : 'unanswered',
+            'status' => empty($discussion['qnA']) ? strtolower($discussion['qnA']) : 'unanswered',
             'dateAccepted' => $discussion['dateAccepted'],
             'dateAnswered' => $discussion['dateOfAnswer'],
             "acceptedAnswers" => $acceptedAnswers,

--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -1317,7 +1317,7 @@ class QnAPlugin extends Gdn_Plugin {
         }
 
         $discussion['attributes']['question'] = [
-            'status' => empty($discussion['qnA']) ? strtolower($discussion['qnA']) : 'unanswered',
+            'status' => !empty($discussion['qnA']) ? strtolower($discussion['qnA']) : 'unanswered',
             'dateAccepted' => $discussion['dateAccepted'],
             'dateAnswered' => $discussion['dateOfAnswer'],
             "acceptedAnswers" => $acceptedAnswers,


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1699

### Details

Making an api/v2/discussions call When a Discussion of Type question and QnA Null would fail with this error
```
"message": "Validation Failed",

"status": 422,

"errors": [

    {

        "field": "status",

        "code": "missingField",

        "path": "[22].attributes.question",

        "status": 422,

        "message": "item[22].attributes.question.status is required."

    }

]
```

This is happening because of https://github.com/vanilla/addons/blob/master/plugins/QnA/class.qna.plugin.php#L1320
w'ere not setting a default value when that field is null.

 
