### PR TITLE
Fix admins able to spoof system user

### DIFF
--- a/plugins/Spoof/class.spoof.plugin.php
+++ b/plugins/Spoof/class.spoof.plugin.php
@@ -31,9 +31,12 @@ class SpoofPlugin implements Gdn_IPlugin {
 	 */
 	public function userController_autoSpoof_create($sender) {
 		$spoofUserID = getValue('0', $sender->RequestArgs);
-		$transientKey = getValue('1', $sender->RequestArgs);
+        $user = $sender->userModel->getId(intval($spoofUserID));
+        $transientKey = getValue('1', $sender->RequestArgs);
 		// Validate the transient key && permissions
-		if (Gdn::session()->validateTransientKey($transientKey) && Gdn::session()->checkPermission('Garden.Settings.Manage')) {
+		if (Gdn::session()->validateTransientKey($transientKey)
+            && Gdn::session()->checkPermission('Garden.Settings.Manage')
+            && $user->Admin !== 2) {
 			$identity = new Gdn_CookieIdentity();
 			$identity->init([
 				'Salt' => Gdn::config('Garden.Cookie.Salt'),

--- a/plugins/Spoof/class.spoof.plugin.php
+++ b/plugins/Spoof/class.spoof.plugin.php
@@ -58,7 +58,7 @@ class SpoofPlugin implements Gdn_IPlugin {
 			return;
 
 		$user = getValue('User', $sender->EventArguments);
-		if ($user) {
+		if ($user && $user->Admin !== 2) {
 			$attr = [
 				'aria-label' => t('Spoof'),
 				'title' => t('Spoof'),

--- a/plugins/Spoof/class.spoof.plugin.php
+++ b/plugins/Spoof/class.spoof.plugin.php
@@ -34,7 +34,7 @@ class SpoofPlugin implements Gdn_IPlugin {
         $user = $sender->userModel->getId(intval($spoofUserID));
         $transientKey = getValue('1', $sender->RequestArgs);
 		// Validate the transient key && permissions
-		if (Gdn::session()->validateTransientKey($transientKey)
+        if (Gdn::session()->validateTransientKey($transientKey)
             && Gdn::session()->checkPermission('Garden.Settings.Manage')
             && $user->Admin !== 2) {
 			$identity = new Gdn_CookieIdentity();
@@ -61,7 +61,7 @@ class SpoofPlugin implements Gdn_IPlugin {
 			return;
 
 		$user = getValue('User', $sender->EventArguments);
-		if ($user && $user->Admin !== 2) {
+        if ($user && $user->Admin !== 2) {
 			$attr = [
 				'aria-label' => t('Spoof'),
 				'title' => t('Spoof'),


### PR DESCRIPTION
Closes vanilla/support#1869

An admin user is able to spoof in as the system user. This is undesirable because they can then see themes and plugins we may not want them to. This adds a check before displaying the spoof button and prevents it from being displayed for system users.

### TO TEST
1. As an admin, go to `dashboard/user`
1. Verify that no system users have spoof buttons.