### PR TITLE
Remove the hard-coded cookie prefix from jsConnect

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -1088,7 +1088,7 @@ class JsConnectPlugin extends SSOAddon {
      * @return string
      */
     private function getCSRFCookieName(): string {
-        return c('Garden.Cookie.Name', 'Vanilla') . '-ssostatetoken';
+        return '-ssostatetoken';
     }
 
     /**


### PR DESCRIPTION
Depends on https://github.com/vanilla/vanilla/pull/10674.