### PR TITLE
Add ranked permission when getting fingerprint module data

### DIFF
--- a/plugins/TrollManagement/class.sharedfingerprintmodule.php
+++ b/plugins/TrollManagement/class.sharedfingerprintmodule.php
@@ -5,11 +5,10 @@
 class SharedFingerprintModule extends Gdn_Module {
 
 	protected $_Data = FALSE;
-	
+
 	public function getData($fingerprintUserID, $fingerprint) {
-		if (!Gdn::session()->checkPermission('Garden.Users.Edit'))
-			return;
-		
+        if (Gdn::session()->getPermissions()->hasRanked('Garden.Users.Edit') !== true)
+            return;
 		$this->_Data = Gdn::sql()
 			->select()
 			->from('User')
@@ -25,10 +24,10 @@ class SharedFingerprintModule extends Gdn_Module {
 	public function toString() {
       if (!$this->_Data)
 			return;
-      
+
 		if ($this->_Data->numRows() == 0)
 			return;
-		
+
 		ob_start();
 		?>
       <div id="SharedFingerprint" class="Box">


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/2073

**Details**

Currently you need Garden.Moderation.Manage and Garden.Users.Edit to view the Shared Accounts panel.
here 
https://github.com/vanilla/addons/blob/master/plugins/TrollManagement/class.trollmanagement.plugin.php#L195

and here https://github.com/vanilla/addons/blob/master/plugins/TrollManagement/class.sharedfingerprintmodule.php#L10

If we have Garden.Moderation.Manage without Garden.Users.Edit, the module wouldn't display.

**To Test**

- Enable Troll Management
- As a moderator with garden settings manage, test if you can view the Shared Accounts panel