### PR TITLE
APPENG-13922 Add deprecation warning for ShareThis plugin

### DIFF
--- a/plugins/ShareThis/addon.json
+++ b/plugins/ShareThis/addon.json
@@ -1,6 +1,6 @@
 {
     "name": "ShareThis",
-    "description": "Adds ShareThis (http://sharethis.com) buttons below discussions.",
+    "description": "<strong>DEPRECATED</strong>. This plugin is no longer supported. Adds ShareThis (http://sharethis.com) buttons below discussions.",
     "version": "1.3",
     "requiredTheme": false,
     "settingsUrl": "/plugin/sharethis",


### PR DESCRIPTION
Request from support to add deprecation on ShareThis plugin - plugin was still showing on staging but not on production.

Closes: https://higherlogic.atlassian.net/browse/APPENG-13922