### PR TITLE
Fix cookies leaking when adding feed

### DIFF
--- a/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
+++ b/plugins/FeedDiscussions/class.feeddiscussions.plugin.php
@@ -194,7 +194,8 @@ class FeedDiscussionsPlugin extends Gdn_Plugin {
                 // Check feed is valid RSS:
                 $pr = new ProxyRequest();
                 $feedRSS = $pr->request([
-                    'URL' => $feedURL
+                    'URL' => $feedURL,
+                    'Cookies' => false
                 ]);
 
                 if (!$feedRSS) {
@@ -281,7 +282,8 @@ class FeedDiscussionsPlugin extends Gdn_Plugin {
     protected function pollFeed($feedURL, $lastImportDate) {
         $pr = new ProxyRequest();
         $feedRSS = $pr->request([
-            'URL' => $feedURL
+            'URL' => $feedURL,
+            'Cookies' => false
         ]);
 
         if (!$feedRSS) {


### PR DESCRIPTION
Closes vanilla/vanilla-patches#684

Cookies are being sent in the proxy request when an admin adds an RSS feed using the "FeedDiscussions" plugin, which is a security risk. This PR changes the request call so that it does not include cookies.

### TO TEST
1. Enable the "Feed Discussions" plugin.
1. Check out this branch
1. Put a breakpoint [here](https://github.com/vanilla/vanilla/blob/1ddcad8a6732f3a24829be5fc395aebafe0a2330/library/core/class.proxyrequest.php#L464).
1. With Xdebug on, add an RSS feed.
1. Verify that the contents of the if-statement are skipped.