### PR TITLE
Add ban by Fingerprint to the Troll management plugin

### DIFF
--- a/plugins/TrollManagement/TrollManagementTest.php
+++ b/plugins/TrollManagement/TrollManagementTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author David Barbier<david.barbier@vanillaforums.com>
+ * @copyright 2009-2021 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\TrollManagement;
+
+use UserModel;
+use RoleModel;
+use VanillaTests\Models\UserModelTest;
+use VanillaTests\SetupTraitsTrait;
+
+/**
+ * Class TrollManagementTest
+ */
+class TrollManagementTest extends UserModelTest {
+    use SetupTraitsTrait;
+
+    /** @var UserModel */
+    protected $userModel;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+    }
+
+    /**
+     * Setup routine, run before the test class is instantiated.
+     */
+    public static function setupBeforeClass(): void {
+        self::$addons = ['vanilla', 'trollmanagement'];
+
+        parent::setupBeforeClass();
+    }
+
+    /**
+     * Tests the automatic assignment of the "applicant" status to a new user registration if the maximum amount of
+     * user accounts sharing the same fingerprint is reached.
+     */
+    public function testRegisterApplicant(): void {
+        /** @var \Gdn_Configuration $configuration */
+        $configuration = static::container()->get('Config');
+
+        $configuration->set('TrollManagement.PerFingerPrint.Enabled', true);
+        $configuration->set('TrollManagement.PerFingerPrint.MaxUserAccounts', 3);
+
+        // Ensure all future registered dummy users uses the same fingerprint.
+        $_COOKIE['__vnf'] = 'THISISAFAKEFINGERPRINT';
+
+        // Create 3 dummy accounts. (The third should be automatically set as "applicant")
+        $importedUsers[] = $this->insertDummyUser();
+        $importedUsers[] = $this->insertDummyUser();
+        $importedUsers[] = $this->insertDummyUser();
+
+        // We pull the associated user's roles.
+        foreach ($importedUsers as $importedUser) {
+            $importedUsersRolesIDs[] = $this->userModel->getRoleIDs($importedUser['UserID'])/*->resultArray()*/;
+        }
+
+        // The FIRST dummy user account is NOT an applicant
+        $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['0']);
+        // The SECOND dummy user account is NOT an applicant
+        $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['1']);
+        // The THIRD dummy user account is NOT an applicant
+        $this->assertContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['2']);
+     }
+}

--- a/plugins/TrollManagement/TrollManagementTest.php
+++ b/plugins/TrollManagement/TrollManagementTest.php
@@ -67,5 +67,5 @@ class TrollManagementTest extends UserModelTest {
         $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['1']);
         // The THIRD dummy user account is NOT an applicant
         $this->assertContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['2']);
-     }
+    }
 }

--- a/plugins/TrollManagement/addon.json
+++ b/plugins/TrollManagement/addon.json
@@ -1,8 +1,9 @@
 {
     "name": "Troll Management",
     "description": "Allows you to mark users as trolls, making it so that only they can see their comments & discussions. They essentially become invisible to other users and eventually just leave because no-one responds to them.",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "mobileFriendly": true,
+    "settingsUrl": "/settings/trollmanagement",
     "icon": "troll_management.png",
     "key": "trollmanagement",
     "type": "addon",
@@ -10,6 +11,11 @@
         {
             "name": "Mark O'Sullivan",
             "email": "mark@vanillaforums.com",
+            "homepage": "http://vanillaforums.com"
+        },
+        {
+            "name": "David Barbier",
+            "email": "david.barbier@vanillaforums.com",
             "homepage": "http://vanillaforums.com"
         }
     ],

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -35,11 +35,22 @@ class TrollManagementPlugin extends Gdn_Plugin {
     private $session;
 
     /**
+     * @var UserModel
+     */
+    private $userModel;
+
+    /**
      * TrollManagementPlugin constructor.
      *
      * @param Gdn_Session $session Injected session.
      */
-    public function __construct(Gdn_Session $session) {
+    public function __construct(Gdn_Session $session, UserModel $userModel = null) {
+        if ($userModel === null) {
+            $this->userModel = Gdn::getContainer()->get(UserModel::class);
+        } else {
+            $this->userModel = $userModel;
+        }
+
         parent::__construct();
         $this->session = $session;
     }
@@ -578,15 +589,12 @@ class TrollManagementPlugin extends Gdn_Plugin {
             return false;
         }
 
-        $sql = clone Gdn::sql();
-        $sql->reset();
-        $users = $sql
+        $usersCount = $this->userModel->SQL
             ->select('userID')
             ->from('User')
             ->where('Fingerprint', $fingerprint)
-            ->limit($maxSiblingAccounts)
-            ->get()->resultArray();
-        return (count($users) == $maxSiblingAccounts);
+            ->limit($maxSiblingAccounts)->get()->numRows();
+        return ($usersCount == $maxSiblingAccounts);
     }
 
     /**

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -76,9 +76,6 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * On plugin disable.
      */
     public function onDisable() {
-        // TODO: Ask Ryan about best practices here.
-        // TODO: Ban records that uses the BanType "Fingerprint"
-        // TODO: Remove "Fingerprint" from the table's Bantype enum.
     }
 
     /**

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -669,13 +669,11 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Add "Fingerprint" to the dashboard's users list search query.
      *
-     * @param array $like
+     * @param array $whereCriterias
      * @param string $keywords
      * @return array
      */
-    public function userModel_searchKeyWords_handler(array $like, string $keywords): array {
-        $whereCriterias = [];
-
+    public function userModel_searchKeyWords_handler(array $whereCriterias, string $keywords): array {
         $whereCriterias['where']['u.Fingerprint'] = $keywords;
 
         return $whereCriterias;

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -173,17 +173,13 @@ class TrollManagementPlugin extends Gdn_Plugin {
 
         // If the cookie exists...
         if (!empty($cookieFingerprint)) {
-
             // If the cookie disagrees with the database, update the database
             if ($databaseFingerprint != $cookieFingerprint) {
                 Gdn::sql()->update('User', ['Fingerprint' => $cookieFingerprint], ['UserID' => $userID])->put();
                 return $cookieFingerprint;
             }
-
-            // If only the user record exists, propagate it to the cookie
         } else if (!empty($databaseFingerprint)) {
-
-            // Propagate it to the cookie
+            // If only the user record exists, propagate it to the cookie
             safeCookie('__vnf', $databaseFingerprint, $expires);
             return $databaseFingerprint;
         }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -160,7 +160,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Set a fingerprint to the user. See setFingerPrint();
+     * Set a fingerprint to the user. See setFingerprint();
      *
      * @param Gdn_Controller $sender
      */
@@ -523,8 +523,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
         $configurationModel = new Gdn_ConfigurationModel($validation);
 
         $configurationModel->setField([
-            'TrollManagement.PerFingerPrint.Enabled' => c('TrollManagement.PerFingerPrint.Enabled', false),
-            'TrollManagement.PerFingerPrint.MaxUserAccounts' => c('TrollManagement.PerFingerPrint.MaxUserAccounts', 5),
+            'TrollManagement.PerFingerPrint.Enabled' => c('TrollManagement.PerFingerprint.Enabled', false),
+            'TrollManagement.PerFingerPrint.MaxUserAccounts' => c('TrollManagement.PerFingerprint.MaxUserAccounts', 5),
         ]);
 
         $sender->Form->setModel($configurationModel);
@@ -533,16 +533,16 @@ class TrollManagementPlugin extends Gdn_Plugin {
         if ($sender->Form->authenticatedPostBack() === false) {
             $sender->Form->setData($configurationModel->Data);
         } else {
-            $configurationModel->Validation->applyRule('TrollManagement.PerFingerPrint.Enabled', 'Boolean');
+            $configurationModel->Validation->applyRule('TrollManagement.PerFingerprint.Enabled', 'Boolean');
 
-            if ($sender->Form->getFormValue('TrollManagement.PerFingerPrint.Enabled')) {
+            if ($sender->Form->getFormValue('TrollManagement.PerFingerprint.Enabled')) {
                 //add custom validation rule
                 $configurationModel->Validation->addRule('validatePositiveNumber', 'function:validatePositiveNumber');
 
-                $configurationModel->Validation->applyRule('TrollManagement.PerFingerPrint.MaxUserAccounts', 'Required');
-                $configurationModel->Validation->applyRule('TrollManagement.PerFingerPrint.MaxUserAccounts', 'Integer');
+                $configurationModel->Validation->applyRule('TrollManagement.PerFingerprint.MaxUserAccounts', 'Required');
+                $configurationModel->Validation->applyRule('TrollManagement.PerFingerprint.MaxUserAccounts', 'Integer');
                 $configurationModel->Validation->applyRule(
-                    'TrollManagement.PerFingerPrint.MaxUserAccounts',
+                    'TrollManagement.PerFingerprint.MaxUserAccounts',
                     'validatePositiveNumber',
                     sprintf(t('%s must be a positive number.'), t("Maximum user's accounts"))
                 );
@@ -564,8 +564,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param array $args
      */
     public function base_applicantInfo_handler($sender, $args) {
-        if (c('TrollManagement.PerFingerPrint.Enabled', false)) {
-            $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
+        if (c('TrollManagement.PerFingerprint.Enabled', false)) {
+            $maxSiblingAccounts = c('TrollManagement.PerFingerprint.MaxUserAccounts');
             $userFingerprint = $args['User']['Fingerprint'] ?? '';
             if (!empty($userFingerprint)) {
                 if ($this->checkMaxSharedFingerprintsExceeded($userFingerprint, $maxSiblingAccounts)) {
@@ -585,7 +585,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param int $maxSiblingAccounts
      * @return bool
      */
-    private function checkMaxSharedFingerprintsExceeded(string $fingerprint, int $maxSiblingAccounts): bool {
+    private function checkMaxSharedFingerprintsExceeded(?string $fingerprint, int $maxSiblingAccounts): bool {
         if (is_null($fingerprint)) {
             return false;
         }
@@ -594,8 +594,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
             ->select('userID')
             ->from('User')
             ->where('Fingerprint', $fingerprint)
-            ->limit($maxSiblingAccounts)->get()->numRows();
-        return ($usersCount == $maxSiblingAccounts);
+            ->limit($maxSiblingAccounts + 1)->get()->numRows();
+        return ($usersCount > $maxSiblingAccounts);
     }
 
     /**
@@ -610,8 +610,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
         $userID = $args['UserID'];
         $userFingerprint = $this->setFingerprint($userID);
 
-        if (c('TrollManagement.PerFingerPrint.Enabled', false) == true) {
-            $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
+        if (c('TrollManagement.PerFingerprint.Enabled', false) == true) {
+            $maxSiblingAccounts = c('TrollManagement.PerFingerprint.MaxUserAccounts');
             if ($userFingerprint !== false) {
                 if ($this->checkMaxSharedFingerprintsExceeded($userFingerprint, $maxSiblingAccounts)) {
                     Gdn::userModel()->addRoles($userID, [RoleModel::APPLICANT_ID], true);

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -462,7 +462,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param DiscussionModel $sender
      * @param array $args
      */
-    public function discussionModel_BeforeNotification_handler(DiscussionModel $sender, array &$args) {
+    public function discussionModel_BeforeNotification_handler(DiscussionModel $sender, array $args) {
         $discussion = $args['Discussion'];
         $this->checkTroll($discussion['InsertUserID'], $args);
     }
@@ -473,7 +473,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param CommentModel $sender
      * @param array $args
      */
-    public function commentModel_BeforeNotification_handler(CommentModel $sender, array &$args) {
+    public function commentModel_BeforeNotification_handler(CommentModel $sender, array $args) {
         $comment = $args['Comment'];
         $this->checkTroll($comment['InsertUserID'], $args);
     }
@@ -484,7 +484,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param ActivityModel $sender
      * @param array $args
      */
-    public function activityModel_beforeWallNotificationSend_handler(ActivityModel $sender, array &$args) {
+    public function activityModel_beforeWallNotificationSend_handler(ActivityModel $sender, array $args) {
         $activity = $args['Activity'];
         $this->checkTroll($activity['ActivityUserID'], $args);
     }
@@ -500,7 +500,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
             return;
         }
         $userModel = $args['UserModel'];
-        $user = $userModel->get($userID);
+        $user = $userModel->getID($userID);
         if ($user && $user->Troll === 1) {
             $args['IsValid'] = false;
         }
@@ -590,11 +590,13 @@ class TrollManagementPlugin extends Gdn_Plugin {
             return false;
         }
 
-        $usersCount = $this->userModel->SQL
-            ->select('userID')
-            ->from('User')
-            ->where('Fingerprint', $fingerprint)
-            ->limit($maxSiblingAccounts + 1)->get()->numRows();
+        $usersCount = $this->userModel->getWhere(
+            ['Fingerprint' => $fingerprint],
+            '',
+            '',
+            $maxSiblingAccounts + 1)
+            ->numRows();
+
         return ($usersCount > $maxSiblingAccounts);
     }
 
@@ -689,17 +691,5 @@ class TrollManagementPlugin extends Gdn_Plugin {
     public function userController_usersListAllowedSorting(array $allowedSorting): array {
         $allowedSorting['Fingerprint'] = 'desc';
         return $allowedSorting;
-    }
-}
-
-if (!function_exists('validatePositiveNumber')) {
-    /**
-     * Validate if number is positive
-     *
-     * @param int|string $number
-     * @return bool
-     */
-    function validatePositiveNumber($number): bool {
-        return (is_numeric($number) && (int)$number > 0);
     }
 }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -462,7 +462,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param DiscussionModel $sender
      * @param array $args
      */
-    public function discussionModel_BeforeNotification_handler(DiscussionModel $sender, array $args) {
+    public function discussionModel_BeforeNotification_handler($sender, $args) {
         $discussion = $args['Discussion'];
         $this->checkTroll($discussion['InsertUserID'], $args);
     }
@@ -473,7 +473,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param CommentModel $sender
      * @param array $args
      */
-    public function commentModel_BeforeNotification_handler(CommentModel $sender, array $args) {
+    public function commentModel_BeforeNotification_handler($sender, $args) {
         $comment = $args['Comment'];
         $this->checkTroll($comment['InsertUserID'], $args);
     }
@@ -594,8 +594,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
             ['Fingerprint' => $fingerprint],
             '',
             '',
-            $maxSiblingAccounts + 1)
-            ->numRows();
+            $maxSiblingAccounts + 1
+        )->numRows();
 
         return ($usersCount > $maxSiblingAccounts);
     }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -541,7 +541,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
             }
         }
 
-        $sender->render($this->getView('configuration.php'));
+        $sender->render('configuration', '', 'plugins/TrollManagement');
     }
 
     /**

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -462,7 +462,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param DiscussionModel $sender
      * @param array $args
      */
-    public function discussionModel_BeforeNotification_handler($sender, $args) {
+    public function discussionModel_beforeNotification_handler($sender, $args) {
         $discussion = $args['Discussion'];
         $this->checkTroll($discussion['InsertUserID'], $args);
     }
@@ -473,7 +473,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param CommentModel $sender
      * @param array $args
      */
-    public function commentModel_BeforeNotification_handler($sender, $args) {
+    public function commentModel_beforeNotification_handler($sender, $args) {
         $comment = $args['Comment'];
         $this->checkTroll($comment['InsertUserID'], $args);
     }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -665,7 +665,6 @@ class TrollManagementPlugin extends Gdn_Plugin {
     public function userModel_searchKeyWords_handler(array $like, string $keywords): array {
         $whereCriterias = [];
 
-//        $whereCriterias['like'] = $like;
         $whereCriterias['where']['u.Fingerprint'] = $keywords;
 
         return $whereCriterias;

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -664,4 +664,14 @@ class TrollManagementPlugin extends Gdn_Plugin {
         return $like;
     }
 
+    /**
+     * Add ordering users by Fingerprint in the dashboard's users list.
+     *
+     * @param array $allowedSorting
+     * @return array
+     */
+    public function userController_usersListAllowedSorting(array $allowedSorting): array {
+        $allowedSorting['Fingerprint'] = 'desc';
+        return $allowedSorting;
+    }
 }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -600,15 +600,17 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param array $args
      */
     public function userModel_afterRegister_handler($sender, $args) {
-        $userID = $args['UserID'];
+        if (c('TrollManagement.PerFingerPrint.Enabled', false) == true) {
+            $userID = $args['UserID'];
 
-        $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
-        $userFingerprint = $this->setFingerprint($userID);
+            $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
+            $userFingerprint = $this->setFingerprint($userID);
 
-        if ($userFingerprint !== false) {
-            $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
-            if ($fingerprintUsages >= $maxSiblingAccounts) {
-                Gdn::userModel()->addRoles($userID, [RoleModel::APPLICANT_ID], true);
+            if ($userFingerprint !== false) {
+                $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
+                if ($fingerprintUsages >= $maxSiblingAccounts) {
+                    Gdn::userModel()->addRoles($userID, [RoleModel::APPLICANT_ID], true);
+                }
             }
         }
     }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -462,7 +462,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param DiscussionModel $sender
      * @param array $args
      */
-    public function discussionModel_beforeNotification_handler($sender, $args) {
+    public function discussionModel_BeforeNotification_handler(DiscussionModel $sender, array &$args) {
         $discussion = $args['Discussion'];
         $this->checkTroll($discussion['InsertUserID'], $args);
     }
@@ -473,7 +473,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param CommentModel $sender
      * @param array $args
      */
-    public function commentModel_beforeNotification_handler($sender, $args) {
+    public function commentModel_BeforeNotification_handler(CommentModel $sender, array &$args) {
         $comment = $args['Comment'];
         $this->checkTroll($comment['InsertUserID'], $args);
     }
@@ -484,7 +484,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param ActivityModel $sender
      * @param array $args
      */
-    public function activityModel_beforeWallNotificationSend_handler(ActivityModel $sender, array $args) {
+    public function activityModel_beforeWallNotificationSend_handler(ActivityModel $sender, array &$args) {
         $activity = $args['Activity'];
         $this->checkTroll($activity['ActivityUserID'], $args);
     }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -663,8 +663,12 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @return array
      */
     public function userModel_searchKeyWords_handler(array $like, string $keywords): array {
-        $like['u.Fingerprint'] = $keywords;
-        return $like;
+        $whereCriterias = [];
+
+//        $whereCriterias['like'] = $like;
+        $whereCriterias['where']['u.Fingerprint'] = $keywords;
+
+        return $whereCriterias;
     }
 
     /**

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -39,14 +39,11 @@ class TrollManagementPlugin extends Gdn_Plugin {
      */
     private $userModel;
 
-
     /**
      * TrollManagementPlugin constructor.
      *
      * @param Gdn_Session $session Injected session.
      * @param UserModel|null $userModel
-     * @throws ContainerException
-     * @throws NotFoundException
      */
     public function __construct(Gdn_Session $session, UserModel $userModel = null) {
         if ($userModel === null) {
@@ -569,7 +566,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     public function base_applicantInfo_handler($sender, $args) {
         if (c('TrollManagement.PerFingerPrint.Enabled', false)) {
             $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
-            $userFingerprint = val('Fingerprint', $args['User'], '');
+            $userFingerprint = $args['User']['Fingerprint'] ?? '';
             if (!empty($userFingerprint)) {
                 if ($this->checkMaxSharedFingerprintsExceeded($userFingerprint, $maxSiblingAccounts)) {
                     $sender->EventArguments['ApplicantMeta'][t("Fingerprint issue")] = sprintf(

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -574,17 +574,21 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Return a count of users using the same provided fingerprint.
      *
-     * @param string $fingerprint
+     * @param null|string $fingerprint
+     * @return int
      */
-    public function getSharedFingerprintsUsersCount(string $fingerprint) {
-        $sql = clone Gdn::sql();
-        $sql->reset();
-        $users = $sql
-            ->select('userID AS siblingsCount', 'count')
-            ->from('User')
-            ->where('Fingerprint', $fingerprint)
-            ->get()->firstRow(DATASET_TYPE_ARRAY);
-        return $users['siblingsCount'];
+    public function getSharedFingerprintsUsersCount($fingerprint): int {
+        if (!is_null($fingerprint)) {
+            $sql = clone Gdn::sql();
+            $sql->reset();
+            $users = $sql
+                ->select('userID AS siblingsCount', 'count')
+                ->from('User')
+                ->where('Fingerprint', $fingerprint)
+                ->get()->firstRow(DATASET_TYPE_ARRAY);
+            return $users['siblingsCount'];
+        }
+        return 0;
     }
 
     /**

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -483,7 +483,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Create a method called "QnA" on the SettingController.
+     * Add a configuration popup to the Troll Management plugin.
      *
      * @param $sender Sending controller instance
      */

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -155,7 +155,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Set a fingerprint the user. See setFingerPrint();
+     * Set a fingerprint to the user. See setFingerPrint();
      *
      * @param Gdn_Controller $sender
      */

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -503,7 +503,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Add a configuration popup to the Troll Management plugin.
      *
-     * @param $sender Sending controller instance
+     * @param Controller $sender
      */
     public function settingsController_trollManagement_create($sender) {
         // Prevent non-admins from accessing this page
@@ -552,6 +552,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * accounts using the same fingerprint.
      *
      * @param Controller $sender
+     * @param array $args
      */
     public function base_applicantInfo_handler($sender, $args) {
         if (c('TrollManagement.PerFingerPrint.Enabled', false)) {
@@ -618,10 +619,10 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Either add "Fingerprint" row header or an fingerprint value to the dashboard's list of users.
      *
-     * @param $sender
-     * @param $args
+     * @param Controller $sender
+     * @param array $args
      */
-    public function base_UserCell_handler($sender, $args) {
+    public function base_userCell_handler($sender, $args) {
         // If we have user data, we create a cell containing the fingerprint.
         if (isset($args['User'])) {
             echo '<td>' . val('Fingerprint', $args['User']) . '</td>';

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -171,8 +171,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
      *
      * @param int|null $userID
      * @return string Fingerprint
-     * @throws ContainerException
-     * @throws NotFoundException
+     * @throws ContainerException Throws exception if there's a problem getting a container.
+     * @throws NotFoundException Throws exception if there's a problem getting a container.
      */
     private function setFingerprint($userID = null): string {
         $userID = $userID ?? Gdn::session()->UserID;
@@ -643,7 +643,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param array $ban
      * @return array
      */
-    public function banModel_banWhere(array $result, array $ban): array {
+    public function banModel_banWhere_handler(array $result, array $ban): array {
         switch (strtolower($ban['BanType'])) {
             case 'fingerprint':
                 $result['u.Fingerprint like'] = $ban['BanValue'];
@@ -659,7 +659,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * @param string $keywords
      * @return array
      */
-    public function userModel_searchKeyWords(array $like, string $keywords): array {
+    public function userModel_searchKeyWords_handler(array $like, string $keywords): array {
         $like['u.Fingerprint'] = $keywords;
         return $like;
     }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -55,20 +55,22 @@ class TrollManagementPlugin extends Gdn_Plugin {
      * Database structure: on update
      */
     public function structure() {
+        $colBanType = Gdn::structure()->get('Ban')->columns('BanType');
+        $BanTypes = $colBanType->Enum;
+
+        if (!in_array('Fingerprint', $BanTypes)) {
+            $BanTypes[] = 'Fingerprint';
+
+            Gdn::structure()
+                ->table('Ban')
+                ->column('BanType', $BanTypes, false, 'unique')
+                ->set();
+        }
+
         Gdn::structure()
             ->table('User')
             ->column('Troll', 'int', '0')
             ->column('Fingerprint', 'varchar(50)', null, 'index')
-            ->set();
-
-        $colBanType = Gdn::structure()->get('Ban')->columns('BanType');
-        $BanTypes = $colBanType->Enum;
-
-        $BanTypes[] = 'Fingerprint';
-
-        Gdn::structure()
-            ->table('Ban')
-            ->column('BanType', $BanTypes, false, 'unique')
             ->set();
     }
 

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -608,11 +608,12 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Adds "Fingerprint" to the allowed banTypes of the "Ban Rules" dashboard interface.
      *
-     * @param $sender
-     * @param $args
+     * @param array $banTypes
+     * @return array
      */
-    public function settingsController_BeforeListBanTypes_handler($sender, $args) {
-        $args['banTypes']['Fingerprint'] = t('Fingerprint');
+    public function settingsController_listBanTypes(array $banTypes): array {
+        $banTypes['Fingerprint'] = t('Fingerprint');
+        return $banTypes;
     }
 
     /**
@@ -638,38 +639,29 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Add "Fingerprint" to the possible ban query.
      *
-     * @param $sender
-     * @param $args
+     * @param array $result
+     * @param array $ban
+     * @return array
      */
-    public function banModel_AfterbanWhere_handler($sender, $args) {
-        $ban = val('ban', $args);
-
-        if ($ban) {
-            switch (strtolower($ban['BanType'])) {
-                case 'fingerprint':
-                    $args['result']['u.Fingerprint like'] = $ban['BanValue'];
-                    break;
-            }
+    public function banModel_banWhere(array $result, array $ban): array {
+        switch (strtolower($ban['BanType'])) {
+            case 'fingerprint':
+                $result['u.Fingerprint like'] = $ban['BanValue'];
+                break;
         }
+        return $result;
     }
 
     /**
-     * Add ordering users by Fingerprint in the dashboard's users list.
+     * Add "Fingerprint" to the dashboard's users list search query.
      *
-     * @param $sender
-     * @param $args
+     * @param array $like
+     * @param string $keywords
+     * @return array
      */
-    public function userController_BeforeAllowedSorting_handler($sender, $args) {
-        $args['allowedSorting']['Fingerprint'] = 'desc';
+    public function userModel_searchKeyWords(array $like, string $keywords): array {
+        $like['u.Fingerprint'] = $keywords;
+        return $like;
     }
 
-    /**
-     * Add "Fingerprint" to hte dashboard's users list search query.
-     *
-     * @param $sender
-     * @param $args
-     */
-    public function userModel_BeforeSearchLikeUserTable_handler($sender, $args) {
-        $args['like']['u.Fingerprint'] = val('keywords', $args);
-    }
 }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -561,7 +561,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
             if (!empty($userFingerprint)) {
                 $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
                 if ($fingerprintUsages >= $maxSiblingAccounts) {
-                    $sender->EventArguments['ApplicantMeta'][] = sprintf(
+                    $sender->EventArguments['ApplicantMeta'][t("Fingerprint issue")] = sprintf(
                         t("%s accounts are sharing the '%s' fingerprint."),
                         $fingerprintUsages,
                         $userFingerprint

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -565,7 +565,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     public function base_applicantInfo_handler($sender, $args) {
         if (c('TrollManagement.PerFingerPrint.Enabled', false)) {
             $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
-            $userFingerprint = val('Fingerprint', $args['User']);
+            $userFingerprint = val('Fingerprint', $args['User'], '');
             if (!empty($userFingerprint)) {
                 if ($this->checkMaxSharedFingerprintsExceeded($userFingerprint, $maxSiblingAccounts)) {
                     $sender->EventArguments['ApplicantMeta'][t("Fingerprint issue")] = sprintf(
@@ -580,11 +580,11 @@ class TrollManagementPlugin extends Gdn_Plugin {
     /**
      * Checks if the maximum amount of accounts using the same fingerprint has been reached.
      *
-     * @param null|string $fingerprint
+     * @param string $fingerprint
      * @param int $maxSiblingAccounts
      * @return bool
      */
-    private function checkMaxSharedFingerprintsExceeded($fingerprint, int $maxSiblingAccounts): bool {
+    private function checkMaxSharedFingerprintsExceeded(string $fingerprint, int $maxSiblingAccounts): bool {
         if (is_null($fingerprint)) {
             return false;
         }

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -39,10 +39,14 @@ class TrollManagementPlugin extends Gdn_Plugin {
      */
     private $userModel;
 
+
     /**
      * TrollManagementPlugin constructor.
      *
      * @param Gdn_Session $session Injected session.
+     * @param UserModel|null $userModel
+     * @throws ContainerException
+     * @throws NotFoundException
      */
     public function __construct(Gdn_Session $session, UserModel $userModel = null) {
         if ($userModel === null) {

--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -558,13 +558,15 @@ class TrollManagementPlugin extends Gdn_Plugin {
         if (c('TrollManagement.PerFingerPrint.Enabled', false)) {
             $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
             $userFingerprint = val('Fingerprint', $args['User']);
-            $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
-            if ($fingerprintUsages >= $maxSiblingAccounts) {
-                $sender->EventArguments['ApplicantMeta'][] = sprintf(
-                    t("%s accounts are sharing the '%s' fingerprint."),
-                    $fingerprintUsages,
-                    $userFingerprint
-                );
+            if (!empty($userFingerprint)) {
+                $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
+                if ($fingerprintUsages >= $maxSiblingAccounts) {
+                    $sender->EventArguments['ApplicantMeta'][] = sprintf(
+                        t("%s accounts are sharing the '%s' fingerprint."),
+                        $fingerprintUsages,
+                        $userFingerprint
+                    );
+                }
             }
         }
     }
@@ -599,9 +601,11 @@ class TrollManagementPlugin extends Gdn_Plugin {
         $maxSiblingAccounts = c('TrollManagement.PerFingerPrint.MaxUserAccounts');
         $userFingerprint = $this->setFingerprint($userID);
 
-        $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
-        if ($fingerprintUsages >= $maxSiblingAccounts) {
-            Gdn::userModel()->addRoles($userID, [RoleModel::APPLICANT_ID], true);
+        if ($userFingerprint !== false) {
+            $fingerprintUsages = $this->getSharedFingerprintsUsersCount($userFingerprint);
+            if ($fingerprintUsages >= $maxSiblingAccounts) {
+                Gdn::userModel()->addRoles($userID, [RoleModel::APPLICANT_ID], true);
+            }
         }
     }
 

--- a/plugins/TrollManagement/tests/TrollManagementTest.php
+++ b/plugins/TrollManagement/tests/TrollManagementTest.php
@@ -50,8 +50,8 @@ class TrollManagementTest extends SiteTestCase {
         /** @var \Gdn_Configuration $configuration */
         $configuration = static::container()->get('Config');
 
-        $configuration->set('TrollManagement.PerFingerPrint.Enabled', true);
-        $configuration->set('TrollManagement.PerFingerPrint.MaxUserAccounts', 3);
+        $configuration->set('TrollManagement.PerFingerprint.Enabled', true);
+        $configuration->set('TrollManagement.PerFingerprint.MaxUserAccounts', 2);
 
         // Ensure all future registered dummy users uses the same fingerprint.
         $_COOKIE['__vnf'] = 'THISISAFAKEFINGERPRINT';
@@ -84,12 +84,12 @@ class TrollManagementTest extends SiteTestCase {
         // As an admin...
         $this->getSession()->start($this->adminID);
 
-        $preExistingMaxUserAccounts = $configuration->get('TrollManagement.PerFingerPrint.MaxUserAccounts');
+        $preExistingMaxUserAccounts = $configuration->get('TrollManagement.PerFingerprint.MaxUserAccounts');
 
         // Test that a MaxUserAccounts of '0' fails.
         $formValues = [
-            'TrollManagement.PerFingerPrint.Enabled' => true,
-            'TrollManagement.PerFingerPrint.MaxUserAccounts' => 0
+            'TrollManagement.PerFingerprint.Enabled' => true,
+            'TrollManagement.PerFingerprint.MaxUserAccounts' => 0
         ];
 
         // Post/fail without throwing error.
@@ -101,14 +101,14 @@ class TrollManagementTest extends SiteTestCase {
         $firstAttemptErrorMsg = $attempt->Form->errorString();
         // We have an error message.
         $this->assertEquals($firstAttemptErrorMsg, "Maximum user's accounts must be a positive number.");
-        $firstAttemptMaxUserAccounts = $configuration->get('TrollManagement.PerFingerPrint.MaxUserAccounts');
+        $firstAttemptMaxUserAccounts = $configuration->get('TrollManagement.PerFingerprint.MaxUserAccounts');
         // The MaxUserAccounts values is still the same as it was when starting the test.
         $this->assertEquals($preExistingMaxUserAccounts, $firstAttemptMaxUserAccounts);
 
         // Second attempt. This time we set a minimal valid MaxUserAccounts value of '1'
         $formValues = [
-            'TrollManagement.PerFingerPrint.Enabled' => true,
-            'TrollManagement.PerFingerPrint.MaxUserAccounts' => 1
+            'TrollManagement.PerFingerprint.Enabled' => true,
+            'TrollManagement.PerFingerprint.MaxUserAccounts' => 1
         ];
 
         $attempt = $this->bessy()->post(
@@ -119,7 +119,7 @@ class TrollManagementTest extends SiteTestCase {
         $secondAttemptErrorMsg = $attempt->Form->errorString();
         // We do not have an error message.
         $this->assertEquals($secondAttemptErrorMsg, "");
-        $secondAttemptMaxUserAccounts = $configuration->get('TrollManagement.PerFingerPrint.MaxUserAccounts');
+        $secondAttemptMaxUserAccounts = $configuration->get('TrollManagement.PerFingerprint.MaxUserAccounts');
         // The MaxUserAccounts values was set to '1'
         $this->assertEquals(1, $secondAttemptMaxUserAccounts);
     }
@@ -132,8 +132,8 @@ class TrollManagementTest extends SiteTestCase {
         /** @var \Gdn_Configuration $configuration */
         $configuration = static::container()->get('Config');
 
-        $configuration->set('TrollManagement.PerFingerPrint.Enabled', false);
-        $configuration->set('TrollManagement.PerFingerPrint.MaxUserAccounts', 1);
+        $configuration->set('TrollManagement.PerFingerprint.Enabled', false);
+        $configuration->set('TrollManagement.PerFingerprint.MaxUserAccounts', 1);
 
         // Ensure all future registered dummy users uses the same fingerprint.
         $_COOKIE['__vnf'] = 'THISISAFAKEFINGERPRINT';

--- a/plugins/TrollManagement/tests/TrollManagementTest.php
+++ b/plugins/TrollManagement/tests/TrollManagementTest.php
@@ -37,9 +37,18 @@ class TrollManagementTest extends SiteTestCase {
      * Setup routine, run before the test class is instantiated.
      */
     public static function setupBeforeClass(): void {
-        self::$addons = ['vanilla', 'trollmanagement'];
+        self::$addons = ['trollmanagement'];
 
         parent::setupBeforeClass();
+    }
+
+    /**
+     * Reset a few of the environment's key elements
+     */
+    public function tearDown(): void {
+        parent::tearDown();
+        // Remove the cookie value that's used for user's fingerprints/
+        unset($_COOKIE['__vnf']);
     }
 
     /**
@@ -70,7 +79,7 @@ class TrollManagementTest extends SiteTestCase {
         $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['0']);
         // The SECOND dummy user account is NOT an applicant
         $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['1']);
-        // The THIRD dummy user account should an applicant
+        // The THIRD dummy user account should be an applicant
         $this->assertContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['2']);
     }
 

--- a/plugins/TrollManagement/tests/TrollManagementTest.php
+++ b/plugins/TrollManagement/tests/TrollManagementTest.php
@@ -25,35 +25,12 @@ class TrollManagementTest extends SiteTestCase {
     /** @var UserModel */
     protected $userModel;
 
-    /** @var \TrollManagementPlugin */
-    private $trollManagementPlugin;
-
-//    /**
-//     * Configure the container before addons are started.
-//     *
-//     * @param Container $container
-//     */
-//    public static function configureContainerBeforeStartup(Container $container) {
-//        $container->rule(TestInstallModel::class)
-//            ->addCall("setConfigDefaults", [self::CONFIG_DEFAULTS]);
-//    }
-
     /**
      * {@inheritDoc}
      */
     public function setUp(): void {
         parent::setUp();
-//
-//        $this->container()->call(function (TermsManagerPlugin $termsManager, TermsManagerModel $termsManagerModel) {
-//            $this->termsManager = $termsManager;
-//            $this->termsManagerModel = $termsManagerModel;
-//        });
-//
-//        $this->termsID = $this->termsManagerModel->save(
-//            self::sprintfCounter(['Body' => 'Test %s', 'Active' => true, 'ForceRenew' => true, 'ShowInPopup' => 0])
-//        );
         $this->createUserFixtures();
-//        $this->getSession()->end();
     }
 
     /**
@@ -107,6 +84,8 @@ class TrollManagementTest extends SiteTestCase {
         // As an admin...
         $this->getSession()->start($this->adminID);
 
+        $preExistingMaxUserAccounts = $configuration->get('TrollManagement.PerFingerPrint.MaxUserAccounts');
+
         $html = $this->bessy()->getHtml('/settings/trollmanagement');
 
         // Test that a MaxUserAccounts of '0' fails.
@@ -125,8 +104,8 @@ class TrollManagementTest extends SiteTestCase {
         // We have an error message.
         $this->assertEquals($firstAttemptErrorMsg, "Maximum user's accounts must be a positive number.");
         $firstAttemptMaxUserAccounts = $configuration->get('TrollManagement.PerFingerPrint.MaxUserAccounts');
-        // The MaxUserAccounts values wasn't set
-        $this->assertEquals(false, $firstAttemptMaxUserAccounts);
+        // The MaxUserAccounts values is still the same as it was when starting the test.
+        $this->assertEquals($preExistingMaxUserAccounts, $firstAttemptMaxUserAccounts);
 
         // Second attempt. This time we set a minimal valid MaxUserAccounts value of '1'
         $formValues = [

--- a/plugins/TrollManagement/tests/TrollManagementTest.php
+++ b/plugins/TrollManagement/tests/TrollManagementTest.php
@@ -86,8 +86,6 @@ class TrollManagementTest extends SiteTestCase {
 
         $preExistingMaxUserAccounts = $configuration->get('TrollManagement.PerFingerPrint.MaxUserAccounts');
 
-        $html = $this->bessy()->getHtml('/settings/trollmanagement');
-
         // Test that a MaxUserAccounts of '0' fails.
         $formValues = [
             'TrollManagement.PerFingerPrint.Enabled' => true,

--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -16,7 +16,7 @@ if (!$fingerprintsEnabled) {
 <?php
         echo $this->Form->toggle(
             'TrollManagement.PerFingerPrint.Enabled',
-            t('Enables fingerprint checks.'),
+            t('Enable fingerprint checks.'),
             [
                 'id' => 'IsFingerprintChecksEnabled',
                 'data-children' => 'js-fingerprints-inputs'

--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -27,7 +27,7 @@ if (!$fingerprintsEnabled) {
     <li class="form-group js-fingerprints-inputs" <?php echo $fingerprintsEnabled ? '' : ' style="display:none;"'?>>
 <?php
         echo $this->Form->labelWrap(
-            t('Maximum allowed number of user accounts tied to a single fingerprint'),
+            t('Maximum allowed number of user accounts tied to a single fingerprint.'),
             'TrollManagement.PerFingerPrint.MaxUserAccounts'
         );
         echo $this->Form->textBoxWrap('TrollManagement.PerFingerPrint.MaxUserAccounts', $fingerprintsChildrenAttributes);

--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -6,7 +6,7 @@
 echo $this->Form->open();
 echo $this->Form->errors();
 $fingerprintsEnabled = (bool)c('TrollManagement.PerFingerPrint.Enabled');
-$textBoxAttributes = [];
+$fingerprintsChildrenAttributes = [];
 if (!$fingerprintsEnabled) {
     $fingerprintsChildrenAttributes['disabled'] = 'disabled';
 }

--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -1,0 +1,37 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+
+<h1><?php echo t($this->Data['Title']); ?></h1>
+
+<?php
+echo $this->Form->open();
+echo $this->Form->errors();
+$fingerprintsEnabled = (bool)c('TrollManagement.PerFingerPrint.Enabled');
+$textBoxAttributes = [];
+if (!$fingerprintsEnabled) {
+    $fingerprintsChildrenAttributes['disabled'] = 'disabled';
+}
+?>
+<ul>
+    <li class="form-group">
+<?php
+        echo $this->Form->toggle(
+            'TrollManagement.PerFingerPrint.Enabled',
+            t('Enables fingerprint checks.'),
+            [
+                'id' => 'IsFingerprintChecksEnabled',
+                'data-children' => 'js-fingerprints-inputs'
+            ]
+        );
+?>
+    </li>
+    <li class="form-group js-fingerprints-inputs" <?php echo $fingerprintsEnabled ? '' : ' style="display:none;"'?>>
+<?php
+        echo $this->Form->labelWrap(
+            t('Maximum allowed number of user accounts tied to a single fingerprint'),
+            'TrollManagement.PerFingerPrint.MaxUserAccounts'
+        );
+        echo $this->Form->textBoxWrap('TrollManagement.PerFingerPrint.MaxUserAccounts', $fingerprintsChildrenAttributes);
+?>
+    </li>
+</ul>
+<?php echo $this->Form->close('Save'); ?>

--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -5,7 +5,7 @@
 <?php
 echo $this->Form->open();
 echo $this->Form->errors();
-$fingerprintsEnabled = (bool)c('TrollManagement.PerFingerPrint.Enabled');
+$fingerprintsEnabled = (bool)c('TrollManagement.PerFingerprint.Enabled');
 $fingerprintsChildrenAttributes = [];
 if (!$fingerprintsEnabled) {
     $fingerprintsChildrenAttributes['disabled'] = 'disabled';
@@ -15,7 +15,7 @@ if (!$fingerprintsEnabled) {
     <li class="form-group">
 <?php
         echo $this->Form->toggle(
-            'TrollManagement.PerFingerPrint.Enabled',
+            'TrollManagement.PerfingerPrint.Enabled',
             t('Enable fingerprint checks.'),
             [
                 'id' => 'IsFingerprintChecksEnabled',
@@ -28,9 +28,9 @@ if (!$fingerprintsEnabled) {
 <?php
         echo $this->Form->labelWrap(
             t('Maximum allowed number of user accounts tied to a single fingerprint.'),
-            'TrollManagement.PerFingerPrint.MaxUserAccounts'
+            'TrollManagement.PerFingerprint.MaxUserAccounts'
         );
-        echo $this->Form->textBoxWrap('TrollManagement.PerFingerPrint.MaxUserAccounts', $fingerprintsChildrenAttributes);
+        echo $this->Form->textBoxWrap('TrollManagement.PerFingerprint.MaxUserAccounts', $fingerprintsChildrenAttributes);
 ?>
     </li>
 </ul>


### PR DESCRIPTION
This is the 'plugin' part for the following issue: https://github.com/vanillaforums/mse/issues/236
As detailed by the following estimate: https://github.com/vanillaforums/estimates/blob/master/mse/mse-troll-plugin-enhancements.md

This is complementary to the following PR: https://github.com/vanilla/vanilla-cloud/pull/2303

**How to test**

- Enable the **Troll management plugin**.
- Configure the plugin.
- Enable fingerprint checks.
- Set a maximum allowed number of user accounts tied to a single fingerprint.
- Logout from the admin account.
- Create a few new user accounts to reach the maximum allowed number of user accounts tied to a single fingerprint.
- Logout & back again as your administrative account.
- Reach the applicants management interface(/dashboard/user/applicants). Your newest user should be listed.

**Notes**

- Added configurations & corresponding screens to allow modification of the amount accounts sharing the same fingerprint.
- A few tweaks were done to the _fingerprinting_ process.
- The user registration process verifies if the number of allowed accounts using the same fingerprint is reached. If it is the case, the newly registered user is set as _applicant_.