### PR TITLE
Filter meta tags with Civil Tongue

### DIFF
--- a/plugins/CivilTongueEx/class.civiltongueex.plugin.php
+++ b/plugins/CivilTongueEx/class.civiltongueex.plugin.php
@@ -566,6 +566,23 @@ class CivilTonguePlugin extends Gdn_Plugin {
     }
 
     /**
+     * Replace dirty words in meta tags, so they won't appear when reposted to facebook, twitter, et al.
+     *
+     * @param HeadModule $sender The head module.
+     */
+    public function headModule_beforeToString_handler($sender) {
+        $tags = $sender->getTags();
+        $newTags = [];
+        foreach ($tags as $tag) {
+            if ($tag['_tag'] === 'meta') {
+                setValue('content', $tag, $this->replace($tag['content']));
+            }
+            $newTags[] = $tag;
+        }
+        $sender->tags($newTags);
+    }
+
+    /**
      * Get the replacement string.
      *
      * @return string


### PR DESCRIPTION
Closes vanilla/support#1461

This PR fixes a problem where meta tags aren't being changed by Civil Tongue, resulting in the bad words reappearing when posts are shared via twitter or facebook. This PR replaces appearances of the bad words in meta tags with the chosen replacement.

### TO TEST
1. Enable Civil Tongue and set up a forbidden word and its replacement.
1. Make a post with the forbidden word.
1. Using dev tools, look at the meta tags and note that the forbidden words appear in the `content` attribute of meta tags.
1. Check out this branch and verify that the words have been replaced.