### PR TITLE
APPENG-13922: Add deprecation notice to ShareThis Plugin

### DIFF
--- a/plugins/ShareThis/addon.json
+++ b/plugins/ShareThis/addon.json
@@ -1,6 +1,6 @@
 {
     "name": "ShareThis",
-    "description": "Adds ShareThis (http://sharethis.com) buttons below discussions.",
+    "description": "<strong>DEPRECATED</strong>. This add-on is no longer supported. Adds ShareThis (http://sharethis.com) buttons below discussions.",
     "version": "1.3",
     "requiredTheme": false,
     "settingsUrl": "/plugin/sharethis",


### PR DESCRIPTION
At request of support a deprecation notice has been added to the plugin ShareThis as it still shows on some staging/test sites but not is available on production.

This closes: https://higherlogic.atlassian.net/browse/APPENG-13922