### PR TITLE
Fix mismatch between unignore translation codes.

### DIFF
--- a/plugins/Ignore/locale/en.php
+++ b/plugins/Ignore/locale/en.php
@@ -5,6 +5,7 @@
  * @license GPL-2.0-only
  */
 
+$Definition['Are you sure you want to unignore %s?'] = 'Are you sure you want to unignore <b>%s</b>?';
 $Definition['IgnoreListMeter'] = 'Ignore list is <b>%s%%</b> full (<b>%d/%d</b>).';
 $Definition['IgnoreListRevoke'] = 'Revoke <b>%s</b>\'s ignore list privileges?';
 $Definition['IgnoreListUnlimited'] = '<b>Unlimited</b> list, ignored <b>%d</b> %s';

--- a/plugins/Ignore/views/confirm.php
+++ b/plugins/Ignore/views/confirm.php
@@ -9,7 +9,7 @@ echo $this->Form->errors();
 switch ($this->data('Mode')) {
    case 'set':
       echo '<div class="P">'.sprintf(t('Are you sure you want to ignore <b>%s</b>?'), htmlspecialchars($this->data('User.Name'))).'</div>';
-      
+
       if ($this->data('Conversations')) {
          $Conversations = (array)$this->data('Conversations');
          $NumConversationsAffected = count($Conversations);
@@ -17,11 +17,11 @@ switch ($this->data('Mode')) {
          echo sprintf(t('Ignoring this person will remove you from <b>%s %s</b> with them.'), $NumConversationsAffected, plural($NumConversationsAffected, 'conversation', 'conversations'));
          echo '</div>';
       }
-      
+
       break;
-   
+
    case 'unset':
-      echo '<div class="P">'.sprintf(t('Are you sure you want to unignore <b>%s</b>?'), htmlspecialchars($this->data('User.Name'))).'</div>';
+      echo '<div class="P">'.sprintf(t('Are you sure you want to unignore %s?'), htmlspecialchars($this->data('User.Name'))).'</div>';
       break;
 }
 


### PR DESCRIPTION
Closes vanilla/support#2122

This PR fixes a problem where a string in the "Ignore" addon was not getting translated because there was a mismatch between the code in the `t()` call and the code in transifex. This fixes changes the string in the call to match what's in transifex.

### TO TEST
1. Enable the "Ignore" plugin.
1. Set the forum language to Italian or French.
1. Ignore someone, then "unignore" them.
1. Note that the unignore text is not translated, but reads "Are you sure you want to unignore {whomever}?"
1. Check out this branch and repeat steps 3 and 4, but note that the text is now translated.