### PR TITLE
Fix authorselector.js jQuery load event

### DIFF
--- a/plugins/AuthorSelector/js/authorselector.js
+++ b/plugins/AuthorSelector/js/authorselector.js
@@ -1,5 +1,5 @@
 // Initiate on our global event.
-$(document).on('contentLoad', function(e) {
+$(document).ready(function(e) {
     /// Author tag token input.
     var $author = $('.MultiComplete', e.target);
     var author = $author.val();


### PR DESCRIPTION
Looks like for authorselector plugin jquery on('contentLoad') event triggers sooner that expected in js file, so changing it to ready() which is equivalent to "DOMContentLoaded" native event.

closes https://github.com/vanilla/support/issues/4516