### PR TITLE
Fix page title in unanswered page

### DIFF
--- a/plugins/QnA/class.qna.plugin.php
+++ b/plugins/QnA/class.qna.plugin.php
@@ -903,6 +903,7 @@ class QnAPlugin extends Gdn_Plugin {
      */
     public function discussionsController_unanswered_create($sender, $args) {
         $sender->View = 'Index';
+        $sender->title(t('Unanswered Questions'));
         $sender->setData('_PagerUrl', 'discussions/unanswered/{Page}');
 
         // Be sure to display every unanswered question (ie from groups)
@@ -988,6 +989,8 @@ class QnAPlugin extends Gdn_Plugin {
             $sender->setData('Announcements', $announcements);
             $sender->AnnounceData = $announcements;
         }
+
+        $sender->setData('Breadcrumbs', [['Name' => t('Unanswered'), 'Url' => '/discussions/unanswered']]);
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1563

**Steps to test:**
- Make sure you have QnA enabled.
- Go to the Unanswered page and notice the page title is "Recent Discussions"
- Checkout this branch and refresh the page