### PR TITLE
Added better messaging for the Troll management plugin's configuration screen

### DIFF
--- a/plugins/TrollManagement/views/configuration.php
+++ b/plugins/TrollManagement/views/configuration.php
@@ -27,7 +27,11 @@ if (!$fingerprintsEnabled) {
     <li class="form-group js-fingerprints-inputs" <?php echo $fingerprintsEnabled ? '' : ' style="display:none;"'?>>
 <?php
         echo $this->Form->labelWrap(
-            t('Maximum allowed number of user accounts tied to a single fingerprint.'),
+            t('Maximum allowed number of user accounts tied to a single fingerprint.') .
+            '<br />' .
+            '<div class="info">' .
+            t("This check isn't retroactive to pre-existing accounts.") .
+            '</div>',
             'TrollManagement.PerFingerprint.MaxUserAccounts'
         );
         echo $this->Form->textBoxWrap('TrollManagement.PerFingerprint.MaxUserAccounts', $fingerprintsChildrenAttributes);


### PR DESCRIPTION
This is a fix/clarification for _part_ of this issue: https://github.com/vanilla/support/issues/4343, specifically what's detailed here: https://github.com/vanilla/support/issues/4343#issuecomment-849817905

## How to test

- Checkout this branch.
- Go to the Troll Management plugin's configuration interface.
- See that the new message (_This check isn't retroactive to pre-existing accounts._) is displayed.
- Success.

![Screen Shot 2021-05-27 at 2 17 22 PM](https://user-images.githubusercontent.com/61435952/119876818-4abc0380-bef6-11eb-8df2-11e0fca5b339.png)
