### PR TITLE
VNLA-1083 Fix Link Types working with warn on leave

### DIFF
--- a/plugins/LinkTypes/js/linktypes.js
+++ b/plugins/LinkTypes/js/linktypes.js
@@ -50,7 +50,7 @@ $(function() {
                 break;
             case 'internal':
                //Test to see if we're hitting the leave warning page
-               if (/leaving\?/.test(href))
+               if (/\/home\/leaving\?/.test(href))
                    $(this).attr('rel', 'noopener noreferrer').attr('target', '_blank');
 
                break;

--- a/plugins/LinkTypes/js/linktypes.js
+++ b/plugins/LinkTypes/js/linktypes.js
@@ -48,9 +48,12 @@ $(function() {
             case 'external':
                 $(this).attr('rel', 'noopener noreferrer').attr('target', '_blank');
                 break;
-            // case 'internal':
-            //    $(this).attr('target', '');
-            //    break;
+            case 'internal':
+               //Test to see if we're hitting the leave warning page
+               if (/leaving\?/.test(href))
+                   $(this).attr('rel', 'noopener noreferrer').attr('target', '_blank');
+
+               break;
         }
     });
 


### PR DESCRIPTION
This fixes sites that are using the Warn on Leave feature with the LinkTypes plugin as the warn links would not open in a new tab, previously. 

The regex is simple and efficient with an almost impossible chance to get a false positive.

Tested locally on a standard build and using basic embed. Was not able to test on the advanced embed due to CORS errors on two test sites.