### PR TITLE
Validate tk on "/resolve" endpoint

### DIFF
--- a/plugins/Resolved/class.resolved.plugin.php
+++ b/plugins/Resolved/class.resolved.plugin.php
@@ -137,9 +137,10 @@ class ResolvedPlugin extends Gdn_Plugin {
                 throw new Exception(t('You do not have a permission to resolve that discussion.'));
             }
         }
+
         // Make sure we are posting back.
-        if (!$sender->Request->isPostBack()) {
-            throw permissionException('Javascript');
+        if (!$sender->Request->isAuthenticatedPostBack(true)) {
+            throw new Exception('Requires POST', 405);
         }
 
         $discussion = $sender->DiscussionModel->getID($discussionID);


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla-patches/issues/717

**Steps to test:**
- Enable the "Resolved Discussions" addon (not v2).
- Choose a discussiond from your local that can be resolved. Get the discussion ID.
- Comment the following lines:
  - https://github.com/vanilla/addons/blob/0ed459ca14a8c764046c2e859cc248044e54b3c4/plugins/Resolved/class.resolved.plugin.php#L129
  - https://github.com/vanilla/addons/blob/0ed459ca14a8c764046c2e859cc248044e54b3c4/plugins/Resolved/class.resolved.plugin.php#L133 (the whole block)
(This way, validation is purely based on the transient key)
- As a guest, make a post to resolve the discussion, you can use the code below for the request:
```
(function () {
    var endpoint = (new URL(document.location)).origin + "/discussion/resolve?discussionID={DiscussionID}&resolve=0";
    var requestBody = JSON.stringify({
  htp: "",
  DeliveryType: "VIEW",
  DeliveryMethod: "JSON",
  Type: "Post",
});
    var request = new XMLHttpRequest();
    request.open("POST", endpoint);
    request.setRequestHeader("Content-Type", "application/json");
    request.send(requestBody);
}());
```
- Observe that the request worked but it shouldn't. You should've been stopped by TK validation.
- Checkout this branch and try performing the request above again, you should get a 403 error.
- Don't forget to uncomment the permissions gates :)