### PR TITLE
Encode settings strings before outputting them

### DIFF
--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -12,24 +12,24 @@ class ShareThisPlugin extends Gdn_Plugin {
    /**
     * Show buttons after OP message body.
     */
-	public function discussionController_afterDiscussionBody_handler($sender) {
-      $publisherNumber = c('Plugin.ShareThis.PublisherNumber', 'Publisher Number');
-      $viaHandle = htmlspecialchars(c('Plugin.ShareThis.ViaHandle', ''));
-      $copyNShare = htmlspecialchars(c('Plugin.ShareThis.CopyNShare', false));
+    public function discussionController_afterDiscussionBody_handler($sender) {
+        $publisherNumber = htmlspecialchars(c('Plugin.ShareThis.PublisherNumber', 'Publisher Number'));
+        $viaHandle = htmlspecialchars(c('Plugin.ShareThis.ViaHandle', ''));
+        $copyNShare = c('Plugin.ShareThis.CopyNShare', false);
 
-      $doNotHash = $copyNShare ? 'false' : 'true';
-      $doNotCopy = $copyNShare ? 'false' : 'true';
-      $domain = Gdn::request()->scheme() == 'https' ? 'https://ws.sharethis.com' : 'http://w.sharethis.com';
+        $doNotHash = $copyNShare ? 'false' : 'true';
+        $doNotCopy = $copyNShare ? 'false' : 'true';
+        $domain = Gdn::request()->scheme() == 'https' ? 'https://ws.sharethis.com' : 'http://w.sharethis.com';
 
-      echo <<<SHARETHIS
-      <script type="text/javascript">var switchTo5x=true;</script>
-      <script type="text/javascript" src="{$domain}/button/buttons.js"></script>
-      <script type="text/javascript">stLight.options({
+        echo <<<SHARETHIS
+        <script type="text/javascript">var switchTo5x=true;</script>
+        <script type="text/javascript" src="{$domain}/button/buttons.js"></script>
+        <script type="text/javascript">stLight.options({
          publisher: "{$publisherNumber}",
          doNotHash: {$doNotHash},
          doNotCopy: {$doNotCopy},
          hashAddressBar: false
-      });</script>
+        });</script>
       <div class="ShareThisButtonWrapper Right">
          <span class="st_twitter_hcount ShareThisButton" st_via="{$viaHandle}" displayText="Tweet"></span>
          <span class="st_facebook_hcount ShareThisButton" displayText="Facebook"></span>
@@ -42,7 +42,7 @@ class ShareThisPlugin extends Gdn_Plugin {
       </div>
 SHARETHIS;
 
-   }
+    }
 
    public function setup() {
       // Nothing to do here!

--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -41,7 +41,6 @@ class ShareThisPlugin extends Gdn_Plugin {
          <span class="st_sharethis_hcount ShareThisButton Hidden" displayText="ShareThis"></span>
       </div>
 SHARETHIS;
-
     }
 
    public function setup() {

--- a/plugins/ShareThis/class.sharethis.plugin.php
+++ b/plugins/ShareThis/class.sharethis.plugin.php
@@ -14,8 +14,8 @@ class ShareThisPlugin extends Gdn_Plugin {
     */
 	public function discussionController_afterDiscussionBody_handler($sender) {
       $publisherNumber = c('Plugin.ShareThis.PublisherNumber', 'Publisher Number');
-      $viaHandle = c('Plugin.ShareThis.ViaHandle', '');
-      $copyNShare = c('Plugin.ShareThis.CopyNShare', false);
+      $viaHandle = htmlspecialchars(c('Plugin.ShareThis.ViaHandle', ''));
+      $copyNShare = htmlspecialchars(c('Plugin.ShareThis.CopyNShare', false));
 
       $doNotHash = $copyNShare ? 'false' : 'true';
       $doNotCopy = $copyNShare ? 'false' : 'true';
@@ -47,7 +47,7 @@ SHARETHIS;
    public function setup() {
       // Nothing to do here!
    }
-   
+
    /**
     * Settings page.
     */


### PR DESCRIPTION
Closes vanilla/vanilla-patches#677

Two parameters that are set by the administrator are not being encoded, making them vulnerable to html injection. This PR runs the strings through the `htmlspecialchars()` method to prevent this.

### TO TEST
1. Enable the ShareThis plugin (make sure to set `hidden` to `false` in the plugin's `addon.json`)
1. In the plugin configuration settings, enter `aaaa"><script>alert(1337)</script>` in both the "Publisher Number" and "via Handle" fields.
1. Navigate to a discussion and note that the alert is triggered.
1. Checkout this branch and navigate to a discussion.
1. Verify that the alert is not triggered.