### PR TITLE
Fix the applicants form crash

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -566,7 +566,7 @@ class TrollManagementPlugin extends Gdn_Plugin {
     public function base_applicantInfo_handler($sender, $args) {
         if (c('TrollManagement.PerFingerprint.Enabled', false)) {
             $maxSiblingAccounts = c('TrollManagement.PerFingerprint.MaxUserAccounts');
-            $userFingerprint = $args['User']['Fingerprint'] ?? '';
+            $userFingerprint = $args['User']->Fingerprint ?? '';
             if (!empty($userFingerprint)) {
                 if ($this->checkMaxSharedFingerprintsExceeded($userFingerprint, $maxSiblingAccounts)) {
                     $sender->EventArguments['ApplicantMeta'][t("Fingerprint issue")] = sprintf(


### PR DESCRIPTION
Properties aren't accessed as an array(anymore), but as an object.