### PR TITLE
VNLA-848: Fix jQuery being called early in the stopAutoDraft plugin

### DIFF
--- a/plugins/StopAutoDraft/class.stopautodraft.plugin.php
+++ b/plugins/StopAutoDraft/class.stopautodraft.plugin.php
@@ -20,16 +20,18 @@ class StopAutoDraftPlugin extends Gdn_Plugin {
 	   $sender->removeJsFile('autosave.js');
 		$sender->Head->addString('
 <script type="text/javascript">
-jQuery(document).ready(function($) {
-   $.fn.autosave = function(opts) {
-		return;
-	}
+window.onVanillaReady(function(){
+    jQuery(document).ready(function($) {
+        $.fn.autosave = function(opts) {
+             return;
+         }
+     });
 });
 </script>
 ');
    }
-	
+
    public function onDisable() { }
    public function setup() { }
-	
+
 }


### PR DESCRIPTION
### This PR fixes jQuery being called before its loaded in the stopAutoDraft plugin

## Changes
- Wraps the existing code in `onVanillaReady`

### Steps to replicate
- Checkout master
- Turn on the Stop AutoDraft plugin
- Go to a new discussion page
- Observe that `jQuery is undefined` in the developer console
- Switch to this branch
- Reload the page
- Observe the error about `jQuery` is gone

Discovered during investigating https://higherlogic.atlassian.net/browse/VNLA-848