### PR TITLE
Fix / Removed every roles but "Applicant" when user is sorted as such by the Troll Management Plugin

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -616,6 +616,8 @@ class TrollManagementPlugin extends Gdn_Plugin {
             $maxSiblingAccounts = c('TrollManagement.PerFingerprint.MaxUserAccounts');
             if ($userFingerprint !== false) {
                 if ($this->checkMaxSharedFingerprintsExceeded($userFingerprint, $maxSiblingAccounts)) {
+                    $currentUserRoles = Gdn::userModel()->getRoles($userID)->resultArray();
+                    Gdn::userModel()->removeRoles($userID, array_column($currentUserRoles, 'RoleID'), false);
                     Gdn::userModel()->addRoles($userID, [RoleModel::APPLICANT_ID], true);
                 }
             }

--- a/plugins/TrollManagement/tests/TrollManagementTest.php
+++ b/plugins/TrollManagement/tests/TrollManagementTest.php
@@ -79,8 +79,8 @@ class TrollManagementTest extends SiteTestCase {
         $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['0']);
         // The SECOND dummy user account is NOT an applicant
         $this->assertNotContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['1']);
-        // The THIRD dummy user account should be an applicant
-        $this->assertContains(RoleModel::APPLICANT_ID, $importedUsersRolesIDs['2']);
+        // The THIRD dummy user account should ONLY be an applicant
+        $this->assertEquals([RoleModel::APPLICANT_ID], $importedUsersRolesIDs['2']);
     }
 
     /**


### PR DESCRIPTION
This is a fix to the following issue: https://higherlogic.atlassian.net/browse/VNLA-274

This fix strips every user role before adding the **Applicant** role.
Tests are adjusted accordingly.