### PR TITLE
Fix typos preventing Troll Management plugin from saving.

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -523,8 +523,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
         $configurationModel = new Gdn_ConfigurationModel($validation);
 
         $configurationModel->setField([
-            'TrollManagement.PerFingerPrint.Enabled' => c('TrollManagement.PerFingerprint.Enabled', false),
-            'TrollManagement.PerFingerPrint.MaxUserAccounts' => c('TrollManagement.PerFingerprint.MaxUserAccounts', 5),
+            'TrollManagement.PerFingerprint.Enabled' => c('TrollManagement.PerFingerprint.Enabled', false),
+            'TrollManagement.PerFingerprint.MaxUserAccounts' => c('TrollManagement.PerFingerprint.MaxUserAccounts', 5),
         ]);
 
         $sender->Form->setModel($configurationModel);

--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -15,7 +15,7 @@ if (!$fingerprintsEnabled) {
     <li class="form-group">
 <?php
         echo $this->Form->toggle(
-            'TrollManagement.PerfingerPrint.Enabled',
+            'TrollManagement.PerFingerprint.Enabled',
             t('Enable fingerprint checks.'),
             [
                 'id' => 'IsFingerprintChecksEnabled',


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/4167

This fixes troll management plugin not saving properly because of typos in the settings keys.