### PR TITLE
Add discussionSiteMaps toggle, and fix plugin description

### DIFF
--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -187,7 +187,7 @@ class SitemapsPlugin extends Gdn_Plugin {
         $configurationModule = new ConfigurationModule($sender);
         $configurationModule->initialize([
             'Feature.discussionSiteMaps.Enabled' => [
-                'LabelCode' => t('Discussion Based Sitemaps (BETA)'),
+                'LabelCode' => t('Discussion Based Sitemaps', 'Discussion Based Sitemaps (BETA)'),
                 'Control' => 'Toggle',
                 'Description' => t('Use the sitemaps that point directly to discussions instead of categories.'),
             ]]);

--- a/plugins/Sitemaps/class.sitemaps.plugin.php
+++ b/plugins/Sitemaps/class.sitemaps.plugin.php
@@ -121,7 +121,7 @@ class SitemapsPlugin extends Gdn_Plugin {
         $urlCode = $m[1];
         $offset = (int)max($m[2] - 1, 0);
         $limit = (int)min($m[3], 5000);
-        
+
         $category = CategoryModel::categories($urlCode);
         if (!$category || $offset > $category['countDiscussions']) {
             throw notFoundException();
@@ -183,6 +183,15 @@ class SitemapsPlugin extends Gdn_Plugin {
         $sender->setData('Title', t('Sitemap Settings'));
         $sender->setData('isSitePrivate', $this->isSitePrivate);
         $sender->addSideMenu();
+
+        $configurationModule = new ConfigurationModule($sender);
+        $configurationModule->initialize([
+            'Feature.discussionSiteMaps.Enabled' => [
+                'LabelCode' => t('Discussion Based Sitemaps (BETA)'),
+                'Control' => 'Toggle',
+                'Description' => t('Use the sitemaps that point directly to discussions instead of categories.'),
+            ]]);
+        $sender->setData('ConfigurationModule', $configurationModule);
         $sender->render('Settings', '', 'plugins/Sitemaps');
     }
 
@@ -311,7 +320,7 @@ class SitemapsPlugin extends Gdn_Plugin {
         $sender->deliveryMethod(DELIVERY_METHOD_XHTML);
         $sender->deliveryType(DELIVERY_TYPE_VIEW);
         $sender->setHeader('Content-Type', 'text/xml');
-        
+
         $filename = $args[0] ?? '';
         if (substr($filename, -4) === '.xml') {
             $filename = substr($filename, 0, -4);

--- a/plugins/Sitemaps/views/settings.twig
+++ b/plugins/Sitemaps/views/settings.twig
@@ -2,7 +2,7 @@
 <div class="padded content">
     {% if isSitePrivate %}
        <p class="Message AlertMessage">
-         Private Communities is currently enabled. Sitemaps are not recommended with Private Communities unless you know what you're doing.
+         Private communities are currently enabled. Sitemaps are not recommended with private communities unless you know what you're doing.
       </p>
     {% endif %}
       <p>

--- a/plugins/Sitemaps/views/settings.twig
+++ b/plugins/Sitemaps/views/settings.twig
@@ -1,14 +1,13 @@
 <h1>{{Title}}</h1>
-<div class="padded">
+<div class="padded content">
     {% if isSitePrivate %}
-    <p class="Message AlertMessage">
-        Private Communities is currently enabled. Sitemaps are not recommended with Private Communities unless you know what you're doing.
-    </p>
+       <p class="Message AlertMessage">
+         Private Communities is currently enabled. Sitemaps are not recommended with Private Communities unless you know what you're doing.
+      </p>
     {% endif %}
-    <p>
-        A site map is an <a href="http://en.wikipedia.org/wiki/XML" target="_blank" rel="noopener">xml</a> file that search engines can use to help index your site.
-    </p>
-    <p>
+      <p>
+         A site map is an xml file that search engines can use to help index your site. Learn more about sitemaps at <a href="https://sitemaps.org" target="_blank" rel="noopener">sitemaps.org.</a>
+      </p>
     <ul>
         <li>
             Your main site map is located here: <a href="{{url('/sitemapindex.xml', true)}}">
@@ -20,14 +19,5 @@
             site map so that search engines that are aware of your site will know where to look.
         </li>
     </ul>
-    </p>
-    <p>{{t('Learn more about sitemaps from the following sites:')}}</p>
-    <ul>
-        <li>
-            <a href="https://www.sitemaps.org/" target="_blank" rel="noopener">sitemaps.org</a>
-        </li>
-        <li>
-            <a href="https://www.google.com/webmasters/" target="_blank" rel="noopener">Google webmaster center</a>
-        </li>
-    </ul>
+   {{ ConfigurationModule.render()|raw }}
 </div>


### PR DESCRIPTION
closes https://github.com/vanilla/addons/issues/817

**To Test**

- Check the description in the referenced ticket.
- Test the toggle, it should set ['Feature']['discussionSiteMaps']['Enabled']
- Enable private community, check the settings page description.

