### PR TITLE
Fix testUnAnsweredQuestionDates test

### DIFF
--- a/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
+++ b/plugins/QnA/tests/APIv2/CommentsAnswerTest.php
@@ -259,7 +259,7 @@ class CommentsAnswerTest extends AbstractAPIv2Test {
         $this->assertEquals(200, $response->getStatusCode());
 
         $body = $response->getBody();
-        $date = new \DateTime($body['dateInserted']);
+        $date = (new \DateTime($body['dateInserted']))->format(DATE_ATOM);
 
         $answeredQuestion = $this->getQuestion($question['discussionID']);
 


### PR DESCRIPTION
Dates in API responses are now strings, not objects. Expecting anything different results in a failed test. That failed test is addressed here.