### PR TITLE
Add translation strings for NoIndex and Author Selector addons

### DIFF
--- a/plugins/AuthorSelector/locale/en.php
+++ b/plugins/AuthorSelector/locale/en.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+// phpcs:ignoreFile
+
+$Definition['New Author'] = 'New Author';

--- a/plugins/NoIndex/locale/en.php
+++ b/plugins/NoIndex/locale/en.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+// phpcs:ignoreFile
+
+$Definition['Discussion marked as noindex'] = 'Discussion marked as noindex';


### PR DESCRIPTION
Closes vanilla/support#2035.

This PR adds locale files and translation strings for the NoIndex and Author Selector addons.