### PR TITLE
Remove deleted user from ignore lists

### DIFF
--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -713,7 +713,7 @@ class IgnorePlugin extends Gdn_Plugin {
    }
 
     /**
-     * If a user is being deleting, remove them from other users' ignore lists.
+     * If a user is being deleted, remove them from other users' ignore lists.
      *
      * @param UserController $sender
      */

--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -712,4 +712,19 @@ class IgnorePlugin extends Gdn_Plugin {
       return $commonConversationIDs;
    }
 
+    /**
+     * If a user is being deleting, remove them from other users' ignore lists.
+     *
+     * @param UserController $sender
+     */
+    public function userController_beforeUserDelete_handler($sender) {
+        $userID = $sender->ReflectArgs['userID'];
+        $requestBody = $sender->Request->getBody();
+        $deleting = $requestBody['Delete_User_Forever'];
+        $content = [];
+        if ($deleting === "Delete User Forever") {
+            $sender->userModel->getDelete('UserMeta', ['Name' => 'Plugin.Ignore.Blocked.User.'.$userID], $content);
+        }
+    }
+
 }


### PR DESCRIPTION
Closes vanilla/support#2241

Currently, when a user is deleted, if that user is on anyone's ignore list, their name changes to "[Deleted User]" and they can no longer be removed from the list because there's no longer a user in the db. This PR fixes that problem by removing a user from all ignore lists before deleting the user.

### TO TEST
1. As an admin, create a user and ignore the user.
1. Delete the user and view your ignore list.
1. Note that you now have "[Deleted User]" on your ignore list and cannot unignore them.
1. Check out this branch and repeat steps 1 and 2.
1. Note that neither the user nor "[Deleted User]" is on your ignore list.