### PR TITLE
VNLA-1220 fix/IPBFormatter Warnings by remove reference from function signatures

### DIFF
--- a/plugins/IPBFormatter/class.ipbformatter.plugin.php
+++ b/plugins/IPBFormatter/class.ipbformatter.plugin.php
@@ -241,7 +241,7 @@ EOT;
      *
      * @param $sender Instance of EditorPlugin firing the event
      */
-    public function editorPlugin_getFormats_handler($sender, &$args) {
+    public function editorPlugin_getFormats_handler($sender, $args) {
         $formats =& $args['formats'];
 
         $formats[] = 'IPB';
@@ -253,7 +253,7 @@ EOT;
      *
      * @param $sender Instance of EditorPlugin firing the event
      */
-    public function editorPlugin_getJSDefinitions_handler($sender, &$args) {
+    public function editorPlugin_getJSDefinitions_handler($sender, $args) {
         $definitions =& $args['definitions'];
 
         /**


### PR DESCRIPTION
# Issue
Two functions from the IPBFormatter plugin were triggering this error: 

```Parameter 2 to IPBFormatterPlugin::editorPlugin_getJSDefinitions_handler() expected to be a reference, value given```.

Both functions were expecting the `$args` argument to be a reference. 

See: https://higherlogic.atlassian.net/browse/VNLA-1220

# Solution
* Use the value rather than the reference in the function signature.

# QA
* Set debug mode on
* Enable the `Advanced Editor` plugin and `IPBFormatter` plugin.
* Notice the error message showing up about those two functions.
* Check out this branch, notice the message is gone.

# Addidionnal QA
* Set the posting type to IPB.
* Post content in the IPB format.
* Notice that the post is rendered properly.