### PR TITLE
Fix the TrollManagement DB structure

### DIFF
--- a/plugins/TrollManagement/class.trollmanagement.plugin.php
+++ b/plugins/TrollManagement/class.trollmanagement.plugin.php
@@ -69,15 +69,14 @@ class TrollManagementPlugin extends Gdn_Plugin {
     public function structure() {
         $colBanType = Gdn::structure()->get('Ban')->columns('BanType');
         $BanTypes = $colBanType->Enum;
-
         if (!in_array('Fingerprint', $BanTypes)) {
             $BanTypes[] = 'Fingerprint';
-
-            Gdn::structure()
-                ->table('Ban')
-                ->column('BanType', $BanTypes, false, 'unique')
-                ->set();
         }
+
+        Gdn::structure()
+            ->table('Ban')
+            ->column('BanType', $BanTypes, false, 'unique')
+            ->set();
 
         Gdn::structure()
             ->table('User')


### PR DESCRIPTION
This was flipping back and forth between active and inactive because after being added once, it would be removed in the core declaration, and then added back again on the next structure