### PR TITLE
Allow deleted users to be removed from Ignore list

### DIFF
--- a/plugins/Ignore/class.ignore.plugin.php
+++ b/plugins/Ignore/class.ignore.plugin.php
@@ -558,8 +558,6 @@ class IgnorePlugin extends Gdn_Plugin {
 
       if ($user === FALSE) {
          throw notFoundException();
-      } else if ($user->Deleted == 1) {
-         throw notFoundException();
       } else if (getValue('UserID', $user) == Gdn::session()->UserID) {
          throw notFoundException();
       } else {


### PR DESCRIPTION
Closes vanilla/support#2241

Currently, if a user who has been deleted is on another user's ignore list, the ignoring user cannot remove the deleted user from the list. This PR allows deleted users to be removed from ignore lists.

### TO TEST
1. As an admin, create a user and ignore the user.
1. Delete the user and view your Ignore list.
1. Note that you now have "[Deleted User]" on your ignore list and cannot unignore them.
1. Check out this branch and try to unignore them again.
1. Note that this time it works.