### PR TITLE
Remove the extra subcommunity folder from the JSConnect redirect.

### DIFF
--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -62,8 +62,8 @@ class JsConnectPlugin extends SSOAddon {
             $target = '/';
         }
 
-        $baseURL = url('/entry/jsconnect-redirect');
-        return $baseURL . '?' . http_build_query([
+        $redictPath = '/entry/jsconnect-redirect';
+        return $redictPath . '?' . http_build_query([
                 'client_id' => $provider[self::FIELD_PROVIDER_CLIENT_ID],
                 'target' => $target
             ]);

--- a/plugins/jsconnect/class.jsconnect.plugin.php
+++ b/plugins/jsconnect/class.jsconnect.plugin.php
@@ -203,7 +203,7 @@ class JsConnectPlugin extends SSOAddon {
             $target = '/';
         }
 
-        $url = url('/entry/jsconnect-redirect').'?'.http_build_query([
+        $redictPath = '/entry/jsconnect-redirect'.'?'.http_build_query([
             'client_id' => $provider[self::FIELD_PROVIDER_CLIENT_ID],
             'target' => $target
         ]);
@@ -211,7 +211,7 @@ class JsConnectPlugin extends SSOAddon {
         $result = '<div class="JsConnect-Guest">'.
             anchor(
                 sprintf(t('Sign In with %s'), $provider['Name']),
-                $url,
+                $redictPath,
                 'Button Primary SignInLink'
             ).
             '</div>';


### PR DESCRIPTION
This PR will close vanilla/support#2154

This commit https://github.com/vanilla/addons/commit/9f4e3eed21d1438f32a5ac2d307d669de787fe97 wrapped the redirect URL that we use to give users the State token before redirecting them to the authentication provider during JSConnect connections with the `url()` function which added the subfolder where it originated. Unfortunately we pass that URL through the same function later so that sub-communities wind up with double sub-community folders (ie.`https://myformum.com/en/en/entry/jsconnect`).

This PR will fix that.

### Testing
 - Turn on Sub-communities.
 - Turn on JSconnect configured for V3
 - Configure `$Configuration['Garden']['SignIn']['Popup'] = false;`
 - Click Sign In, see that you get redirected to yourdomain.com/subccommunity/subcommunity/entry... which is wrong
 - Checkout this branch.
 - Repeat.