### PR TITLE
Fix BBCode format when IPB Fomatter is enabled

### DIFF
--- a/plugins/IPBFormatter/Formats/IPBFormat.php
+++ b/plugins/IPBFormatter/Formats/IPBFormat.php
@@ -41,6 +41,7 @@ class IPBFormat extends HtmlFormat {
 
         $this->bbcodeParser = $bbcodeParser;
         $this->bbcodeParser->nbbc()->setIgnoreNewlines(true);
+        $this->bbcodeParser->nbbc()->setEscapeContent(false);
     }
 
     /**

--- a/plugins/IPBFormatter/bootstrap.php
+++ b/plugins/IPBFormatter/bootstrap.php
@@ -4,9 +4,17 @@
  * @license GPL-2.0-only
  */
 
+use Vanilla\Formatting\FormatService;
+use IPBFormatter\Formats\IPBFormat;
+use IPBFormatter\Formatter;
+use \Garden\Container\Reference;
+
 $container = Gdn::getContainer();
 
-$container->rule(IPBFormatter\Formatter::class)
+$container->rule(FormatService::class)
+    ->addCall('registerFormat', [IPBFormat::FORMAT_KEY, new Reference(IPBFormat::class)]);
+
+$container->rule(Formatter::class)
     ->addAlias('IPBFormatter')
     ->addAlias('ipbFormatter')
     ->setShared(true);

--- a/plugins/IPBFormatter/bootstrap.php
+++ b/plugins/IPBFormatter/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+$container = Gdn::getContainer();
+
+$container->rule(IPBFormatter\Formatter::class)
+    ->addAlias('IPBFormatter')
+    ->addAlias('ipbFormatter')
+    ->setShared(true);

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -29,9 +29,9 @@ class IPBFormatterPlugin extends Gdn_Plugin {
         $formatService = $dic->get(FormatService::class);
         $formatService->registerFormat(IPBFormat::FORMAT_KEY, $dic->get(IPBFormat::class));
 
-        $dic->rule("IPBFormatter")
-            ->setClass(Formatter::class)
-            ->setShared(true);
+//        $dic->rule("IPBFormatter")
+//            ->setClass(Formatter::class)
+//            ->setShared(true);
     }
 
     /**
@@ -248,15 +248,6 @@ EOT;
         }
 
         return '';
-    }
-
-    /**
-     * @param $sender
-     * @param $args
-     */
-    public function bBCode_afterBBCodeSetup_handler($sender, $args) {
-        $nbbc = $args['BBCode'];
-        $nbbc->setEscapeContent(false);
     }
 
     /**

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -21,16 +21,6 @@ class IPBFormatterPlugin extends Gdn_Plugin {
     protected $_Media = null;
 
     /**
-     * Hook into the main container initialization.
-     *
-     * @param ContainerInterface $dic
-     */
-    public function container_init(ContainerInterface $dic) {
-        $formatService = $dic->get(FormatService::class);
-        $formatService->registerFormat(IPBFormat::FORMAT_KEY, $dic->get(IPBFormat::class));
-    }
-
-    /**
      *
      *
      * @param $string

--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -28,10 +28,6 @@ class IPBFormatterPlugin extends Gdn_Plugin {
     public function container_init(ContainerInterface $dic) {
         $formatService = $dic->get(FormatService::class);
         $formatService->registerFormat(IPBFormat::FORMAT_KEY, $dic->get(IPBFormat::class));
-
-//        $dic->rule("IPBFormatter")
-//            ->setClass(Formatter::class)
-//            ->setShared(true);
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1562

**Steps to test:**
- Enable the "IPB Formatter" plugin (addons)
- Set the posting format to "BBCode"
- Make a comment and using the editor emoji menu, create a heart emoji
- Put in a line break (press return/enter), make another heart emoji
- Create comment
- the `<br>` line break tag should be escaped (bug)
- Checkout this branch

**Further testing:**
- Make another BBCode comment and add a some BBCode, maybe some acceptable HTML
- Change the format in the DB to "ipb"
- Check if the comment renders alright.