### PR TITLE
VNLA-1121: Disable StopAutoDraft Plugin Universally

### DIFF
--- a/plugins/StopAutoDraft/addon.json
+++ b/plugins/StopAutoDraft/addon.json
@@ -5,6 +5,7 @@
     "icon": "stop_auto_draft.png",
     "key": "stopautodraft",
     "type": "addon",
+    "hidden": true,
     "authors": [
         {
             "name": "Mark O'Sullivan",

--- a/plugins/StopAutoDraft/class.stopautodraft.plugin.php
+++ b/plugins/StopAutoDraft/class.stopautodraft.plugin.php
@@ -23,6 +23,13 @@ class StopAutoDraftPlugin extends Gdn_Plugin
     /** @var AddonManager  */
     protected $addonManager;
 
+    /**
+     * D.I.
+     *
+     * @param \Vanilla\Contracts\ConfigurationInterface $config
+     * @param \Vanilla\Models\AddonModel $addonModel
+     * @param AddonManager $addonManager
+     */
     public function __construct(
         \Vanilla\Contracts\ConfigurationInterface $config,
         \Vanilla\Models\AddonModel $addonModel,
@@ -34,6 +41,9 @@ class StopAutoDraftPlugin extends Gdn_Plugin
         parent::__construct();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function structure()
     {
         $this->config->saveToConfig("Vanilla.Drafts.Autosave", false);
@@ -41,11 +51,17 @@ class StopAutoDraftPlugin extends Gdn_Plugin
         $this->addonModel->disable($addon);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function setup()
     {
         $this->structure();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function onDisable()
     {
     }

--- a/plugins/StopAutoDraft/class.stopautodraft.plugin.php
+++ b/plugins/StopAutoDraft/class.stopautodraft.plugin.php
@@ -1,4 +1,8 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php use Vanilla\AddonManager;
+
+if (!defined("APPLICATION")) {
+    exit();
+}
 /*
 Copyright 2008, 2009 Vanilla Forums Inc.
 This file is part of Garden.
@@ -8,28 +12,36 @@ You should have received a copy of the GNU General Public License along with Gar
 Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 */
 
-class StopAutoDraftPlugin extends Gdn_Plugin {
+class StopAutoDraftPlugin extends Gdn_Plugin
+{
+    /** @var \Vanilla\Contracts\ConfigurationInterface */
+    protected $config;
 
-   public function discussionController_render_before($sender) {
-		$this->_NoDrafting($sender);
-	}
-   public function postController_render_before($sender) {
-		$this->_NoDrafting($sender);
-	}
-	private function _NoDrafting($sender) {
-	   $sender->removeJsFile('autosave.js');
-		$sender->Head->addString('
-<script type="text/javascript">
-jQuery(document).ready(function($) {
-   $.fn.autosave = function(opts) {
-		return;
-	}
-});
-</script>
-');
-   }
-	
-   public function onDisable() { }
-   public function setup() { }
-	
+    /** @var \Vanilla\Models\AddonModel  */
+    protected $addonModel;
+
+    /** @var AddonManager  */
+    protected $addonManager;
+
+    public function __construct(
+        \Vanilla\Contracts\ConfigurationInterface $config,
+        \Vanilla\Models\AddonModel $addonModel,
+        AddonManager $addonManager
+    ) {
+        $this->config = $config;
+        $this->addonModel = $addonModel;
+        $this->addonManager = $addonManager;
+        parent::__construct();
+    }
+
+    public function container_init()
+    {
+        $this->config->saveToConfig("Vanilla.Drafts.Autosave", false);
+        $addon = $this->addonManager->lookupAddon("stopautodraft");
+        $this->addonModel->disable($addon);
+    }
+
+    public function onDisable()
+    {
+    }
 }

--- a/plugins/StopAutoDraft/class.stopautodraft.plugin.php
+++ b/plugins/StopAutoDraft/class.stopautodraft.plugin.php
@@ -34,11 +34,16 @@ class StopAutoDraftPlugin extends Gdn_Plugin
         parent::__construct();
     }
 
-    public function container_init()
+    public function structure()
     {
         $this->config->saveToConfig("Vanilla.Drafts.Autosave", false);
         $addon = $this->addonManager->lookupAddon("stopautodraft");
         $this->addonModel->disable($addon);
+    }
+
+    public function setup()
+    {
+        $this->structure();
     }
 
     public function onDisable()

--- a/plugins/StopAutoDraft/tests/StopAutoDraftTest.php
+++ b/plugins/StopAutoDraft/tests/StopAutoDraftTest.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @author Richard Flynn <rflynn@higherlogic.com>
+ * @copyright 2009-2023 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+class StopAutoDraftTest extends \VanillaTests\SiteTestCase
+{
+    public function testEnablingStopAutoDraft(): void
+    {
+        $this->assertConfigValue("Vanilla.Drafts.Autosave", null);
+        $this->enableAddon("stopautodraft");
+        $this->assertConfigValue("Vanilla.Drafts.Autosave", false);
+    }
+}

--- a/plugins/StopAutoDraft/tests/StopAutoDraftTest.php
+++ b/plugins/StopAutoDraft/tests/StopAutoDraftTest.php
@@ -5,8 +5,15 @@
  * @copyright 2009-2023 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
+
+/**
+ * Tests for the StopAutoDraft plugin.
+ */
 class StopAutoDraftTest extends \VanillaTests\SiteTestCase
 {
+    /**
+     * Test that enabling the plugin sets the "Vanilla.Drafts.Autosave" config value to false.
+     */
     public function testEnablingStopAutoDraft(): void
     {
         $this->assertConfigValue("Vanilla.Drafts.Autosave", null);


### PR DESCRIPTION
Companion PR to vanilla/vanilla-cloud#5559

This PR changes the logic of the StopAutoDraft plugin to simply set the new `Vanilla.Drafts.Autosave` config value to `false`. This setting is used by the new settings option on the `vanilla/settings/posting` page. Once the config value is set, the addon disables itself. The PR also hides the plugin, so it cannot be found subsequently.